### PR TITLE
Fix hanging alphaTex import on backslash

### DIFF
--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -1846,7 +1846,11 @@ export class AlphaTexImporter extends ScoreImporter {
                 master.isAnacrusis = true;
                 this._sy = this.newSy();
             } else {
-                if (bar.index === 0 && !this.handleStaffMeta()) {
+                if (bar.index === 0) {
+                    if(!this.handleStaffMeta()) {
+                        this.error('measure-effects', AlphaTexSymbols.String, false);
+                    }
+                } else {
                     this.error('measure-effects', AlphaTexSymbols.String, false);
                 }
             }

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -903,4 +903,13 @@ describe('AlphaTexImporterTest', () => {
         expect(score.tracks[0].name).toEqual("🎸");
         expect(score.tracks[0].staves[0].bars[0].voices[0].beats[2].lyrics![0]).toEqual("🤘");
     });
+    
+    it('does-not-hang-on-backslash', () => {
+        try {
+            parseTex('\\title Test . 3.3 \\')
+            fail('Parsing should fail');
+        } catch (e) {
+            // success
+        }
+    })
 });


### PR DESCRIPTION
### Issues
Fixes #581

### Proposed changes
Treat empty bar metadata as error. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [x] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
