### PR TITLE
Adds support for any font as rendering resource

### DIFF
--- a/Documentation/input/_Head.cshtml
+++ b/Documentation/input/_Head.cshtml
@@ -1,3 +1,4 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism.min.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/plugins/line-numbers/prism-line-numbers.min.css" />
 <script src="@Context.GetLink("/assets/js/alphaTab/alphaTab.min.js")"></script>
+<link href="https://fonts.googleapis.com/css?family=Roboto+Slab&display=swap" rel="stylesheet">

--- a/Documentation/input/examples/render-customization/colors-fonts.cshtml
+++ b/Documentation/input/examples/render-customization/colors-fonts.cshtml
@@ -16,7 +16,7 @@ Order: 10
             </tr>
         </thead>
         <tbody>
-            <tr><td>copyrightFont</td>      <td>Font</td>   <td>Music copyright information in page layouts</td> <td>12px Arial bold</td></tr>
+            <tr><td>copyrightFont</td>      <td>Font</td>   <td>Music copyright information in page layouts</td> <td>bold 12px Arial</td></tr>
             <tr><td>titleFont</td>          <td>Font</td>   <td>Title of the song in page layouts</td> <td>32px Georgia</td></tr>
             <tr><td>subTitleFont</td>       <td>Font</td>   <td>Subtitle of the song in page layouts</td> <td>20px Georgia</td></tr>
             <tr><td>wordsFont</td>          <td>Font</td>   <td>Lyrics information of the song in page layouts</td> <td>15px Georgia</td></tr>
@@ -26,7 +26,7 @@ Order: 10
             <tr><td>graceFont</td>          <td>Font</td>   <td>The numbers grace notes in tablature staves</td> <td>11px Arial</td></tr>
             <tr><td>barNumberFont</td>      <td>Font</td>   <td>The numbers above bars</td> <td>11px Arial</td></tr>
             <tr><td>fingeringFont</td>      <td>Font</td>   <td>The numbers shown for fingering information</td><td>14px Georgia</td></tr>
-            <tr><td>markerFont</td>         <td>Font</td>   <td>The section marker labels</td> <td>14px Arial bold</td> </tr>
+            <tr><td>markerFont</td>         <td>Font</td>   <td>The section marker labels</td> <td>bold 14px Arial</td> </tr>
             
             <tr><td>staffLineColor</td>     <td>Color</td>  <td>The lines for all staves</td> <td>rgb(165,165,165)</td></tr>
             <tr><td>barSeparatorColor</td>  <td>Color</td>  <td>The lines for bar separators and repeat indicators</td> <td>rgb(34,34,17)</td></tr>
@@ -44,7 +44,7 @@ Order: 10
             <h3 class="panel-title">Usage of different fonts</h3> 
         </div>
         <div class="panel-body">
-        The usage of other fonts can result in alignment or layouting issues and in a slighly worse performance. If such problems are detected, please inform us on <a href="https://github.com/CoderLine/alphaTab/issues/new/choose" target="_blank">GitHub</a>. The format for fonts is similar to the CSS shorthand font declarations but with some limitations: <code>Size Family Style</code>. No relative font sizes are supported and every size beside px will be converted to px. For styles <code>italic</code> and <code>bold</code> are supported. 
+        The usage of other fonts can result in alignment or layouting issues and in a slighly worse performance. If such problems are detected, please inform us on <a href="https://github.com/CoderLine/alphaTab/issues/new/choose" target="_blank">GitHub</a>. The format for fonts is similar to the CSS shorthand font declarations but with some limitations: <code>Style Size Family</code>. No relative font sizes are supported and every size beside px will be converted to px. For styles <code>italic</code> and <code>bold</code> are supported. 
         </div> 
     </div>
     
