### PR TITLE
Create workers via blobs by default

### DIFF
--- a/Source/AlphaTab.JavaScript/Environment.cs
+++ b/Source/AlphaTab.JavaScript/Environment.cs
@@ -32,8 +32,9 @@ namespace AlphaTab
 
             RegisterJQueryPlugin();
 
-            Script.Write(
-                "untyped __js__(\"Math.log2 = Math.log2 || function(x) { return Math.log(x) * Math.LOG2E; };\");");
+            // polyfills
+            Script.Write("untyped __js__(\"Math.log2 = Math.log2 || function(x) { return Math.log(x) * Math.LOG2E; };\");");
+            Script.Write("untyped __js__(\"Int32Array.prototype.slice = Int32Array.prototype.slice || function(begin, end) { return new Int32Array(Array.prototype.slice.call(this, begin, end)) };\");");
 
             // try to build the find the alphaTab script url in case we are not in the webworker already
             if (Lib.Global.document)

--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaSynthWebWorkerApi.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaSynthWebWorkerApi.cs
@@ -198,16 +198,16 @@ namespace AlphaTab.Platform.JavaScript
 
             try
             {
-                _synth = new Worker(alphaSynthScriptFile);
+                HaxeString script = "importScripts('" + alphaSynthScriptFile + "')";
+                var blob = new Blob(Script.Write<object>("[ script ]"));
+                _synth = new Worker(URL.CreateObjectURL(blob));
             }
             catch
             {
-                // fallback to blob worker
+                // fallback to direct worker
                 try
                 {
-                    HaxeString script = "importScripts('" + alphaSynthScriptFile + "')";
-                    var blob = new Blob(Script.Write<object>("[ script ]"));
-                    _synth = new Worker(URL.CreateObjectURL(blob));
+                    _synth = new Worker(alphaSynthScriptFile);
                 }
                 catch (Exception e)
                 {

--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabWorkerScoreRenderer.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaTabWorkerScoreRenderer.cs
@@ -21,28 +21,31 @@ namespace AlphaTab.Platform.JavaScript
         public AlphaTabWorkerScoreRenderer(AlphaTabApi<T> api, Settings settings)
         {
             _api = api;
+            // first try blob worker
             try
             {
-                _worker = new Worker(settings.Core.ScriptFile);
+                HaxeString script = "importScripts('" + settings.Core.ScriptFile + "')";
+                var blob = new Blob(new[]
+                {
+                    script
+                });
+                _worker = new Worker(URL.CreateObjectURL(blob));
             }
-            catch
+            catch (Exception e)
             {
-                // fallback to blob worker
+                // fallback to direct worker
                 try
                 {
-                    HaxeString script = "importScripts('" + settings.Core.ScriptFile + "')";
-                    var blob = new Blob(new[]
-                    {
-                        script
-                    });
-                    _worker = new Worker(URL.CreateObjectURL(blob));
+                    _worker = new Worker(settings.Core.ScriptFile);
                 }
-                catch (Exception e)
+                catch
                 {
                     Logger.Error("Rendering", "Failed to create WebWorker: " + e);
                     // TODO: fallback to synchronous mode
                 }
             }
+
+
 
             _worker.PostMessage(new
             {


### PR DESCRIPTION
Fixes #304 

Firefox has some weird behavior on worker creations in CORS scenarios. Blob workers with importScripts seem to work and it does not break anything on other browsers. 