### PR TITLE
Added missing player activation

### DIFF
--- a/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaSynthWebWorkerApi.cs
+++ b/Source/AlphaTab.JavaScript/Platform/JavaScript/AlphaSynthWebWorkerApi.cs
@@ -266,6 +266,7 @@ namespace AlphaTab.Platform.JavaScript
         /// <inheritdoc />
         public void PlayPause()
         {
+            _output.Activate();
             _synth.PostMessage(new
             {
                 cmd = AlphaSynthWebWorker.CmdPlayPause


### PR DESCRIPTION
fixes #290 

Web Audio context instances are nowadays suspended for most browsers. They only can be activated within an event triggered by user interaction. PlayPause was missing this activation. 