### PR TITLE
Added usage of resize observer if available.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -152,6 +152,12 @@
       "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==",
       "dev": true
     },
+    "@types/resize-observer-browser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.5.tgz",
+      "integrity": "sha512-8k/67Z95Goa6Lznuykxkfhq9YU3l1Qe6LNZmwde1u7802a3x8v44oq0j91DICclxatTr0rNnhXx7+VTIetSrSQ==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
     "@types/jasmine": "^3.6.2",
+    "@types/resize-observer-browser": "^0.1.5",
     "concurrently": "^5.3.0",
     "cors": "^2.8.5",
     "fs-extra": "^9.0.1",

--- a/src.csharp/AlphaTab.Windows/WinForms/ControlContainer.cs
+++ b/src.csharp/AlphaTab.Windows/WinForms/ControlContainer.cs
@@ -12,17 +12,6 @@ namespace AlphaTab.WinForms
         {
             Control = control;
 
-            Scroll = new DelegatedEventEmitter(
-                value =>
-                {
-                    if (Control is ScrollableControl scroll)
-                    {
-                        scroll.Scroll += (sender, args) => value();
-                    }
-                },
-                value => { }
-            );
-
             Resize = new DelegatedEventEmitter(
                 value => { Control.Resize += (sender, args) => value(); },
                 value => { }
@@ -127,7 +116,6 @@ namespace AlphaTab.WinForms
             Control.Controls.Clear();
         }
 
-        public IEventEmitter Scroll { get; set; }
         public IEventEmitter Resize { get; set; }
         public IEventEmitterOfT<IMouseEventArgs> MouseDown { get; set; }
         public IEventEmitterOfT<IMouseEventArgs> MouseMove { get; set; }

--- a/src.csharp/AlphaTab.Windows/Wpf/FrameworkElementContainer.cs
+++ b/src.csharp/AlphaTab.Windows/Wpf/FrameworkElementContainer.cs
@@ -14,17 +14,6 @@ namespace AlphaTab.Wpf
         {
             Control = control;
 
-            Scroll = new DelegatedEventEmitter(
-                value =>
-                {
-                    if (Control is ScrollViewer scroll)
-                    {
-                        scroll.ScrollChanged += (sender, args) => value();
-                    }
-                },
-                value => { }
-            );
-
             Resize = new DelegatedEventEmitter(
                 value => { Control.SizeChanged += (sender, args) => value(); },
                 value => { }
@@ -153,7 +142,6 @@ namespace AlphaTab.Wpf
             }
         }
 
-        public IEventEmitter Scroll { get; set; }
         public IEventEmitter Resize { get; set; }
         public IEventEmitterOfT<IMouseEventArgs> MouseDown { get; set; }
         public IEventEmitterOfT<IMouseEventArgs> MouseMove { get; set; }

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -53,6 +53,7 @@ import { FontLoadingChecker } from '@src/util/FontLoadingChecker';
 import { Logger } from '@src/Logger';
 import { LeftHandTapEffectInfo } from './rendering/effects/LeftHandTapEffectInfo';
 import { CapellaImporter } from './importer/CapellaImporter';
+import { ResizeObserverPolyfill } from './platform/javascript/ResizeObserverPolyfill';
 
 export class LayoutEngineFactory {
     public readonly vertical: boolean;
@@ -450,6 +451,11 @@ export class Environment {
         Environment.registerJQueryPlugin();
         if (!Environment.isRunningInWorker) {
             Environment.HighDpiFactor = window.devicePixelRatio;
+            // ResizeObserver API does not yet exist so long on Safari (only start 2020 with iOS Safari 13.7 and Desktop 13.1)
+            // so we better add a polyfill for it 
+            if(!('ResizeObserver' in globalThis)) {
+                (globalThis as any).ResizeObserver = ResizeObserverPolyfill;
+            }
         } else {
             AlphaTabWebWorker.init();
             AlphaSynthWebWorker.init();

--- a/src/platform/IContainer.ts
+++ b/src/platform/IContainer.ts
@@ -64,11 +64,6 @@ export interface IContainer {
     clear(): void;
 
     /**
-     * This event occurs when a scroll on the control happened.
-     */
-    scroll: IEventEmitter;
-
-    /**
      * This event occurs when the control was resized.
      */
     resize: IEventEmitter;

--- a/src/platform/javascript/ResizeObserverPolyfill.ts
+++ b/src/platform/javascript/ResizeObserverPolyfill.ts
@@ -1,0 +1,41 @@
+/**
+ * A very basic polyfill of the ResizeObserver which triggers 
+ * a the callback on window resize for all registered targets.
+ * @target web
+ */
+export class ResizeObserverPolyfill {
+    private _callback: ResizeObserverCallback;
+    private _targets = new Set<Element>();
+
+    public constructor(callback: ResizeObserverCallback) {
+        this._callback = callback;
+        window.addEventListener('resize', this.onWindowResize.bind(this), false);
+    }
+
+    public observe(target: Element) {
+        this._targets.add(target);
+    }
+
+    public unobserve(target: Element) {
+        this._targets.delete(target);
+    }
+
+    public disconnect() {
+        this._targets.clear();
+    }
+
+
+    private onWindowResize() {
+        const entries: ResizeObserverEntry[] = [];
+        for (const t of this._targets) {
+            entries.push({
+                target: t,
+                // not used by alphaTab
+                contentRect: undefined!,
+                borderBoxSize: undefined!,
+                contentBoxSize: []
+            });
+        }
+        this._callback(entries, this);
+    }
+}


### PR DESCRIPTION
### Issues
Fixes #511

### Proposed changes
Uses the Resize Observer if available instead of the window resize event. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