@@ -76,7 +76,7 @@ Order: 10
                 $('#alphaTabScriptInit').alphaTab({
                   file: '@Context.GetLink("/assets/files/features/Skillet.gp5")',
                   resources: {
-                    copyrightFont: "12px Roboto bold",
+                    copyrightFont: "bold 12px Roboto",
                     titleFont: "32px 'Roboto Slab'",
                     subTitleFont: "20px 'Roboto Slab'",
                     wordsFont: "15px 'Roboto Slab'",
@@ -86,7 +86,7 @@ Order: 10
                     graceFont: "11px Roboto",
                     barNumberFont: "11px Roboto",
                     fingeringFont: "14px 'Roboto Slab'",
-                    markerFont: "14px Roboto bold",
+                    markerFont: "bold 14px Roboto",
     
                     staffLineColor: "rgba(255,255,255, 0.8)",
                     barSeparatorColor: "rgb(255,255,255)",
@@ -105,17 +105,17 @@ Order: 10
                 .alphaTabSurface { background: #000; }
             </style>
             <div id="alphaTabDataInit" data-file="@Context.GetLink("/assets/files/features/Skillet.gp5")"
-                data-resources-copyrightFont="12px Roboto bold"
+                data-resources-copyrightFont="bold 12px Roboto"
                 data-resources-titleFont="32px 'Roboto Slab'"
                 data-resources-subTitleFont="20px 'Roboto Slab'"
                 data-resources-wordsFont="15px 'Roboto Slab'"
-                data-resources-effectFont="12px 'Roboto Slab' italic"
+                data-resources-effectFont=" italic 12px 'Roboto Slab'"
                 data-resources-fretboardNumberFont="11px Roboto"
                 data-resources-tablatureFont="13px Roboto"
                 data-resources-graceFont="11px Roboto"
                 data-resources-barNumberFont="11px Roboto"
                 data-resources-fingeringFont="14px 'Roboto Slab'"
-                data-resources-markerFont="14px Roboto bold"
+                data-resources-markerFont=" bold 14px Roboto"
 
                 data-resources-staffLineColor="rgba(255,255,255, 0.8)"
                 data-resources-barSeparatorColor="rgb(255,255,255)"

--- a/Documentation/input/reference/property/renderingresources.cshtml
+++ b/Documentation/input/reference/property/renderingresources.cshtml
@@ -122,9 +122,10 @@ Following resources exist for adjusting the style.
 
 <h3>Fonts</h3>
 <p>
-For the .net platform any installed font on the system can be used. For JavaScript until <a href="https://github.com/CoderLine/alphaTab/issues/266" target="_blank">this feature</a> is implemented the 2 fonts "Arial" and "Georgia" are officially supported. Due to the nature of Web Workers, no font metrics are available which needs a custom solution for measuring texts. 
-<br />
-On .net simply construct the <code>Font</code> object to configure your desired fonts. For JavaScript you can use any CSS font property compliant string. Relative font sizes with percentual values are not supported.
+For the .net platform any installed font on the system can be used. Simply construct the <code>Font</code> object to configure your desired fonts. 
+</p>
+<p>
+For the JavaScript platform any font that might be installed on the client machines can be used. Any additional fonts can be added via WebFonts. The rendering of the score will be delayed until it is detected that the font was loaded. Simply use any CSS font property compliant string as configuration. Relative font sizes with percentual values are not supported, remaining values will be considered if supported.
 </p>
 
 

--- a/Phase/Mscorlib/system/CsString.hx
+++ b/Phase/Mscorlib/system/CsString.hx
@@ -358,4 +358,5 @@ abstract CsString(String) from String to String
 	@:op(A + B) public static inline function add16(lhs : system.CsString, rhs : system.Single) : system.CsString return lhs + rhs.toString();
     @:op(A + B) public static inline function add17(lhs : system.CsString, rhs : system.Double) : system.CsString return lhs + rhs.toString();
     @:op(A + B) public static inline function add18(lhs : system.CsString, rhs : system.CsString) : system.CsString return lhs.toHaxeString() + rhs.toHaxeString();
+    @:op(A + B) public static inline function add19(lhs : system.CsString, rhs : system.Boolean) : system.CsString return lhs.toHaxeString() + Std.string(rhs);
 }

--- a/Samples/CSharp/AlphaTab.Samples.PngDump/Program.cs
+++ b/Samples/CSharp/AlphaTab.Samples.PngDump/Program.cs
@@ -52,7 +52,7 @@ namespace AlphaTab.Samples.PngDump
                 var info = new FileInfo(args[0]);
                 var path = Path.Combine(info.DirectoryName, Path.GetFileNameWithoutExtension(info.Name) + "-" + i + ".png");
 
-                using (var full = SKSurface.Create(totalWidth, totalHeight, SKImageInfo.PlatformColorType, SKAlphaType.Premul))
+                using (var full = SKSurface.Create(new SKImageInfo(totalWidth, totalHeight, SKImageInfo.PlatformColorType, SKAlphaType.Premul)))
                 {
                     var y = 0;
                     foreach (var image in images)

--- a/Source/AlphaTab.CSharp/Platform/CSharp/ManagedUiFacade.cs
+++ b/Source/AlphaTab.CSharp/Platform/CSharp/ManagedUiFacade.cs
@@ -10,7 +10,7 @@ using AlphaTab.UI;
 
 namespace AlphaTab.Platform.CSharp
 {
-    public abstract class ManagedUiFacade<TSettings> : IUiFacade<TSettings>
+    internal abstract class ManagedUiFacade<TSettings> : IUiFacade<TSettings>
     {
         protected ConcurrentQueue<Counter> TotalResultCount { get; private set; }
 

--- a/Source/AlphaTab.CSharp/Platform/Svg/FontSizes.cs
+++ b/Source/AlphaTab.CSharp/Platform/Svg/FontSizes.cs
@@ -1,0 +1,27 @@
+﻿namespace AlphaTab.Platform.Svg
+{
+    /// <summary>
+    /// This public class stores text widths for several fonts and allows width calculation
+    /// </summary>
+    internal partial class FontSizes
+    {
+        public static void GenerateFontLookup(string family)
+        {
+            if (FontSizeLookupTables == null)
+            {
+                Init();
+            }
+
+            if (FontSizeLookupTables.ContainsKey(family))
+            {
+                return;
+            }
+
+            // TODO: maybe allow fallback to GDI/Skia based on availability?
+            FontSizeLookupTables[family] = new byte[]
+            {
+                8
+            };
+        }
+    }
+}

--- a/Source/AlphaTab.JavaScript/Collections/FastDictionary.cs
+++ b/Source/AlphaTab.JavaScript/Collections/FastDictionary.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using Phase;
 using Phase.Attributes;
 

--- a/Source/AlphaTab.JavaScript/Haxe/IO/HaxeBytesBuffer.cs
+++ b/Source/AlphaTab.JavaScript/Haxe/IO/HaxeBytesBuffer.cs
@@ -1,5 +1,4 @@
-﻿using Haxe;
-using Phase.Attributes;
+﻿using Phase.Attributes;
 
 namespace Haxe.IO
 {

--- a/Source/AlphaTab.JavaScript/Haxe/Js/Html/Blob.cs
+++ b/Source/AlphaTab.JavaScript/Haxe/Js/Html/Blob.cs
@@ -1,5 +1,4 @@
-﻿using Haxe;
-using Phase.Attributes;
+﻿using Phase.Attributes;
 
 namespace AlphaTab.Haxe.Js.Html
 {

--- a/Source/AlphaTab.JavaScript/Haxe/Js/Html/CSSStyleDeclaration.cs
+++ b/Source/AlphaTab.JavaScript/Haxe/Js/Html/CSSStyleDeclaration.cs
@@ -1,4 +1,5 @@
-﻿using Haxe;
+﻿using System.Net.Mail;
+using Haxe;
 using Phase.Attributes;
 
 namespace AlphaTab.Haxe.Js.Html
@@ -57,5 +58,29 @@ namespace AlphaTab.Haxe.Js.Html
 
         [Name("transitionDuration")]
         public HaxeString TransitionDuration { get; set; }
+
+        [Name("fontSynthesis")]
+        public HaxeString FontSynthesis { get; set; }
+
+        [Name("maxWidth")]
+        public HaxeString MaxWidth { get; set; }
+
+        [Name("minWidth")]
+        public HaxeString MinWidth { get; set; }
+
+        [Name("minHeight")]
+        public HaxeString MinHeight { get; set; }
+
+        [Name("margin")]
+        public HaxeString Margin { get; set; }
+
+        [Name("padding")]
+        public HaxeString Padding { get; set; }
+
+        [Name("whiteSpace")]
+        public HaxeString WhiteSpace { get; set; }
+
+        [Name("font")]
+        public HaxeString Font { get; set; }
     }
 }

--- a/Source/AlphaTab.JavaScript/Haxe/Js/Html/CSSStyleDeclaration.cs
+++ b/Source/AlphaTab.JavaScript/Haxe/Js/Html/CSSStyleDeclaration.cs
@@ -1,5 +1,4 @@
-﻿using System.Net.Mail;
-using Haxe;
+﻿using Haxe;
 using Phase.Attributes;
 
 namespace AlphaTab.Haxe.Js.Html
@@ -59,28 +58,5 @@ namespace AlphaTab.Haxe.Js.Html
         [Name("transitionDuration")]
         public HaxeString TransitionDuration { get; set; }
 
-        [Name("fontSynthesis")]
-        public HaxeString FontSynthesis { get; set; }
-
-        [Name("maxWidth")]
-        public HaxeString MaxWidth { get; set; }
-
-        [Name("minWidth")]
-        public HaxeString MinWidth { get; set; }
-
-        [Name("minHeight")]
-        public HaxeString MinHeight { get; set; }
-
-        [Name("margin")]
-        public HaxeString Margin { get; set; }
-
-        [Name("padding")]
-        public HaxeString Padding { get; set; }
-
-        [Name("whiteSpace")]
-        public HaxeString WhiteSpace { get; set; }
-
-        [Name("font")]
-        public HaxeString Font { get; set; }
     }
 }

--- a/Source/AlphaTab.JavaScript/Haxe/Js/Html/DOMElement.cs
+++ b/Source/AlphaTab.JavaScript/Haxe/Js/Html/DOMElement.cs
@@ -67,6 +67,10 @@ namespace AlphaTab.Haxe.Js.Html
         [Name("scrollLeft")]
         public HaxeInt ScrollLeft { get; set; }
 
+        [Name("scrollWidth")]
+        public HaxeInt ScrollWidth { get; set; }
+
+
 
         [Name("querySelector")]
         public extern Element QuerySelector(HaxeString selectors);

--- a/Source/AlphaTab.JavaScript/Haxe/Js/Html/DOMElement.cs
+++ b/Source/AlphaTab.JavaScript/Haxe/Js/Html/DOMElement.cs
@@ -67,11 +67,6 @@ namespace AlphaTab.Haxe.Js.Html
         [Name("scrollLeft")]
         public HaxeInt ScrollLeft { get; set; }
 
-        [Name("scrollWidth")]
-        public HaxeInt ScrollWidth { get; set; }
-
-
-
         [Name("querySelector")]
         public extern Element QuerySelector(HaxeString selectors);
 

--- a/Source/AlphaTab.JavaScript/Haxe/Js/Html/Node.cs
+++ b/Source/AlphaTab.JavaScript/Haxe/Js/Html/Node.cs
@@ -14,9 +14,6 @@ namespace AlphaTab.Haxe.Js.Html
         [Name("nodeValue")]
         public extern HaxeString NodeValue { get; }
 
-        [Name("parentNode")]
-        public Node ParentNode { get; set; }
-
         [Name("appendChild")]
         public extern void AppendChild(Node node);
 

--- a/Source/AlphaTab.JavaScript/Haxe/Js/Html/Node.cs
+++ b/Source/AlphaTab.JavaScript/Haxe/Js/Html/Node.cs
@@ -14,6 +14,9 @@ namespace AlphaTab.Haxe.Js.Html
         [Name("nodeValue")]
         public extern HaxeString NodeValue { get; }
 
+        [Name("parentNode")]
+        public Node ParentNode { get; set; }
+
         [Name("appendChild")]
         public extern void AppendChild(Node node);
 

--- a/Source/AlphaTab.JavaScript/Haxe/Js/Navigator.cs
+++ b/Source/AlphaTab.JavaScript/Haxe/Js/Navigator.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Haxe;
+﻿using Haxe;
 using Phase.Attributes;
 
 namespace AlphaTab.Haxe.Js

--- a/Source/AlphaTab.JavaScript/Haxe/Zip/Reader.cs
+++ b/Source/AlphaTab.JavaScript/Haxe/Zip/Reader.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Haxe.IO;
 using Phase.Attributes;
 

--- a/Source/AlphaTab.JavaScript/IO/ZipFile.cs
+++ b/Source/AlphaTab.JavaScript/IO/ZipFile.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using AlphaTab.Importer;
+﻿using AlphaTab.Importer;
 using Haxe.Zip;
 using Phase;
 

--- a/Source/AlphaTab.JavaScript/Importer/ScoreLoader.cs
+++ b/Source/AlphaTab.JavaScript/Importer/ScoreLoader.cs
@@ -4,7 +4,6 @@ using AlphaTab.Model;
 using AlphaTab.Platform;
 using Haxe.Js.Html;
 using Phase;
-using Phase.Attributes;
 
 namespace AlphaTab.Importer
 {

--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaSynthFlashOutput.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaSynthFlashOutput.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using AlphaTab.Audio.Synth;
-using AlphaTab.Audio.Synth.Ds;
 using AlphaTab.Collections;
 using AlphaTab.Haxe.Js;
 using AlphaTab.Haxe.Js.Html;

--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaSynthWebAudioOutput.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaSynthWebAudioOutput.cs
@@ -4,8 +4,6 @@ using AlphaTab.Audio.Synth.Ds;
 using AlphaTab.Haxe.Js;
 using AlphaTab.Haxe.Js.Html;
 using AlphaTab.Haxe.Js.Html.Audio;
-using AlphaTab.Util;
-using Haxe;
 
 namespace AlphaTab.Platform.JavaScript
 {

--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaSynthWebWorkerApi.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaSynthWebWorkerApi.cs
@@ -2,7 +2,6 @@
 using AlphaTab.Audio.Synth;
 using AlphaTab.Audio.Synth.Midi;
 using AlphaTab.Audio.Synth.Util;
-using AlphaTab.Collections;
 using AlphaTab.Haxe.Js.Html;
 using AlphaTab.Model;
 using AlphaTab.Util;

--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaSynthWorkerSynthOutput.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaSynthWorkerSynthOutput.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using AlphaTab.Audio.Synth;
-using AlphaTab.Audio.Synth.Ds;
 using AlphaTab.Haxe.Js;
 using AlphaTab.Haxe.Js.Html;
 using AlphaTab.Util;

--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabApi.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabApi.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Diagnostics.Contracts;
 using AlphaTab.Audio.Generator;
 using AlphaTab.Audio.Synth;
 using AlphaTab.Audio.Synth.Midi;
 using AlphaTab.Collections;
 using AlphaTab.Haxe.Js;
 using AlphaTab.Haxe.Js.Html;
-using AlphaTab.Importer;
 using AlphaTab.Model;
 using AlphaTab.UI;
 using Haxe.Js.Html;

--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabWebWorker.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabWebWorker.cs
@@ -1,10 +1,8 @@
 using System;
-using AlphaTab.Collections;
 using AlphaTab.Haxe;
 using AlphaTab.Haxe.Js;
 using AlphaTab.Haxe.Js.Html;
 using AlphaTab.Model;
-using AlphaTab.Platform.Svg;
 using AlphaTab.Rendering;
 using AlphaTab.Util;
 

--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabWebWorker.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabWebWorker.cs
@@ -67,25 +67,12 @@ namespace AlphaTab.Platform.JavaScript
                     _renderer.Width = data.width;
                     break;
                 case "alphaTab.renderScore":
-                    ImportFonts(data.fonts);
-
                     var score = JsonConverter.JsObjectToScore(data.score, _renderer.Settings);
                     RenderMultiple(score, data.trackIndexes);
                     break;
                 case "alphaTab.updateSettings":
                     UpdateSettings(data.settings);
                     break;
-            }
-        }
-
-        private void ImportFonts(FastDictionary<string, byte[]> fonts)
-        {
-            foreach (var font in fonts)
-            {
-                if (!FontSizes.FontSizeLookupTables.ContainsKey(font))
-                {
-                    FontSizes.FontSizeLookupTables[font] = fonts[font];
-                }
             }
         }
 

--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabWebWorker.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabWebWorker.cs
@@ -1,8 +1,10 @@
 using System;
+using AlphaTab.Collections;
 using AlphaTab.Haxe;
 using AlphaTab.Haxe.Js;
 using AlphaTab.Haxe.Js.Html;
 using AlphaTab.Model;
+using AlphaTab.Platform.Svg;
 using AlphaTab.Rendering;
 using AlphaTab.Util;
 
@@ -65,12 +67,25 @@ namespace AlphaTab.Platform.JavaScript
                     _renderer.Width = data.width;
                     break;
                 case "alphaTab.renderScore":
+                    ImportFonts(data.fonts);
+
                     var score = JsonConverter.JsObjectToScore(data.score, _renderer.Settings);
                     RenderMultiple(score, data.trackIndexes);
                     break;
                 case "alphaTab.updateSettings":
                     UpdateSettings(data.settings);
                     break;
+            }
+        }
+
+        private void ImportFonts(FastDictionary<string, byte[]> fonts)
+        {
+            foreach (var font in fonts)
+            {
+                if (!FontSizes.FontSizeLookupTables.ContainsKey(font))
+                {
+                    FontSizes.FontSizeLookupTables[font] = fonts[font];
+                }
             }
         }
 

--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabWorkerScoreRenderer.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabWorkerScoreRenderer.cs
@@ -1,7 +1,6 @@
 using System;
 using AlphaTab.Haxe.Js.Html;
 using AlphaTab.Model;
-using AlphaTab.Platform.Svg;
 using AlphaTab.Rendering;
 using AlphaTab.Rendering.Utils;
 using AlphaTab.Util;

--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabWorkerScoreRenderer.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabWorkerScoreRenderer.cs
@@ -127,8 +127,7 @@ namespace AlphaTab.Platform.JavaScript
             {
                 cmd = "alphaTab.renderScore",
                 score = jsObject,
-                trackIndexes = trackIndexes,
-                fonts = FontSizes.FontSizeLookupTables
+                trackIndexes = trackIndexes
             });
         }
 

