### PR TITLE
Fix crash when lyrics startBar is over bars length

### DIFF
--- a/src/model/Track.ts
+++ b/src/model/Track.ts
@@ -93,7 +93,7 @@ export class Track {
         let staff: Staff = this.staves[0];
         for (let li: number = 0; li < lyrics.length; li++) {
             let lyric: Lyrics = lyrics[li];
-            if (lyric.startBar >= 0) {
+            if (lyric.startBar >= 0 && lyric.startBar < staff.bars.length) {
                 let beat: Beat | null = staff.bars[lyric.startBar].voices[0].beats[0];
                 for (let ci: number = 0; ci < lyric.chunks.length && beat; ci++) {
                     // skip rests and empty beats


### PR DESCRIPTION
When reading that file, alphaTab crash because lyrics is at bar 126 but there's only 108 bars. With the fix, lyrics placed after last bar is ignored.

[The Cranberries - Zombie (ver 7 by kartapus).zip](https://github.com/CoderLine/alphaTab/files/5597576/The.Cranberries.-.Zombie.ver.7.by.kartapus.zip)
