### PR TITLE
Add IntersectionObserver for initial load and lazy loading

### DIFF
--- a/src/CoreSettings.ts
+++ b/src/CoreSettings.ts
@@ -37,13 +37,6 @@ export class CoreSettings {
     public tracks: unknown = null;
 
     /**
-     * Gets or sets the interval in which alphaTab should check whether the 
-     * target element for rendering is already visible. 
-     * @target web
-     */
-    public visibilityCheckInterval: number = 500;
-
-    /**
      * Gets or sets whether lazy loading for displayed elements is enabled.
      */
     public enableLazyLoading: boolean = true;

--- a/src/generated/CoreSettingsSerializer.ts
+++ b/src/generated/CoreSettingsSerializer.ts
@@ -28,8 +28,6 @@ export class CoreSettingsSerializer {
         o.set("tex", obj.tex); 
         /*@target web*/
         o.set("tracks", obj.tracks); 
-        /*@target web*/
-        o.set("visibilityCheckInterval", obj.visibilityCheckInterval); 
         o.set("enableLazyLoading", obj.enableLazyLoading); 
         o.set("engine", obj.engine); 
         o.set("logLevel", (obj.logLevel as number)); 
@@ -58,10 +56,6 @@ export class CoreSettingsSerializer {
             /*@target web*/
             case "tracks":
                 obj.tracks = (v as unknown);
-                return true;
-            /*@target web*/
-            case "visibilitycheckinterval":
-                obj.visibilityCheckInterval = (v as number);
                 return true;
             case "enablelazyloading":
                 obj.enableLazyLoading = (v as boolean);

--- a/test/model/JsonConverter.test.ts
+++ b/test/model/JsonConverter.test.ts
@@ -94,8 +94,6 @@ describe('JsonConverterTest', () => {
         expected.core.tex = true;
         /**@target web*/
         expected.core.tracks = [1, 2, 3];
-        /**@target web*/
-        expected.core.visibilityCheckInterval = 4711;
 
         expected.core.enableLazyLoading = false;
         expected.core.engine = "engine";


### PR DESCRIPTION
### Issues
Fixes #510

### Proposed changes
1. Replaces the old timer based visibility checker with the IntersectionObserver 
2. Replaces the `getBoundingClientRect` based lazy loading system with the IntersectionObserver 


### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