--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabWorkerScoreRenderer.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabWorkerScoreRenderer.cs
@@ -1,6 +1,7 @@
 using System;
 using AlphaTab.Haxe.Js.Html;
 using AlphaTab.Model;
+using AlphaTab.Platform.Svg;
 using AlphaTab.Rendering;
 using AlphaTab.Rendering.Utils;
 using AlphaTab.Util;
@@ -126,7 +127,8 @@ namespace AlphaTab.Platform.JavaScript
             {
                 cmd = "alphaTab.renderScore",
                 score = jsObject,
-                trackIndexes = trackIndexes
+                trackIndexes = trackIndexes,
+                fonts = FontSizes.FontSizeLookupTables
             });
         }
 

--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/Html5Canvas.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/Html5Canvas.cs
@@ -2,9 +2,7 @@
 using AlphaTab.Haxe.Js;
 using AlphaTab.Haxe.Js.Html;
 using AlphaTab.Platform.Model;
-using AlphaTab.Rendering;
 using AlphaTab.Rendering.Glyphs;
-using Phase;
 using TextAlign = AlphaTab.Platform.Model.TextAlign;
 
 namespace AlphaTab.Platform.JavaScript

--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/JQueryAlphaTab.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/JQueryAlphaTab.cs
@@ -6,7 +6,6 @@ using AlphaTab.Haxe.Js;
 using AlphaTab.Haxe.Js.Html;
 using AlphaTab.Model;
 using AlphaTab.Rendering;
