### PR TITLE
Improved detection of instrument and tuning in alphaTex

### DIFF
--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -782,8 +782,8 @@ describe('AlphaTexImporterTest', () => {
                 c4 d4 e4 f4 |
                 \\staff{score} \\tuning piano \\clef F4
                 c2 c2 c2 c2 |
-            \\track Guitar"
-                \\staff{tabs} \\capo 5
+            \\track Guitar
+                \\staff{tabs} \\instrument acousticguitarsteel \\capo 5
                 1.2 3.2 0.1 1.1
         `;
         let score: Score = parseTex(tex);
@@ -872,5 +872,23 @@ describe('AlphaTexImporterTest', () => {
                 fail(`Expected UnsupportedFormatError got ${e}`);
             }
         }
+    });
+
+    it('auto-detect-tuning-from-instrument', () => {
+        let score = parseTex('\\instrument acousticguitarsteel . 3.3');
+        expect(score.tracks[0].staves[0].tuning.length).toEqual(6);
+        expect(score.tracks[0].staves[0].displayTranspositionPitch).toEqual(-12);
+
+        score = parseTex('\\instrument acousticbass . 3.3');
+        expect(score.tracks[0].staves[0].tuning.length).toEqual(4);
+        expect(score.tracks[0].staves[0].displayTranspositionPitch).toEqual(-12);
+
+        score = parseTex('\\instrument violin . 3.3');
+        expect(score.tracks[0].staves[0].tuning.length).toEqual(4);
+        expect(score.tracks[0].staves[0].displayTranspositionPitch).toEqual(0);
+
+        score = parseTex('\\instrument acousticpiano . 3.3');
+        expect(score.tracks[0].staves[0].tuning.length).toEqual(0);
+        expect(score.tracks[0].staves[0].displayTranspositionPitch).toEqual(0);
     });
 });


### PR DESCRIPTION
### Issues
Fixes #449

### Proposed changes
Adds an autodetection of the right tuning for a set of instruments. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [x] New tests were added

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website
