### PR TITLE
Fixed map parsing on JSON serializer

### DIFF
--- a/src.compiler/typescript/SerializerEmitter.ts
+++ b/src.compiler/typescript/SerializerEmitter.ts
@@ -801,14 +801,12 @@ function generateSetPropertyBody(program: ts.Program,
                 ts.factory.createExpressionStatement(
                     ts.factory.createCallExpression(
                         ts.factory.createPropertyAccessExpression(
-                            ts.factory.createAsExpression(
-                                ts.factory.createIdentifier('v'),
-                                createStringUnknownMapNode()
-                            ),
+                            ts.factory.createIdentifier('JsonHelper'),
                             'forEach'
                         ),
                         undefined,
                         [
+                            ts.factory.createIdentifier('v'),
                             ts.factory.createArrowFunction(
                                 undefined,
                                 undefined,

--- a/src/generated/NotationSettingsSerializer.ts
+++ b/src/generated/NotationSettingsSerializer.ts
@@ -48,7 +48,7 @@ export class NotationSettingsSerializer {
                 return true;
             case "elements":
                 obj.elements = new Map<NotationElement, boolean>();
-                (v as Map<string, unknown>).forEach((v, k) => {
+                JsonHelper.forEach(v, (v, k) => {
                     obj.elements.set((JsonHelper.parseEnum<NotationElement>(k, NotationElement)!), (v as boolean)); 
                 });
                 return true;

--- a/src/generated/model/MasterBarSerializer.ts
+++ b/src/generated/model/MasterBarSerializer.ts
@@ -81,7 +81,7 @@ export class MasterBarSerializer {
                 return true;
             case "fermata":
                 obj.fermata = new Map<number, Fermata>();
-                (v as Map<string, unknown>).forEach((v, k) => {
+                JsonHelper.forEach(v, (v, k) => {
                     const i = new Fermata(); 
                     FermataSerializer.fromJson(i, (v as Map<string, unknown>)); 
                     obj.fermata.set(parseInt(k), i); 

--- a/src/generated/model/StaffSerializer.ts
+++ b/src/generated/model/StaffSerializer.ts
@@ -50,7 +50,7 @@ export class StaffSerializer {
                 return true;
             case "chords":
                 obj.chords = new Map<string, Chord>();
-                (v as Map<string, unknown>).forEach((v, k) => {
+                JsonHelper.forEach(v, (v, k) => {
                     const i = new Chord(); 
                     ChordSerializer.fromJson(i, (v as Map<string, unknown>)); 
                     obj.addChord(k, i); 


### PR DESCRIPTION
### Issues
Fixes #500

### Proposed changes
Use `JsonHelper.forEach` to iterate object/map objects correctly when parsing JSON. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