-using AlphaTab.UI;
 using AlphaTab.Util;
 using Phase;
 using Phase.Attributes;

--- a/Source/AlphaTab.JavaScript/Platform/Platform.cs
+++ b/Source/AlphaTab.JavaScript/Platform/Platform.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using AlphaTab.Audio.Synth;
-using AlphaTab.Audio.Synth.Midi;
-using AlphaTab.Audio.Synth.Midi.Event;
 using AlphaTab.Collections;
 using AlphaTab.Haxe.Js;
 using AlphaTab.IO;
-using AlphaTab.Platform.JavaScript;
 using AlphaTab.Util;
 using Haxe;
 using Haxe.Js.Html;

--- a/Source/AlphaTab.JavaScript/Platform/Svg/FontSizes.cs
+++ b/Source/AlphaTab.JavaScript/Platform/Svg/FontSizes.cs
@@ -5,36 +5,44 @@ using AlphaTab.Haxe.Js.Html;
 namespace AlphaTab.Platform.Svg
 {
     /// <summary>
-    /// This public class stores text widths for several fonts and allows width calculation 
+    /// This public class stores text widths for several fonts and allows width calculation
     /// </summary>
     internal partial class FontSizes
     {
-        public static byte[] GenerateFontLookup(string family)
+        public static void GenerateFontLookup(string family)
         {
             if (FontSizeLookupTables == null)
             {
-                FontSizeLookupTables = new FastDictionary<string, byte[]>();
+                Init();
             }
-
             if (FontSizeLookupTables.ContainsKey(family))
             {
-                return FontSizeLookupTables[family];
+                return;
             }
 
-            var canvas = (CanvasElement)Browser.Document.CreateElement("canvas");
-            var measureContext = (CanvasRenderingContext2D)canvas.GetContext("2d");
-            measureContext.Font = "11px " + family;
-
-            var sizes = new FastList<byte>();
-            for (var i = 0x20; i < 255; i++)
+            if (Lib.Global.document)
             {
-                var s = Platform.StringFromCharCode(i);
-                sizes.Add((byte)measureContext.MeasureText(s).Width);
-            }
+                var canvas = (CanvasElement)Browser.Document.CreateElement("canvas");
+                var measureContext = (CanvasRenderingContext2D)canvas.GetContext("2d");
+                measureContext.Font = "11px " + family;
 
-            var data = sizes.ToArray();
-            FontSizeLookupTables[family] = data;
-            return data;
+                var sizes = new FastList<byte>();
+                for (var i = 0x20; i < 255; i++)
+                {
+                    var s = Platform.StringFromCharCode(i);
+                    sizes.Add((byte)measureContext.MeasureText(s).Width);
+                }
+
+                var data = sizes.ToArray();
+                FontSizeLookupTables[family] = data;
+            }
+            else
+            {
+                FontSizeLookupTables[family] = new byte[]
+                {
+                    8
+                };
+            }
         }
     }
 }

