### PR TITLE
Add Basic Color Test for RGB

### DIFF
--- a/src/model/Color.ts
+++ b/src/model/Color.ts
@@ -119,7 +119,8 @@ export class Color {
                             throw new FormatError('No values specified for rgb/rgba function');
                         }
 
-                        const numbers = json.substring(start + 1, end - start - 1).split(',');
+                        const numbers = json.substring(start + 1, end).split(',');
+
                         if (numbers.length === 3) {
                             return new Color(parseInt(numbers[0]), parseInt(numbers[1]), parseInt(numbers[2]));
                         }

--- a/test/model/Color.test.ts
+++ b/test/model/Color.test.ts
@@ -1,7 +1,7 @@
 import { Color } from "@src/model/Color";
 
 describe('ColorTests', () => {
-  it('fromJson rgb', () => {
+  it('fromJson-rgb', () => {
     const color = Color.fromJson('rgb(0,0,0)');
 
     expect(color!.rgba).toEqual('#000000');

--- a/test/model/Color.test.ts
+++ b/test/model/Color.test.ts
@@ -1,0 +1,9 @@
+import { Color } from "@src/model/Color";
+
+describe('ColorTests', () => {
+  it('fromJson rgb', () => {
+    const color = Color.fromJson('rgb(0,0,0)');
+
+    expect(color!.rgba).toEqual('#000000');
+  });
+});


### PR DESCRIPTION
### Issues
Fixes #387 

### Proposed changes

Updates the `substring` logic in `Color.ts` to properly grab the RGB values. Without this change `numbers` ends up being an array w/ a single item in it with eventually causes the method to return `null`.

<img width="638" alt="Screen Shot 2021-02-11 at 8 05 22 AM" src="https://user-images.githubusercontent.com/192464/107640204-eecbb880-6c3f-11eb-8bf4-68530cd6bbb8.png">

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [x] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
