### PR TITLE
Fully destroy alphaTab player

### DIFF
--- a/src.csharp/AlphaTab.Windows/NAudioSynthOutput.cs
+++ b/src.csharp/AlphaTab.Windows/NAudioSynthOutput.cs
@@ -48,6 +48,12 @@ namespace AlphaTab
 
             ((EventEmitter) Ready).Trigger();
         }
+		
+        /// <inheritdoc />
+		public void Destroy()
+		{
+			Dispose();
+		}
 
         /// <inheritdoc />
         public void Dispose()

--- a/src.csharp/AlphaTab.Windows/NAudioSynthOutput.cs
+++ b/src.csharp/AlphaTab.Windows/NAudioSynthOutput.cs
@@ -48,12 +48,12 @@ namespace AlphaTab
 
             ((EventEmitter) Ready).Trigger();
         }
-		
+
         /// <inheritdoc />
-		public void Destroy()
-		{
-			Dispose();
-		}
+        public void Destroy()
+        {
+            Dispose();
+        }
 
         /// <inheritdoc />
         public void Dispose()

--- a/src/platform/javascript/AlphaSynthWebAudioOutput.ts
+++ b/src/platform/javascript/AlphaSynthWebAudioOutput.ts
@@ -119,6 +119,11 @@ export class AlphaSynthWebAudioOutput implements ISynthOutput {
         this._audioNode = null;
     }
 
+    public destroy(): void {
+        this.pause();
+        this._context?.close();        
+    }
+
     public addSamples(f: Float32Array): void {
         this._circularBuffer.write(f, 0, f.length);
     }

--- a/src/platform/javascript/AlphaSynthWebWorker.ts
+++ b/src/platform/javascript/AlphaSynthWebWorker.ts
@@ -124,6 +124,9 @@ export class AlphaSynthWebWorker {
                 break;
             case 'alphaSynth.destroy':
                 this._player.destroy();
+                this._main.postMessage({
+                    cmd: 'alphaSynth.destroyed'
+                });
                 break;
         }
     }

--- a/src/platform/javascript/AlphaSynthWebWorker.ts
+++ b/src/platform/javascript/AlphaSynthWebWorker.ts
@@ -122,6 +122,9 @@ export class AlphaSynthWebWorker {
             case 'alphaSynth.resetChannelStates':
                 this._player.resetChannelStates();
                 break;
+            case 'alphaSynth.destroy':
+                this._player.destroy();
+                break;
         }
     }
 

--- a/src/platform/javascript/AlphaSynthWebWorkerApi.ts
+++ b/src/platform/javascript/AlphaSynthWebWorkerApi.ts
@@ -228,7 +228,9 @@ export class AlphaSynthWebWorkerApi implements IAlphaSynth {
     }
 
     public destroy(): void {
-        this._synth.terminate();
+        this._synth.postMessage({
+            cmd: 'alphaSynth.destroy'
+        });
     }
 
     //
