### PR TITLE
Add support for full-bar rests

### DIFF
--- a/src/importer/MusicXmlImporter.ts
+++ b/src/importer/MusicXmlImporter.ts
@@ -614,6 +614,7 @@ export class MusicXmlImporter extends ScoreImporter {
         beat.isEmpty = false;
         beat.addNote(note);
         beat.dots = 0;
+        let isFullBarRest = false;
         for (let c of element.childNodes) {
             if (c.nodeType === XmlNodeType.Element) {
                 switch (c.localName) {
@@ -626,7 +627,7 @@ export class MusicXmlImporter extends ScoreImporter {
                         beat.duration = Duration.ThirtySecond;
                         break;
                     case 'duration':
-                        if (beat.isRest) {
+                        if (beat.isRest && !isFullBarRest) {
                             // unit: divisions per quarter note
                             let duration: number = parseInt(c.innerText);
                             switch (duration) {
@@ -708,8 +709,10 @@ export class MusicXmlImporter extends ScoreImporter {
                         this.parseUnpitched(c, note);
                         break;
                     case 'rest':
+                        isFullBarRest = c.getAttribute('measure') === 'yes';
                         beat.isEmpty = false;
                         beat.notes = [];
+                        beat.duration = Duration.Whole;
                         break;
                 }
             }

--- a/src/model/Beat.ts
+++ b/src/model/Beat.ts
@@ -178,6 +178,13 @@ export class Beat {
     }
 
     /**
+     * Gets a value indicating whether this beat is a full bar rest.
+     */
+    public get isFullBarRest(): boolean {
+        return this.isRest && this.voice.beats.length === 1 && this.duration === Duration.Whole;
+    }
+
+    /**
      * Gets or sets whether any note in this beat has a let-ring applied.
      * @json_ignore
      */
@@ -509,6 +516,9 @@ export class Beat {
     }
 
     private calculateDuration(): number {
+        if(this.isFullBarRest) {
+            return this.voice.bar.masterBar.calculateDuration();
+        }
         let ticks: number = MidiUtils.toTicks(this.duration);
         if (this.dots === 2) {
             ticks = MidiUtils.applyDot(ticks, true);

--- a/test-data/musicxml3/full-bar-rest.musicxml
+++ b/test-data/musicxml3/full-bar-rest.musicxml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Title</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer</creator>
+    <encoding>
+      <software>MuseScore 3.5.0</software>
+      <encoding-date>2021-01-07</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1683.36</page-height>
+      <page-width>1190.88</page-width>
+      <page-margins type="even">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="595.44" default-y="1626.67" justify="center" valign="top" font-size="24">Title</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="1134.19" default-y="1526.67" justify="right" valign="bottom" font-size="12">Composer</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="179.49">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>0.00</left-margin>
+            <right-margin>650.76</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>2</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <rest measure="yes"/>
+        <duration>2</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="123.62">
+      <note>
+        <rest measure="yes"/>
+        <duration>2</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3" width="123.62">
+      <note>
+        <rest measure="yes"/>
+        <duration>2</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/test/importer/MusicXmlImporter.test.ts
+++ b/test/importer/MusicXmlImporter.test.ts
@@ -1,0 +1,39 @@
+import { MusicXmlImporterTestHelper } from '@test/importer/MusicXmlImporterTestHelper';
+import { Score } from '@src/model/Score';
+
+describe('MusicXmlImporterTests', () => {
+    it('track-volume', async () => {
+        let score: Score = await MusicXmlImporterTestHelper.testReferenceFile(
+            'test-data/musicxml3/track-volume-balance.musicxml'
+        );
+
+        expect(score.tracks[0].playbackInfo.volume).toBe(16);
+        expect(score.tracks[1].playbackInfo.volume).toBe(12);
+        expect(score.tracks[2].playbackInfo.volume).toBe(8);
+        expect(score.tracks[3].playbackInfo.volume).toBe(4);
+        expect(score.tracks[4].playbackInfo.volume).toBe(0);
+    });
+
+    it('track-balance', async () => {
+        let score: Score = await MusicXmlImporterTestHelper.testReferenceFile(
+            'test-data/musicxml3/track-volume-balance.musicxml'
+        );
+
+        expect(score.tracks[0].playbackInfo.balance).toBe(0);
+        expect(score.tracks[1].playbackInfo.balance).toBe(4);
+        expect(score.tracks[2].playbackInfo.balance).toBe(8);
+        expect(score.tracks[3].playbackInfo.balance).toBe(12);
+        expect(score.tracks[4].playbackInfo.balance).toBe(16);
+    });
+
+    
+    it('full-bar-rest', async () => {
+        let score: Score = await MusicXmlImporterTestHelper.testReferenceFile(
+            'test-data/musicxml3/full-bar-rest.musicxml'
+        );
+
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].isFullBarRest).toBeTrue();
+        expect(score.tracks[0].staves[0].bars[1].voices[0].beats[0].isFullBarRest).toBeTrue();
+        expect(score.tracks[0].staves[0].bars[2].voices[0].beats[0].isFullBarRest).toBeTrue();
+    });
+});

--- a/test/importer/MusicXmlImporterTestSuite.test.ts
+++ b/test/importer/MusicXmlImporterTestSuite.test.ts
@@ -1,5 +1,4 @@
 import { MusicXmlImporterTestHelper } from '@test/importer/MusicXmlImporterTestHelper';
-import { Score } from '@src/model/Score';
 
 describe('MusicXmlImporterTestSuiteTests', () => {
     it('01a_Pitches_Pitches', async () => {
@@ -606,29 +605,5 @@ describe('MusicXmlImporterTestSuiteTests', () => {
         await MusicXmlImporterTestHelper.testReferenceFile(
             'test-data/musicxml-testsuite/99b-Lyrics-BeamsMelismata-IgnoreBeams.xml'
         );
-    });
-
-    it('Track_Volume', async () => {
-        let score: Score = await MusicXmlImporterTestHelper.testReferenceFile(
-            'test-data/musicxml3/track-volume-balance.musicxml'
-        );
-
-        expect(score.tracks[0].playbackInfo.volume).toBe(16);
-        expect(score.tracks[1].playbackInfo.volume).toBe(12);
-        expect(score.tracks[2].playbackInfo.volume).toBe(8);
-        expect(score.tracks[3].playbackInfo.volume).toBe(4);
-        expect(score.tracks[4].playbackInfo.volume).toBe(0);
-    });
-
-    it('Track_Balance', async () => {
-        let score: Score = await MusicXmlImporterTestHelper.testReferenceFile(
-            'test-data/musicxml3/track-volume-balance.musicxml'
-        );
-
-        expect(score.tracks[0].playbackInfo.balance).toBe(0);
-        expect(score.tracks[1].playbackInfo.balance).toBe(4);
-        expect(score.tracks[2].playbackInfo.balance).toBe(8);
-        expect(score.tracks[3].playbackInfo.balance).toBe(12);
-        expect(score.tracks[4].playbackInfo.balance).toBe(16);
     });
 });


### PR DESCRIPTION
### Issues
Fixes #495

### Proposed changes
Adds full-bar-rest handling to the data model, file importers and midi generator.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [x] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