--- a/Source/AlphaTab.JavaScript/Rendering/Utils/BoundsLookup.cs
+++ b/Source/AlphaTab.JavaScript/Rendering/Utils/BoundsLookup.cs
@@ -1,5 +1,4 @@
 ﻿using AlphaTab.Collections;
-using AlphaTab.Haxe.Js.Html;
 using AlphaTab.Model;
 using AlphaTab.Platform;
 

--- a/Source/AlphaTab.JavaScript/Settings.cs
+++ b/Source/AlphaTab.JavaScript/Settings.cs
@@ -885,8 +885,6 @@ namespace AlphaTab
                     family = family.Substring(1, family.Length - 2);
                 }
 
-                FontSizes.GenerateFontLookup(family);
-
                 string fontSizeString = style.FontSize.ToLowerCase();
                 float fontSize;
                 // as per https://websemantics.uk/articles/font-size-conversion/

--- a/Source/AlphaTab.JavaScript/UI/BrowserUiFacade.cs
+++ b/Source/AlphaTab.JavaScript/UI/BrowserUiFacade.cs
@@ -9,6 +9,7 @@ using AlphaTab.Model;
 using AlphaTab.Platform;
 using AlphaTab.Platform.JavaScript;
 using AlphaTab.Platform.Model;
+using AlphaTab.Platform.Svg;
 using AlphaTab.Rendering;
 using AlphaTab.Rendering.Utils;
 using AlphaTab.Util;
