### PR TITLE
Fixed jumping on cursor for multi staff setups

### DIFF
--- a/Source/AlphaTab/Audio/MidiTickLookup.cs
+++ b/Source/AlphaTab/Audio/MidiTickLookup.cs
@@ -248,7 +248,9 @@ namespace AlphaTab.Audio
             var result = new MidiTickLookupFindBeatResult();
             result.CurrentBeat = beat.Beat;
             result.NextBeat = nextBeat == null ? null : nextBeat.Beat;
-            result.Duration = MidiUtils.TicksToMillis(beat.End - beat.Start, masterBar.Tempo);
+            result.Duration = nextBeat == null
+                ? MidiUtils.TicksToMillis(beat.End - beat.Start, masterBar.Tempo)
+                : MidiUtils.TicksToMillis(nextBeat.Start - beat.Start, masterBar.Tempo);
             return result;
         }
 

--- a/Source/AlphaTab/Rendering/BarRendererFactory.cs
+++ b/Source/AlphaTab/Rendering/BarRendererFactory.cs
@@ -8,6 +8,7 @@ namespace AlphaTab.Rendering
     internal abstract class BarRendererFactory
     {
         public bool IsInAccolade { get; set; }
+        public bool IsRelevantForBoundsLookup { get; set; }
         public bool HideOnMultiTrack { get; set; }
         public bool HideOnPercussionTrack { get; set; }
         public abstract string StaffId { get; }
@@ -15,6 +16,7 @@ namespace AlphaTab.Rendering
         protected BarRendererFactory()
         {
             IsInAccolade = true;
+            IsRelevantForBoundsLookup = true;
             HideOnPercussionTrack = false;
             HideOnMultiTrack = false;
         }

--- a/Source/AlphaTab/Rendering/EffectBarRendererFactory.cs
+++ b/Source/AlphaTab/Rendering/EffectBarRendererFactory.cs
@@ -14,6 +14,7 @@ namespace AlphaTab.Rendering
             _infos = infos;
             _staffId = staffId;
             IsInAccolade = false;
+            IsRelevantForBoundsLookup = false;
         }
 
         public override BarRendererBase Create(ScoreRenderer renderer, Bar bar)

--- a/Source/AlphaTab/Rendering/Staves/Staff.cs
+++ b/Source/AlphaTab/Rendering/Staves/Staff.cs
@@ -86,6 +86,7 @@ namespace AlphaTab.Rendering.Staves
         }
 
         public bool IsInAccolade => _factory.IsInAccolade;
+        public bool IsRelevantForBoundsLookup => _factory.IsRelevantForBoundsLookup;
 
         public void RegisterStaffTop(float offset)
         {

--- a/Source/AlphaTab/Rendering/Staves/StaveTrackGroup.cs
+++ b/Source/AlphaTab/Rendering/Staves/StaveTrackGroup.cs
@@ -8,6 +8,7 @@ namespace AlphaTab.Rendering.Staves
         public Track Track { get; set; }
         public StaveGroup StaveGroup { get; set; }
         public FastList<Staff> Staves { get; set; }
+        public FastList<Staff> StavesRelevantForBoundsLookup { get; set; }
 
         public Staff FirstStaffInAccolade { get; set; }
         public Staff LastStaffInAccolade { get; set; }
@@ -17,6 +18,16 @@ namespace AlphaTab.Rendering.Staves
             StaveGroup = staveGroup;
             Track = track;
             Staves = new FastList<Staff>();
+            StavesRelevantForBoundsLookup = new FastList<Staff>();
+        }
+
+        public void AddStaff(Staff staff)
+        {
+            Staves.Add(staff);
+            if (staff.IsRelevantForBoundsLookup)
+            {
+                StavesRelevantForBoundsLookup.Add(staff);
+            }
         }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,6 @@ install:
   - npm install -g jasmine-core
   - npm install -g karma
   - npm install -g karma-jasmine
-  - npm install -g karma-cli
   - npm install -g karma-chrome-launcher
   - npm install -g puppeteer
   - npm install -g karma-trx-reporter


### PR DESCRIPTION
fixes #318 

This PR changes 2 parts of the cursor handling: 

1. The duration of the cursor movement considers now the tick of the nextBeat 
2. The bounds lookup is now filled with with all staves that are relevant for the position handling 