### PR TITLE
Add dynamic enable/disable of player and cursor feature

### DIFF
--- a/Documentation/input/reference/api/loadsoundfont.cshtml
+++ b/Documentation/input/reference/api/loadsoundfont.cshtml
@@ -9,7 +9,8 @@ Since: 0.9.4
 
 <h2>Description</h2>
 <p>
-    This function initiates a load of the soundfont using the given data. The supported data types is depending on the platform. AlphaTab only supports SoundFont2 encoded soundfonts for loading.
+    This function initiates a load of the soundfont using the given data. The supported data types is depending on the platform. AlphaTab only supports SoundFont2 encoded soundfonts for loading. To load a soundfont the player must be enabled in advance. 
+	
 </p>
 
 <h2>Signatures</h2>

--- a/Source/AlphaTab.CSharp/Platform/CSharp/ManagedUiFacade.cs
+++ b/Source/AlphaTab.CSharp/Platform/CSharp/ManagedUiFacade.cs
@@ -85,6 +85,7 @@ namespace AlphaTab.Platform.CSharp
         protected abstract void RenderTracks();
 
         public abstract void BeginAppendRenderResults(RenderFinishedEventArgs renderResults);
+        public abstract void DestroyCursors();
         public abstract Cursors CreateCursors();
         public abstract void BeginInvoke(Action action);
         public abstract void RemoveHighlights();

--- a/Source/AlphaTab.CSharp/Platform/CSharp/WinForms/WinFormsUiFacade.cs
+++ b/Source/AlphaTab.CSharp/Platform/CSharp/WinForms/WinFormsUiFacade.cs
@@ -194,6 +194,10 @@ namespace AlphaTab.Platform.CSharp.WinForms
         }
 
 
+        public override void DestroyCursors()
+        {
+        }
+
         public override Cursors CreateCursors()
         {
             // no cursors for winforms, why? - It lacks of proper transparency support

--- a/Source/AlphaTab.CSharp/Platform/CSharp/Wpf/WpfUiFacade.cs
+++ b/Source/AlphaTab.CSharp/Platform/CSharp/Wpf/WpfUiFacade.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -191,10 +192,20 @@ namespace AlphaTab.Platform.CSharp.Wpf
                 r);
         }
 
+        public override void DestroyCursors()
+        {
+            var element = (Panel)((FrameworkElementContainer)Api.CanvasElement).Control.Parent;
+            var cursors = element.Children.OfType<Canvas>().FirstOrDefault(c => "at-cursors".Equals(c.Tag));
+            if (cursors != null)
+            {
+                element.Children.Remove(cursors);
+            }
+        }
 
         public override Cursors CreateCursors()
         {
             var cursorWrapper = new Canvas();
+            cursorWrapper.Tag = "at-cursors";
             cursorWrapper.HorizontalAlignment = HorizontalAlignment.Left;
             cursorWrapper.VerticalAlignment = VerticalAlignment.Top;
 

--- a/Source/AlphaTab.JavaScript/UI/BrowserUiFacade.cs
+++ b/Source/AlphaTab.JavaScript/UI/BrowserUiFacade.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using AlphaTab.Audio.Synth;
 using AlphaTab.Collections;
 using AlphaTab.Haxe;
@@ -649,7 +650,13 @@ namespace AlphaTab.UI
             }
             else
             {
-                player.Ready += () => { ((AlphaTabApi)_api).LoadSoundFontFromUrl(_api.Settings.SoundFontFile); };
+                player.Ready += () =>
+                {
+                    if (!string.IsNullOrEmpty(_api.Settings.SoundFontFile))
+                    {
+                        ((AlphaTabApi)_api).LoadSoundFontFromUrl(_api.Settings.SoundFontFile);
+                    }
+                };
             }
 
             return player;
@@ -678,6 +685,13 @@ namespace AlphaTab.UI
             {
                 elements.Item(0).ClassList.Remove("at-highlight");
             }
+        }
+
+        public void DestroyCursors()
+        {
+            var element = ((HtmlElementContainer)_api.Container).Element;
+            var cursorWrapper = element.QuerySelector(".at-cursors");
+            element.RemoveChild(cursorWrapper);
         }
 
         public Cursors CreateCursors()

--- a/Source/AlphaTab/UI/IUiFacade.cs
+++ b/Source/AlphaTab/UI/IUiFacade.cs
@@ -99,6 +99,11 @@ namespace AlphaTab.UI
         Cursors CreateCursors();
 
         /// <summary>
+        /// Destroys the cursor objects that are used to highlight the currently played beats and bars.
+        /// </summary>
+        void DestroyCursors();
+
+        /// <summary>
         /// Tells the UI layer to invoke the given action.
         /// </summary>
         /// <param name="action"></param>


### PR DESCRIPTION
Fixes #293 

This PR ensures the player is dynamically enabled and destroyed based on the settings when calling `updateSettings`