@@ -62,8 +63,10 @@ namespace AlphaTab.UI
         }
 
         public event Action CanRenderChanged;
-        private void OnFontLoaded()
+        private void OnFontLoaded(string family)
         {
+            FontSizes.GenerateFontLookup(family);
+
             if (AreAllFontsLoaded())
             {
                 var handler = CanRenderChanged;

--- a/Source/AlphaTab.JavaScript/UI/BrowserUiFacade.cs
+++ b/Source/AlphaTab.JavaScript/UI/BrowserUiFacade.cs
@@ -8,9 +8,11 @@ using AlphaTab.Importer;
 using AlphaTab.Model;
 using AlphaTab.Platform;
 using AlphaTab.Platform.JavaScript;
+using AlphaTab.Platform.Model;
 using AlphaTab.Rendering;
 using AlphaTab.Rendering.Utils;
 using AlphaTab.Util;
+using AlphaTab.Utils;
 using Haxe;
 using Haxe.Js.Html;
 using Phase;
@@ -20,6 +22,8 @@ namespace AlphaTab.UI
     internal class BrowserUiFacade : IUiFacade<object>
     {
         private event Action _rootContainerBecameVisible;
+
+        private FastDictionary<string, FontLoadingChecker> _fontCheckers;
 
         private AlphaTabApi<object> _api;
         private string _contents;
@@ -34,20 +38,50 @@ namespace AlphaTab.UI
         public IContainer RootContainer { get; }
         public bool AreWorkersSupported { get; }
 
-        public bool CanRender => _api.Settings.Engine != "html5" || Environment.IsFontLoaded;
+        public bool CanRender => AreAllFontsLoaded();
 
-        public event Action CanRenderChanged
+        private bool AreAllFontsLoaded()
         {
-            add => Environment.FontLoaded += value;
-            remove => Environment.FontLoaded += value;
+            if (!Environment.BravuraFontChecker.IsFontLoaded)
+            {
+                return false;
+            }
+
+            foreach (var font in _fontCheckers)
+            {
+                var checker = _fontCheckers[font];
+                if (!checker.IsFontLoaded)
+                {
+                    return false;
+                }
+            }
+
+            Logger.Debug("Font", "All fonts loaded: " + _fontCheckers.Count);
+
+            return true;
+        }
+
+        public event Action CanRenderChanged;
+        private void OnFontLoaded()
+        {
+            if (AreAllFontsLoaded())
+            {
+                var handler = CanRenderChanged;
+                if (handler != null)
+                {
+                    handler();
+                }
+            }
         }
 
         public BrowserUiFacade(Element rootElement)
         {
+            _fontCheckers = new FastDictionary<string, FontLoadingChecker>();
             rootElement.ClassList.Add("alphaTab");
             RootContainer = new HtmlElementContainer(rootElement);
             var workersUnsupported = !Browser.Window.Member<bool>("Worker");
             AreWorkersSupported = !workersUnsupported;
+            Environment.BravuraFontChecker.FontLoaded += OnFontLoaded;
         }
 
         public IScoreRenderer CreateWorkerRenderer()
@@ -104,6 +138,8 @@ namespace AlphaTab.UI
                 api.Container.Resize += ShowSvgsInViewPort;
             }
 
+            SetupFontCheckers(settings);
+
             #region build tracks array
 
             // get track data to parse
@@ -129,7 +165,6 @@ namespace AlphaTab.UI
 
             #endregion
 
-
             _contents = "";
             var element = ((HtmlElementContainer)api.Container);
             if (dataAttributes.ContainsKey("tex") && element.Element.InnerText.IsTruthy())
@@ -153,6 +188,32 @@ namespace AlphaTab.UI
             if (options && options.visibilityCheckInterval)
             {
                 _visibilityCheckInterval = options.visibilityCheckInterval;
+            }
+        }
+
+        private void SetupFontCheckers(Settings settings)
+        {
+            RegisterFontChecker(settings.RenderingResources.CopyrightFont);
+            RegisterFontChecker(settings.RenderingResources.EffectFont);
+            RegisterFontChecker(settings.RenderingResources.FingeringFont);
+            RegisterFontChecker(settings.RenderingResources.GraceFont);
+            RegisterFontChecker(settings.RenderingResources.MarkerFont);
+            RegisterFontChecker(settings.RenderingResources.TablatureFont);
+            RegisterFontChecker(settings.RenderingResources.TitleFont);
+            RegisterFontChecker(settings.RenderingResources.WordsFont);
+            RegisterFontChecker(settings.RenderingResources.BarNumberFont);
+            RegisterFontChecker(settings.RenderingResources.FretboardNumberFont);
+            RegisterFontChecker(settings.RenderingResources.SubTitleFont);
+        }
+
+        private void RegisterFontChecker(Font font)
+        {
+            if (!_fontCheckers.ContainsKey(font.Family))
+            {
+                var checker = new FontLoadingChecker(font.Family);
+                _fontCheckers[font.Family] = checker;
+                checker.FontLoaded += OnFontLoaded;
+                checker.CheckForFontAvailability();
             }
         }
 
@@ -334,7 +395,7 @@ namespace AlphaTab.UI
                 css.AppendLine("}");
                 styleElement.InnerHTML = css.ToString();
                 elementDocument.GetElementsByTagName("head").Item(0).AppendChild(styleElement);
-                Environment.CheckForFontAvailability();
+                Environment.BravuraFontChecker.CheckForFontAvailability();
             }
         }
 

