### PR TITLE
Ability to display more notes more compactly

### DIFF
--- a/Source/AlphaTab/Rendering/Glyphs/BeatGlyphBase.cs
+++ b/Source/AlphaTab/Rendering/Glyphs/BeatGlyphBase.cs
@@ -28,7 +28,7 @@ namespace AlphaTab.Rendering.Glyphs
                     w += g.Width;
                 }
             }
-            Width = w;
+            Width = (int)(w * Renderer.Settings.Layout.Get("spacingScale", 1.0f));
         }
 
         protected void NoteLoop(Action<Note> action)

--- a/Source/AlphaTab/Settings.cs
+++ b/Source/AlphaTab/Settings.cs
@@ -196,6 +196,7 @@ namespace AlphaTab
         /// <ul>
         ///  <li><strong>autoSize</strong> - Whether the width of the canvas should be automatically determined by the used layout. (bool, default:true)</li>
         ///  <li><strong>barsPerRow</strong> - Limit the displayed bars per row, <em>-1 for sized based limit<em> (integer, default:-1)</li>
+        ///  <li><strong>spacingScale</strong> - Control how closely glyphs are spaced (float, default:1.0f)</li>
         ///  <li><strong>start</strong> - The bar start index to start layouting with (integer: default: 0)</li>
         ///  <li><strong>count</strong> - The amount of bars to render overall, <em>-1 for all till the end</em>  (integer, default:-1)</li>
         ///  <li><strong>hideInfo</strong> - Render the song information or not (boolean, default:true)</li>


### PR DESCRIPTION
Our users want to be able to see more notes at once (andulv/RSTabExplorer#7) but when use the scale setting everything quickly becomes more difficult to read.

Setting beatsPerBar to 4 isn't suitable: having a bar with 20 notes squashed into a small space doesn't work, and having 12 empty bars take a whole page is wasteful. Also it causes some [buggy rendering](https://cloud.githubusercontent.com/assets/1028741/2897184/24dda5e6-d57a-11e3-867d-b8a8d1302bed.png).

Instead I wanted to be able to keep the automatic layout while having the option to reduce how far apart notes are.

I've got it working by adding a setting which scales the width of GlyphBeatBase.

![screenshot-p146](https://cloud.githubusercontent.com/assets/1028741/2897092/87ff10b2-d578-11e3-957c-e1e57c95ed65.png)
