### PR TITLE
Tied notes midi generation and cross-bar rendering fixes

### DIFF
--- a/Source/AlphaTab/Audio/Generator/MidiFileGenerator.cs
+++ b/Source/AlphaTab/Audio/Generator/MidiFileGenerator.cs
@@ -343,6 +343,10 @@ namespace AlphaTab.Audio.Generator
             {
                 return (duration / 2);
             }
+            if (note.IsTieOrigin) 
+            {
+                return GetTieOriginNoteDuration(note);
+            }
             return duration;
         }
 
@@ -350,6 +354,30 @@ namespace AlphaTab.Audio.Generator
         {
             var value = (_currentTempo * duration) / 60;
             return Math.Min(value, maximum);
+        }
+
+        private int GetTieOriginNoteDuration(Note startNote) {
+            int duration = 0;
+
+            Note note = startNote;
+            for (Beat beat = note.Beat; ; beat = beat.NextBeat) 
+            {
+                duration += beat.Duration.ToTicks();
+
+                Note destination = note.TieDestination;
+                if (beat == destination.Beat) 
+                {
+                    if (destination.IsTieOrigin)
+                    {
+                        note = destination;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+            return duration;
         }
 
         private DynamicValue GetDynamicValue(Note note)

--- a/Source/AlphaTab/Rendering/Glyphs/TieGlyph.cs
+++ b/Source/AlphaTab/Rendering/Glyphs/TieGlyph.cs
@@ -71,14 +71,23 @@ namespace AlphaTab.Rendering.Glyphs
             // either can draw till the end note, or we just can draw till the bar end
             if (!_forEnd)
             {
-                // bar break or line break: to bar end
+                // line break or bar break
                 if (startNoteRenderer != endNoteRenderer)
                 {
-                    // TODO: expand tie to next bar if possible, currently we draw a tie till the 
-                    // bar end if we have different bars
-
                     startX = cx + startNoteRenderer.GetNoteX(StartNote);
-                    endX = cx + parent.X + parent.PostNotes.X + parent.PostNotes.Width;
+
+                    // line break: to bar end
+                    if (startNoteRenderer.Stave != endNoteRenderer.Stave)
+                    {
+                        endX = cx + parent.X + parent.PostNotes.X + parent.PostNotes.Width;
+                    }
+                    // bar break: to tie destination 
+                    // differs only by addition of EndNote X coordinate
+                    else
+                    {
+                        endX = cx + parent.X + parent.PostNotes.X + parent.PostNotes.Width;
+                        endX += endNoteRenderer.GetNoteX(EndNote); 
+                    }
 
                     startY = cy + startNoteRenderer.GetNoteY(StartNote) + YOffset;
                     endY = startY;


### PR DESCRIPTION
I've used this alphaTex code to generate midi and render the score to debug:
    
    0.1.2 0.1.2 | -.1.2 -.1.4 -.1.4 | -.1.4 1.1.4 

Now it works properly: midi playback doesn't stop after the first note in the tied sequence and TieGlyph is drawn from note to note between the bars (there was a TODO for the latter).