@@ -349,6 +351,9 @@ export class AlphaSynthWebWorkerApi implements IAlphaSynth {
                 this._workerIsReady = true;
                 this.checkReady();
                 break;
+            case 'alphaSynth.destroyed':
+                this._synth.terminate();
+                break;
             case 'alphaSynth.readyForPlayback':
                 this._workerIsReadyForPlayback = true;
                 this.checkReadyForPlayback();
@@ -398,6 +403,9 @@ export class AlphaSynthWebWorkerApi implements IAlphaSynth {
                 break;
             case 'alphaSynth.output.pause':
                 this._output.pause();
+                break;
+            case 'alphaSynth.output.destroy':
+                this._output.destroy();
                 break;
             case 'alphaSynth.output.resetSamples':
                 this._output.resetSamples();

--- a/src/platform/javascript/AlphaSynthWorkerSynthOutput.ts
+++ b/src/platform/javascript/AlphaSynthWorkerSynthOutput.ts
@@ -35,6 +35,12 @@ export class AlphaSynthWorkerSynthOutput implements ISynthOutput {
         (this.ready as EventEmitter).trigger();
     }
 
+    public destroy(): void {
+        this._worker.postMessage({
+            cmd: 'alphaSynth.output.destroy'
+        });
+    }
+
     private handleMessage(e: MessageEvent): void {
         let data: any = e.data;
         let cmd: any = data.cmd;

--- a/src/synth/AlphaSynth.ts
+++ b/src/synth/AlphaSynth.ts
@@ -149,7 +149,7 @@ export class AlphaSynth implements IAlphaSynth {
 
     public destroy(): void {
         Logger.debug('AlphaSynth', 'Destroying player');
-        this.stop(true);
+        this.internalStop(true);
         this.output.destroy();
     }
 
@@ -261,7 +261,11 @@ export class AlphaSynth implements IAlphaSynth {
         }
     }
 
-    public stop(destroying: boolean = false): void {
+    public stop(): void {
+        this.internalStop(false);
+    }
+
+    public internalStop(destroying: boolean = false): void {
         if (!this._isMidiLoaded) {
             return;
         }

--- a/src/synth/AlphaSynth.ts
+++ b/src/synth/AlphaSynth.ts
@@ -149,7 +149,8 @@ export class AlphaSynth implements IAlphaSynth {
 
     public destroy(): void {
         Logger.debug('AlphaSynth', 'Destroying player');
-        this.stop();
+        this.stop(true);
+        this.output.destroy();
     }
 
     /**
@@ -260,7 +261,7 @@ export class AlphaSynth implements IAlphaSynth {
         }
     }
 
-    public stop(): void {
+    public stop(destroying: boolean = false): void {
         if (!this._isMidiLoaded) {
             return;
         }
@@ -270,9 +271,11 @@ export class AlphaSynth implements IAlphaSynth {
         this._sequencer.stop();
         this._synthesizer.noteOffAll(true);
         this.tickPosition = this._sequencer.playbackRange ? this._sequencer.playbackRange.startTick : 0;
-        (this.stateChanged as EventEmitterOfT<PlayerStateChangedEventArgs>).trigger(
-            new PlayerStateChangedEventArgs(this.state, true)
-        );
+        if (!destroying) {
+            (this.stateChanged as EventEmitterOfT<PlayerStateChangedEventArgs>).trigger(
+                new PlayerStateChangedEventArgs(this.state, true)
+            );
+        }
     }
 
     public playOneTimeMidiFile(midi: MidiFile): void {

--- a/src/synth/AlphaSynth.ts
+++ b/src/synth/AlphaSynth.ts
@@ -149,7 +149,7 @@ export class AlphaSynth implements IAlphaSynth {
 
     public destroy(): void {
         Logger.debug('AlphaSynth', 'Destroying player');
-        this.internalStop(true);
+        this.stop();
         this.output.destroy();
     }
 
@@ -262,10 +262,6 @@ export class AlphaSynth implements IAlphaSynth {
     }
 
     public stop(): void {
-        this.internalStop(false);
-    }
-
-    public internalStop(destroying: boolean = false): void {
         if (!this._isMidiLoaded) {
             return;
         }
@@ -275,11 +271,9 @@ export class AlphaSynth implements IAlphaSynth {
         this._sequencer.stop();
         this._synthesizer.noteOffAll(true);
         this.tickPosition = this._sequencer.playbackRange ? this._sequencer.playbackRange.startTick : 0;
-        if (!destroying) {
-            (this.stateChanged as EventEmitterOfT<PlayerStateChangedEventArgs>).trigger(
-                new PlayerStateChangedEventArgs(this.state, true)
-            );
-        }
+        (this.stateChanged as EventEmitterOfT<PlayerStateChangedEventArgs>).trigger(
+            new PlayerStateChangedEventArgs(this.state, true)
+        );
     }
 
     public playOneTimeMidiFile(midi: MidiFile): void {

--- a/src/synth/ISynthOutput.ts
+++ b/src/synth/ISynthOutput.ts
@@ -22,6 +22,11 @@ export interface ISynthOutput {
     play(): void;
 
     /**
+     * Requests the output to destroy itself.
+     */
+    destroy(): void;
+
+    /**
      * Called when the output should stop the playback.
      */
     pause(): void;

--- a/test/audio/TestOutput.ts
+++ b/test/audio/TestOutput.ts
@@ -17,6 +17,10 @@ export class TestOutput implements ISynthOutput {
         // nothing to do
     }
 
+    public destroy(): void {
+        // nothing to do
+    }
+
     public next(): void {
         (this.sampleRequest as EventEmitter).trigger();
     }


### PR DESCRIPTION
### Issues
Fixes #594

### Proposed changes
Extends the destroy sequence to first shutdown the synth output. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