--- a/Source/AlphaTab.JavaScript/Utils/FontLoadingChecker.cs
+++ b/Source/AlphaTab.JavaScript/Utils/FontLoadingChecker.cs
@@ -182,7 +182,6 @@ namespace AlphaTab.Utils
             checkerElement.Style.Overflow = "hidden";
 
             checkerElement.Style.Top = "-1000px";
-            checkerElement.Style.FontSynthesis = "none";
 
             checkerElement.Style.FontSize = "100px";
             checkerElement.Style.FontFamily = family;

--- a/Source/AlphaTab.JavaScript/Utils/FontLoadingChecker.cs
+++ b/Source/AlphaTab.JavaScript/Utils/FontLoadingChecker.cs
@@ -16,14 +16,14 @@ namespace AlphaTab.Utils
         private readonly string _fallbackText;
         private bool _isStarted;
         public bool IsFontLoaded { get; set; }
-        public event Action FontLoaded;
+        public event Action<string> FontLoaded;
 
         private void OnFontLoaded()
         {
             var handler = FontLoaded;
             if (handler != null)
             {
-                handler();
+                handler(_family);
             }
         }
 

--- a/Source/AlphaTab.JavaScript/Utils/FontLoadingChecker.cs
+++ b/Source/AlphaTab.JavaScript/Utils/FontLoadingChecker.cs
@@ -1,0 +1,195 @@
+using System;
+using AlphaTab.Haxe.Js;
+using AlphaTab.Haxe.Js.Html;
+using AlphaTab.Platform;
+using AlphaTab.Util;
+using Phase;
+
+namespace AlphaTab.Utils
+{
+    /// <summary>
+    /// This small utility helps to detect whether a particular font is already loaded.
+    /// </summary>
+    internal class FontLoadingChecker
+    {
+        private readonly string _family;
+        private readonly string _fallbackText;
+        private bool _isStarted;
+        public bool IsFontLoaded { get; set; }
+        public event Action FontLoaded;
+
+        private void OnFontLoaded()
+        {
+            var handler = FontLoaded;
+            if (handler != null)
+            {
+                handler();
+            }
+        }
+
+        public FontLoadingChecker(
+            string family,
+            string fallbackText = null)
+        {
+            _family = family;
+            _fallbackText = fallbackText == null ? "BESbwy" : fallbackText;
+        }
+
+        public void CheckForFontAvailability()
+        {
+            var isWorker =
+                Script.Write<bool>(
+                    "untyped __js__(\"typeof(WorkerGlobalScope) !== 'undefined' && self instanceof WorkerGlobalScope\")");
+            if (isWorker)
+            {
+                // no web fonts in web worker
+                IsFontLoaded = false;
+                return;
+            }
+
+            if (_isStarted)
+            {
+                return;
+            }
+
+            _isStarted = true;
+            var failCounter = 0;
+            var failCounterId = Browser.Window.SetInterval(new Action(() =>
+            {
+                failCounter++;
+                Logger.Warning("Rendering",
+                    "Could not load font '" + _family + "' within " + (failCounter * 5) + " seconds");
+            }),
+            5000);
+
+            Logger.Debug("Font", "Start checking for font availablility: " + _family);
+            var cssFontLoadingModuleSupported = Browser.Document.Fonts.IsTruthy() &&
+                                                Browser.Document.Fonts.Member<object>("load").IsTruthy();
+            if (cssFontLoadingModuleSupported)
+            {
+                Logger.Debug("Font", "[" + _family + "] Font API available");
+                Action checkFont = null;
+                checkFont = () =>
+                {
+                    Browser.Document.Fonts.Load("1em " + _family).Then(_ =>
+                    {
+                        Logger.Debug("Font", "[" + _family + "] Font API signaled loaded");
+                        if (Browser.Document.Fonts.Check("1em " + _family))
+                        {
+                            Logger.Info("Rendering", "[" + _family + "] Font API signaled available");
+                            IsFontLoaded = true;
+                            Browser.Window.ClearInterval(failCounterId);
+                            OnFontLoaded();
+                        }
+                        else
+                        {
+                            Logger.Debug("Font",
+                                "[" + _family +
+                                "] Font API loaded reported, but font not available, checking later again");
+                            Browser.Window.SetTimeout((Action)(() =>
+                                {
+                                    checkFont();
+                                }),
+                                250);
+                        }
+
+                        return true;
+                    });
+                };
+                checkFont();
+            }
+            else
+            {
+                Logger.Debug("Font", "[" + _family + "] Font API not available, using resize trick");
+                // based on the idea of https://www.bramstein.com/writing/detecting-system-fonts-without-flash.html
+                // simply create 3 elements with the 3 default font families and measure them
+                // then change to the desired font and expect a change on the width
+
+                Element sans = null;
+                Element serif = null;
+                Element monospace = null;
+
+                var initialSansWidth = -1;
+                var initialSerifWidth = -1;
+                var initialMonospaceWidth = -1;
+
+                Action checkFont = null;
+                checkFont = () =>
+                {
+                    if (sans == null)
+                    {
+                        sans = CreateCheckerElement("sans-serif");
+                        serif = CreateCheckerElement("serif");
+                        monospace = CreateCheckerElement("monospace");
+
+                        Browser.Document.Body.AppendChild(sans);
+                        Browser.Document.Body.AppendChild(serif);
+                        Browser.Document.Body.AppendChild(monospace);
+
+                        initialSansWidth = sans.OffsetWidth;
+                        initialSerifWidth = serif.OffsetWidth;
+                        initialMonospaceWidth = monospace.OffsetWidth;
+
+                        sans.Style.FontFamily = "'" + _family + "',sans-serif";
+                        serif.Style.FontFamily = "'" + _family + "',serif";
+                        monospace.Style.FontFamily = "'" + _family + "',monospace";
+
+
+                    }
+
+                    var sansWidth = sans.OffsetWidth;
+                    var serifWidth = serif.OffsetWidth;
+                    var monospaceWidth = monospace.OffsetWidth;
+
+                    if ((sansWidth != initialSansWidth && serifWidth != initialSerifWidth) ||
+                        (sansWidth != initialSansWidth && monospaceWidth != initialMonospaceWidth) ||
+                        (serifWidth != initialSerifWidth && monospaceWidth != initialMonospaceWidth))
+                    {
+                        if (sansWidth == serifWidth || sansWidth == monospaceWidth || serifWidth == monospaceWidth)
+                        {
+                            Browser.Document.Body.RemoveChild(sans);
+                            Browser.Document.Body.RemoveChild(serif);
+                            Browser.Document.Body.RemoveChild(monospace);
+                            IsFontLoaded = true;
+                            Browser.Window.ClearInterval(failCounterId);
+                            OnFontLoaded();
+                        }
+                        else
+                        {
+                            Browser.Window.SetTimeout(checkFont, 250);
+                        }
+                    }
+                    else
+                    {
+                        Browser.Window.SetTimeout(checkFont, 250);
+                    }
+                };
+
+                Browser.Window.AddEventListener("DOMContentLoaded",
+                    (Action)(() =>
+                    {
+                        checkFont();
+                    }));
+            }
+        }
+
+        private Element CreateCheckerElement(string family)
+        {
+            var document = Browser.Document;
+            var checkerElement = document.CreateElement("span");
+            checkerElement.Style.Display = "inline-block";
+            checkerElement.Style.Position = "absolute";
+            checkerElement.Style.Overflow = "hidden";
+
+            checkerElement.Style.Top = "-1000px";
+            checkerElement.Style.FontSynthesis = "none";
+
+            checkerElement.Style.FontSize = "100px";
+            checkerElement.Style.FontFamily = family;
+            checkerElement.InnerHTML = _fallbackText;
+
+            document.Body.AppendChild(checkerElement);
+            return checkerElement;
+        }
+    }
+}

