### PR TITLE
Enable sourcemaps for alphaTab.js & alphaTab.min.js

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,12 +22,14 @@ module.exports = [
         output: [
             {
                 file: 'dist/alphaTab.js',
-                name: 'alphaTab'
+                name: 'alphaTab',
+                sourcemap: true
             },
             {
                 file: 'dist/alphaTab.min.js',
                 name: 'alphaTab',
-                plugins: [terser()]
+                plugins: [terser()],
+                sourcemap: true,
             }
         ].map(o => ({ ...o, ...commonOutput })),
         external: [],


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Implements #582

### Proposed changes
Enable sourcemaps for alphaTab.js & alphaTab.min.js
### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
