### PR TITLE
Add high DPI scaling for HTML5 canvas for better display

### DIFF
--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -89,6 +89,12 @@ export class Environment {
      * The font size of the music font in pixel. 
      */
     public static readonly MusicFontSize = 34;
+
+    /**
+     * The scaling factor to use when rending raster graphics for sharper rendering on high-dpi displays. 
+     */
+    public static HighDpiFactor = 1;
+
     /**
      * @target web
      */
@@ -530,6 +536,8 @@ export class Environment {
               };
 
         if (!Environment.isRunningInWorker) {
+            Environment.HighDpiFactor = window.devicePixelRatio;
+
             let vbAjaxLoader: string = '';
             vbAjaxLoader += 'Function VbAjaxLoader(method, fileName)' + '\r\n';
             vbAjaxLoader += '    Dim xhr' + '\r\n';

--- a/src/platform/javascript/Html5Canvas.ts
+++ b/src/platform/javascript/Html5Canvas.ts
@@ -1,3 +1,4 @@
+import { Environment } from '@src/Environment';
 import { Color } from '@src/model/Color';
 import { Font, FontStyle } from '@src/model/Font';
 import { MusicFontSymbol } from '@src/model/MusicFontSymbol';
@@ -45,12 +46,13 @@ export class Html5Canvas implements ICanvas {
 
     public beginRender(width: number, height: number): void {
         this._canvas = document.createElement('canvas');
-        this._canvas.width = width | 0;
-        this._canvas.height = height | 0;
+        this._canvas.width = (width * Environment.HighDpiFactor) | 0;
+        this._canvas.height = (height  * Environment.HighDpiFactor) | 0;
         this._canvas.style.width = width + 'px';
         this._canvas.style.height = height + 'px';
         this._context = this._canvas.getContext('2d')!;
         this._context.textBaseline = 'hanging';
+        this._context.scale(Environment.HighDpiFactor, Environment.HighDpiFactor);
         this._context.lineWidth = this._lineWidth;
     }
 

--- a/test/visualTests/VisualTestHelper.ts
+++ b/test/visualTests/VisualTestHelper.ts
@@ -72,6 +72,7 @@ export class VisualTestHelper {
 
             settings.core.fontDirectory = CoreSettings.ensureFullUrl('/base/font/bravura/');
             settings.core.engine = 'html5';
+            Environment.HighDpiFactor = 1; // test data is in scale 1
             settings.core.enableLazyLoading = false;
 
             let referenceFileData: Uint8Array;


### PR DESCRIPTION
### Issues
Fixes #496

### Proposed changes
Detect the HighDPI displays and render images in the corresponding scale. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [x] New tests were added (skipped)

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