--- a/Source/AlphaTab/AlphaTabApi.cs
+++ b/Source/AlphaTab/AlphaTabApi.cs
@@ -214,6 +214,10 @@ namespace AlphaTab
             InternalRenderTracks(score, tracks.ToArray());
         }
 
+        /// <summary>
+        /// Renders the given list of tracks.
+        /// </summary>
+        /// <param name="tracks">The tracks to render. They must all belong to the same score.</param>
         public void RenderTracks(Track[] tracks)
         {
             if (tracks.Length > 0)

--- a/Source/AlphaTab/Audio/Synth/ISynthOutput.cs
+++ b/Source/AlphaTab/Audio/Synth/ISynthOutput.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using AlphaTab.Audio.Synth.Ds;
 
 namespace AlphaTab.Audio.Synth
 {

--- a/Source/AlphaTab/Platform/Svg/FontSizes.cs
+++ b/Source/AlphaTab/Platform/Svg/FontSizes.cs
@@ -5,7 +5,7 @@ using AlphaTab.Platform.Model;
 namespace AlphaTab.Platform.Svg
 {
     /// <summary>
-    /// This public class stores text widths for several fonts and allows width calculation 
+    /// This public class stores text widths for several fonts and allows width calculation
     /// </summary>
     internal partial class FontSizes
     {
@@ -57,18 +57,11 @@ namespace AlphaTab.Platform.Svg
 
             byte[] data;
             var dataSize = 11;
-            if (FontSizeLookupTables.ContainsKey(family))
+            if (!FontSizeLookupTables.ContainsKey(family))
             {
-                data = FontSizeLookupTables[family];
+                GenerateFontLookup(family);
             }
-            else
-            {
-                // TODO: on-the-fly-generation for all canvas types
-                data = new byte[]
-                {
-                    8
-                };
-            }
+            data = FontSizeLookupTables[family];
 
             float factor = 1;
             if ((style & FontStyle.Italic) != 0)


### PR DESCRIPTION
Closes #266 

This PR adds support for all available browser fonts to alphaTab. 

Tasks: 

- [x] Add logic to generate lookup on-the-fly based on settings
- [x] Adopt workflow of font-lookup generation to respect if fonts are available (web fonts might be loaded delayed)
- [x] Add samples and docs