### PR TITLE
Use HTML5 AudioWorklet beside ScriptProcessor for passing audio.

### DIFF
--- a/src.csharp/AlphaTab.Windows/NAudioSynthOutput.cs
+++ b/src.csharp/AlphaTab.Windows/NAudioSynthOutput.cs
@@ -107,7 +107,7 @@ namespace AlphaTab
         {
             // if we fall under the half of buffers
             // we request one half
-            const int halfBufferCount = _bufferCount / 2;
+            var halfBufferCount = _bufferCount / 2;
             var halfSamples = halfBufferCount * BufferSize;
             // Issue #631: it can happen that requestBuffers is called multiple times
             // before we already get samples via addSamples, therefore we need to

--- a/src.csharp/AlphaTab.Windows/NAudioSynthOutput.cs
+++ b/src.csharp/AlphaTab.Windows/NAudioSynthOutput.cs
@@ -13,11 +13,13 @@ namespace AlphaTab
     public class NAudioSynthOutput : WaveProvider32, ISynthOutput, IDisposable
     {
         private const int BufferSize = 4096;
-        private const int BufferCount = 10;
         private const int PreferredSampleRate = 44100;
-
+        private const int TotalBufferTimeInMilliseconds = 5000;
+        
         private DirectSoundOut _context;
         private CircularSampleBuffer _circularBuffer;
+        private int _bufferCount = 0;
+        private int _requestedBufferCount = 0;
 
         /// <inheritdoc />
         public double SampleRate => PreferredSampleRate;
@@ -41,8 +43,12 @@ namespace AlphaTab
         /// <inheritdoc />
         public void Open()
         {
-            _circularBuffer = new CircularSampleBuffer(BufferSize * BufferCount);
-
+            _bufferCount = (int)(
+                (TotalBufferTimeInMilliseconds * PreferredSampleRate) /
+                1000 /
+                BufferSize
+            );
+            _circularBuffer = new CircularSampleBuffer(BufferSize * _bufferCount);
             _context = new DirectSoundOut(100);
             _context.Init(this);
 
@@ -88,6 +94,7 @@ namespace AlphaTab
         public void AddSamples(Float32Array f)
         {
             _circularBuffer.Write(f, 0, f.Length);
+            _requestedBufferCount--;
         }
 
         /// <inheritdoc />
@@ -100,12 +107,19 @@ namespace AlphaTab
         {
             // if we fall under the half of buffers
             // we request one half
-            const int count = BufferCount / 2 * BufferSize;
-            if (_circularBuffer.Count < count && SampleRequest != null)
+            const int halfBufferCount = _bufferCount / 2;
+            var halfSamples = halfBufferCount * BufferSize;
+            // Issue #631: it can happen that requestBuffers is called multiple times
+            // before we already get samples via addSamples, therefore we need to
+            // remember how many buffers have been requested, and consider them as available.
+            var bufferedSamples = _circularBuffer.Count + _requestedBufferCount * BufferSize;
+ 
+            if (bufferedSamples < halfSamples)
             {
-                for (var i = 0; i < BufferCount / 2; i++)
+                for (var i = 0; i < halfBufferCount; i++)
                 {
                     ((EventEmitter) SampleRequest).Trigger();
+                    _requestedBufferCount++;
                 }
             }
         }

--- a/src/AlphaTabApiBase.ts
+++ b/src/AlphaTabApiBase.ts
@@ -892,59 +892,77 @@ export class AlphaTabApiBase<TSettings> {
                     // Logger.Info("Player",
                     //    "Transition from " + beatBoundings.VisualBounds.X + " to " + nextBeatX + " in " + duration +
                     //    "(" + Player.PlaybackRange + ")");
-                    beatCursor!.transitionToX(duration, nextBeatX);
+
+                    // we need to put the transition to an own animation frame
+                    // otherwise the stop animation above is not applied. 
+                    this.uiFacade.beginInvoke(() => { 
+                        beatCursor!.transitionToX(duration, nextBeatX);
+                    });
                 }
             }
             if (!this._beatMouseDown && this.settings.player.scrollMode !== ScrollMode.Off) {
                 let scrollElement: IContainer = this.uiFacade.getScrollContainer();
                 let isVertical: boolean = Environment.getLayoutEngineFactory(this.settings).vertical;
                 let mode: ScrollMode = this.settings.player.scrollMode;
-                let elementOffset: Bounds = this.uiFacade.getOffset(scrollElement, this.container);
                 if (isVertical) {
-                    switch (mode) {
-                        case ScrollMode.Continuous:
-                            let y: number =
-                                elementOffset.y + barBoundings.realBounds.y + this.settings.player.scrollOffsetY;
-                            if (y !== this._lastScroll) {
-                                this._lastScroll = y;
-                                this.uiFacade.scrollToY(scrollElement, y, this.settings.player.scrollSpeed);
-                            }
-                            break;
-                        case ScrollMode.OffScreen:
-                            let elementBottom: number =
-                                scrollElement.scrollTop + this.uiFacade.getOffset(null, scrollElement).h;
-                            if (
-                                barBoundings.visualBounds.y + barBoundings.visualBounds.h >= elementBottom ||
-                                barBoundings.visualBounds.y < scrollElement.scrollTop
-                            ) {
-                                let scrollTop: number = barBoundings.realBounds.y + this.settings.player.scrollOffsetY;
-                                this._lastScroll = barBoundings.visualBounds.x;
-                                this.uiFacade.scrollToY(scrollElement, scrollTop, this.settings.player.scrollSpeed);
-                            }
-                            break;
+                    // when scrolling on the y-axis, we preliminary check if the new beat/bar have
+                    // moved on the y-axis
+                    let y: number = barBoundings.realBounds.y + this.settings.player.scrollOffsetY;
+                    if (y !== this._lastScroll) {
+                        this._lastScroll = y;
+                        switch (mode) {
+                            case ScrollMode.Continuous:
+                                let elementOffset: Bounds = this.uiFacade.getOffset(scrollElement, this.container);
+                                this.uiFacade.scrollToY(
+                                    scrollElement,
+                                    elementOffset.y + y,
+                                    this.settings.player.scrollSpeed
+                                );
+                                break;
+                            case ScrollMode.OffScreen:
+                                let elementBottom: number =
+                                    scrollElement.scrollTop + this.uiFacade.getOffset(null, scrollElement).h;
+                                if (
+                                    barBoundings.visualBounds.y + barBoundings.visualBounds.h >= elementBottom ||
+                                    barBoundings.visualBounds.y < scrollElement.scrollTop
+                                ) {
+                                    let scrollTop: number =
+                                        barBoundings.realBounds.y + this.settings.player.scrollOffsetY;
+                                    this.uiFacade.scrollToY(scrollElement, scrollTop, this.settings.player.scrollSpeed);
+                                }
+                                break;
+                        }
                     }
                 } else {
-                    switch (mode) {
-                        case ScrollMode.Continuous:
-                            let x: number = barBoundings.visualBounds.x;
-                            if (x !== this._lastScroll) {
+                    // when scrolling on the x-axis, we preliminary check if the new bar has
+                    // moved on the x-axis
+                    let x: number = barBoundings.visualBounds.x;
+                    if (x !== this._lastScroll) {
+                        this._lastScroll = x;
+                        switch (mode) {
+                            case ScrollMode.Continuous:
                                 let scrollLeft: number = barBoundings.realBounds.x + this.settings.player.scrollOffsetX;
                                 this._lastScroll = barBoundings.visualBounds.x;
                                 this.uiFacade.scrollToX(scrollElement, scrollLeft, this.settings.player.scrollSpeed);
-                            }
-                            break;
-                        case ScrollMode.OffScreen:
-                            let elementRight: number =
-                                scrollElement.scrollLeft + this.uiFacade.getOffset(null, scrollElement).w;
-                            if (
-                                barBoundings.visualBounds.x + barBoundings.visualBounds.w >= elementRight ||
-                                barBoundings.visualBounds.x < scrollElement.scrollLeft
-                            ) {
-                                let scrollLeft: number = barBoundings.realBounds.x + this.settings.player.scrollOffsetX;
-                                this._lastScroll = barBoundings.visualBounds.x;
-                                this.uiFacade.scrollToX(scrollElement, scrollLeft, this.settings.player.scrollSpeed);
-                            }
-                            break;
+                                break;
+                            case ScrollMode.OffScreen:
+                                let elementRight: number =
+                                    scrollElement.scrollLeft + this.uiFacade.getOffset(null, scrollElement).w;
+                                if (
+                                    barBoundings.visualBounds.x + barBoundings.visualBounds.w >= elementRight ||
+                                    barBoundings.visualBounds.x < scrollElement.scrollLeft
+                                ) {
+                                    let scrollLeft: number =
+                                        barBoundings.realBounds.x + this.settings.player.scrollOffsetX;
+                                    this._lastScroll = barBoundings.visualBounds.x;
+                                    this.uiFacade.scrollToX(
+                                        scrollElement,
+                                        scrollLeft,
+                                        this.settings.player.scrollSpeed
+                                    );
+                                }
+                                break;
+                        }
                     }
                 }
             }

--- a/src/AlphaTabApiBase.ts
+++ b/src/AlphaTabApiBase.ts
@@ -766,9 +766,7 @@ export class AlphaTabApiBase<TSettings> {
         if (this.player) {
             this.player.positionChanged.on(e => {
                 this._previousTick = e.currentTick;
-                this.uiFacade.beginInvoke(() => {
-                    this.cursorUpdateTick(e.currentTick, false);
-                });
+                this.cursorUpdateTick(e.currentTick, false);
             });
             this.player.stateChanged.on(e => {
                 this._playerState = e.state;
@@ -891,12 +889,10 @@ export class AlphaTabApiBase<TSettings> {
                 }
 
                 if (beatCursor) {
-                    this.uiFacade.beginInvoke(() => {
-                        // Logger.Info("Player",
-                        //    "Transition from " + beatBoundings.VisualBounds.X + " to " + nextBeatX + " in " + duration +
-                        //    "(" + Player.PlaybackRange + ")");
-                        beatCursor!.transitionToX(duration, nextBeatX);
-                    });
+                    // Logger.Info("Player",
+                    //    "Transition from " + beatBoundings.VisualBounds.X + " to " + nextBeatX + " in " + duration +
+                    //    "(" + Player.PlaybackRange + ")");
+                    beatCursor!.transitionToX(duration, nextBeatX);
                 }
             }
             if (!this._beatMouseDown && this.settings.player.scrollMode !== ScrollMode.Off) {

--- a/src/AlphaTabApiBase.ts
+++ b/src/AlphaTabApiBase.ts
@@ -792,6 +792,9 @@ export class AlphaTabApiBase<TSettings> {
         if (cache) {
             let tracks: Track[] = this.tracks;
             if (tracks.length > 0) {
+                // TODO: perf - searching the new beat every time from scratch is not needed
+                // from the previous result we should know which the next beat is
+                // unless we're looping we can take the known next beat as a hint 
                 let beat: MidiTickLookupFindBeatResult | null = cache.findBeat(tracks, tick);
                 if (beat) {
                     this.cursorUpdateBeat(beat.currentBeat, beat.nextBeat, beat.duration, stop, beat.beatsToHighlight);
@@ -831,9 +834,7 @@ export class AlphaTabApiBase<TSettings> {
             return;
         }
 
-        this.uiFacade.beginInvoke(() => {
-            this.internalCursorUpdateBeat(beat, nextBeat, duration, stop, beatsToHighlight, cache!, beatBoundings!);
-        });
+        this.internalCursorUpdateBeat(beat, nextBeat, duration, stop, beatsToHighlight, cache!, beatBoundings!);
     }
 
     private internalCursorUpdateBeat(

--- a/src/CoreSettings.ts
+++ b/src/CoreSettings.ts
@@ -67,6 +67,23 @@ export class CoreSettings {
     public includeNoteBounds: boolean = false;
 
     /**
+     * Gets or sets whether jQuery events are triggered beside
+     * the other event systems. This can gain a performance boost
+     * because these events can be costly on slow devices. 
+     * @target web
+     */
+    public enableJqueryEvents:boolean = true;
+
+     
+    /**
+     * Gets or sets whether native browser events are triggered beside
+     * the other event systems. This can gain a performance boost
+     * because these events can be costly on slow devices. 
+     * @target web
+     */
+    public enableBrowserEvents:boolean = true;
+
+    /**
      * @target web
      */
     public constructor() {

--- a/src/PlayerSettings.ts
+++ b/src/PlayerSettings.ts
@@ -137,9 +137,15 @@ export class PlayerSettings {
     public scrollMode: ScrollMode = ScrollMode.Continuous;
 
     /**
-     * Gets or sets how fast the scrolling to the new position should happen (in milliseconds)
+     * Gets or sets how fast the scrolling to the new position should happen (in milliseconds).
      */
     public scrollSpeed: number = 300;
+
+    /**
+     * Gets or sets whether the native browser smooth scroll mechanism should be used over a custom animation.
+     * @target web
+     */
+    public nativeBrowserSmoothScroll: boolean = true;
 
     /**
      * Gets or sets the bend duration in milliseconds for songbook bends.

--- a/src/PlayerSettings.ts
+++ b/src/PlayerSettings.ts
@@ -115,6 +115,12 @@ export class PlayerSettings {
      */
     public enableCursor: boolean = true;
 
+
+    /**
+     * Gets or sets whether the beat cursor should be animated or just ticking. 
+     */
+    public enableAnimatedBeatCursor: boolean = true;
+
     /**
      * Gets or sets alphaTab should provide user interaction features to
      * select playback ranges and jump to the playback position by click (aka. seeking).

--- a/src/PlayerSettings.ts
+++ b/src/PlayerSettings.ts
@@ -122,6 +122,12 @@ export class PlayerSettings {
     public enableAnimatedBeatCursor: boolean = true;
 
     /**
+     * Gets or sets whether the notation elements of the currently played beat should be
+     * highlighted 
+     */
+    public enableElementHighlighting: boolean = true;
+
+    /**
      * Gets or sets alphaTab should provide user interaction features to
      * select playback ranges and jump to the playback position by click (aka. seeking).
      */

--- a/src/generated/CoreSettingsSerializer.ts
+++ b/src/generated/CoreSettingsSerializer.ts
@@ -33,6 +33,10 @@ export class CoreSettingsSerializer {
         o.set("logLevel", obj.logLevel as number); 
         o.set("useWorkers", obj.useWorkers); 
         o.set("includeNoteBounds", obj.includeNoteBounds); 
+        /*@target web*/
+        o.set("enableJqueryEvents", obj.enableJqueryEvents); 
+        /*@target web*/
+        o.set("enableBrowserEvents", obj.enableBrowserEvents); 
         return o; 
     }
     public static setProperty(obj: CoreSettings, property: string, v: unknown): boolean {
@@ -71,6 +75,14 @@ export class CoreSettingsSerializer {
                 return true;
             case "includenotebounds":
                 obj.includeNoteBounds = v! as boolean;
+                return true;
+            /*@target web*/
+            case "enablejqueryevents":
+                obj.enableJqueryEvents = v! as boolean;
+                return true;
+            /*@target web*/
+            case "enablebrowserevents":
+                obj.enableBrowserEvents = v! as boolean;
                 return true;
         } 
         return false; 

--- a/src/generated/PlayerSettingsSerializer.ts
+++ b/src/generated/PlayerSettingsSerializer.ts
@@ -25,6 +25,7 @@ export class PlayerSettingsSerializer {
         o.set("enablePlayer", obj.enablePlayer); 
         o.set("enableCursor", obj.enableCursor); 
         o.set("enableAnimatedBeatCursor", obj.enableAnimatedBeatCursor); 
+        o.set("enableElementHighlighting", obj.enableElementHighlighting); 
         o.set("enableUserInteraction", obj.enableUserInteraction); 
         o.set("scrollOffsetX", obj.scrollOffsetX); 
         o.set("scrollOffsetY", obj.scrollOffsetY); 
@@ -55,6 +56,9 @@ export class PlayerSettingsSerializer {
                 return true;
             case "enableanimatedbeatcursor":
                 obj.enableAnimatedBeatCursor = v! as boolean;
+                return true;
+            case "enableelementhighlighting":
+                obj.enableElementHighlighting = v! as boolean;
                 return true;
             case "enableuserinteraction":
                 obj.enableUserInteraction = v! as boolean;

--- a/src/generated/PlayerSettingsSerializer.ts
+++ b/src/generated/PlayerSettingsSerializer.ts
@@ -29,6 +29,8 @@ export class PlayerSettingsSerializer {
         o.set("scrollOffsetY", obj.scrollOffsetY); 
         o.set("scrollMode", obj.scrollMode as number); 
         o.set("scrollSpeed", obj.scrollSpeed); 
+        /*@target web*/
+        o.set("nativeBrowserSmoothScroll", obj.nativeBrowserSmoothScroll); 
         o.set("songBookBendDuration", obj.songBookBendDuration); 
         o.set("songBookDipDuration", obj.songBookDipDuration); 
         o.set("vibrato", VibratoPlaybackSettingsSerializer.toJson(obj.vibrato)); 
@@ -64,6 +66,10 @@ export class PlayerSettingsSerializer {
                 return true;
             case "scrollspeed":
                 obj.scrollSpeed = v! as number;
+                return true;
+            /*@target web*/
+            case "nativebrowsersmoothscroll":
+                obj.nativeBrowserSmoothScroll = v! as boolean;
                 return true;
             case "songbookbendduration":
                 obj.songBookBendDuration = v! as number;

--- a/src/generated/PlayerSettingsSerializer.ts
+++ b/src/generated/PlayerSettingsSerializer.ts
@@ -24,6 +24,7 @@ export class PlayerSettingsSerializer {
         o.set("scrollElement", obj.scrollElement); 
         o.set("enablePlayer", obj.enablePlayer); 
         o.set("enableCursor", obj.enableCursor); 
+        o.set("enableAnimatedBeatCursor", obj.enableAnimatedBeatCursor); 
         o.set("enableUserInteraction", obj.enableUserInteraction); 
         o.set("scrollOffsetX", obj.scrollOffsetX); 
         o.set("scrollOffsetY", obj.scrollOffsetY); 
@@ -51,6 +52,9 @@ export class PlayerSettingsSerializer {
                 return true;
             case "enablecursor":
                 obj.enableCursor = v! as boolean;
+                return true;
+            case "enableanimatedbeatcursor":
+                obj.enableAnimatedBeatCursor = v! as boolean;
                 return true;
             case "enableuserinteraction":
                 obj.enableUserInteraction = v! as boolean;

--- a/src/midi/BeatTickLookup.ts
+++ b/src/midi/BeatTickLookup.ts
@@ -1,10 +1,13 @@
 import { Beat } from '@src/model/Beat';
+import { MasterBarTickLookup } from './MasterBarTickLookup';
 
 /**
  * Represents the time period, for which a {@link Beat} is played.
  */
 export class BeatTickLookup {
     private _highlightedBeats: Map<number, boolean> = new Map();
+
+    public index: number = 0;
 
     /**
      * Gets or sets the start time in midi ticks at which the given beat is played.
@@ -31,6 +34,8 @@ export class BeatTickLookup {
      * the beat of this lookup starts playing.
      */
     public beatsToHighlight: Beat[] = [];
+
+    public masterBar!: MasterBarTickLookup;
 
     public highlightBeat(beat: Beat): void {
         if (!this._highlightedBeats.has(beat.id)) {

--- a/src/midi/MasterBarTickLookup.ts
+++ b/src/midi/MasterBarTickLookup.ts
@@ -50,6 +50,8 @@ export class MasterBarTickLookup {
      * @param beat
      */
     public addBeat(beat: BeatTickLookup): void {
+        beat.masterBar = this;
+        beat.index = this.beats.length;
         this.beats.push(beat);
     }
 }

--- a/src/platform/IContainer.ts
+++ b/src/platform/IContainer.ts
@@ -1,5 +1,6 @@
 import { IEventEmitter, IEventEmitterOfT } from '@src/EventEmitter';
 import { IMouseEventArgs } from '@src/platform/IMouseEventArgs';
+import { Bounds } from '@src/rendering/utils/Bounds';
 
 /**
  * This interface represents a container control in the UI layer.
@@ -49,6 +50,11 @@ export interface IContainer {
      * @param h The height
      */
     setBounds(x:number, y:number, w:number, h:number): void;
+
+    /**
+     * Gets the current position and size of the container.
+     */
+    getBounds(): Bounds;
 
     /**
      * Tells the control to move to the given X-position in the given time.

--- a/src/platform/IContainer.ts
+++ b/src/platform/IContainer.ts
@@ -6,16 +6,6 @@ import { IMouseEventArgs } from '@src/platform/IMouseEventArgs';
  */
 export interface IContainer {
     /**
-     * Gets or sets the Y-position of the control, relative to its parent.
-     */
-    top: number;
-
-    /**
-     * Gets or sets the X-position of the control, relative to its parent.
-     */
-    left: number;
-
-    /**
      * Gets or sets the width of the control.
      */
     width: number;
@@ -50,6 +40,15 @@ export interface IContainer {
      * Stops the animations of this control immediately.
      */
     stopAnimation(): void;
+
+    /**
+     * Sets the position and size of the container for efficient repositioning.
+     * @param x The X-position
+     * @param y The Y-position
+     * @param w The width
+     * @param h The height
+     */
+    setBounds(x:number, y:number, w:number, h:number): void;
 
     /**
      * Tells the control to move to the given X-position in the given time.

--- a/src/platform/IUiFacade.ts
+++ b/src/platform/IUiFacade.ts
@@ -109,9 +109,10 @@ export interface IUiFacade<TSettings> {
 
     /**
      * Tells the UI layer to highlight the music notation elements with the given ID.
+     * @param masterBarIndex The index of the related masterbar of the highlighted group.
      * @param groupId The group id that identifies the elements to be highlighted.
      */
-    highlightElements(groupId: string): void;
+    highlightElements(masterBarIndex:number, groupId: string): void;
 
     /**
      * Creates a new UI element that is used to display the selection rectangle.

--- a/src/platform/javascript/BrowserUiFacade.ts
+++ b/src/platform/javascript/BrowserUiFacade.ts
@@ -519,12 +519,16 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
         barCursor.style.left = '0';
         barCursor.style.top = '0';
         barCursor.style.willChange = 'transform';
+        barCursor.style.width = '1px';
+        barCursor.style.height = '1px';
         beatCursor.style.position = 'absolute';
         beatCursor.style.left = '0';
         beatCursor.style.top = '0';
         beatCursor.style.transition = 'all 0s linear';
         beatCursor.style.willChange = 'transform';
-        
+        beatCursor.style.width = '3px';
+        beatCursor.style.height = '1px';
+
         // add cursors to UI
         element.insertBefore(cursorWrapper, element.firstChild);
         cursorWrapper.appendChild(selectionWrapper);

--- a/src/platform/javascript/BrowserUiFacade.ts
+++ b/src/platform/javascript/BrowserUiFacade.ts
@@ -191,18 +191,22 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
         details: unknown = null,
         originalEvent?: IMouseEventArgs
     ): void {
-        let element: HTMLElement = (container as HtmlElementContainer).element;
-        name = 'alphaTab.' + name;
-        let e: any = document.createEvent('CustomEvent');
         let originalMouseEvent: MouseEvent | null = originalEvent
             ? (originalEvent as BrowserMouseEventArgs).mouseEvent
             : null;
-        e.initCustomEvent(name, false, false, details);
-        if (originalMouseEvent) {
-            e.originalEvent = originalMouseEvent;
+        let element: HTMLElement = (container as HtmlElementContainer).element;
+
+        if (this._api.settings.core.enableBrowserEvents) {
+            name = 'alphaTab.' + name;
+            let e: any = document.createEvent('CustomEvent');
+            e.initCustomEvent(name, false, false, details);
+            if (originalMouseEvent) {
+                e.originalEvent = originalMouseEvent;
+            }
+            element.dispatchEvent(e);
         }
-        element.dispatchEvent(e);
-        if (window && 'jQuery' in window) {
+
+        if (this._api.settings.core.enableJqueryEvents && window && 'jQuery' in window) {
             let jquery: any = (window as any)['jQuery'];
             let args: unknown[] = [];
             args.push(details);

--- a/src/platform/javascript/BrowserUiFacade.ts
+++ b/src/platform/javascript/BrowserUiFacade.ts
@@ -507,8 +507,15 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
         cursorWrapper.style.pointerEvents = 'none';
         selectionWrapper.style.position = 'absolute';
         barCursor.style.position = 'absolute';
+        barCursor.style.left = '0';
+        barCursor.style.top = '0';
+        barCursor.style.willChange = 'transform';
         beatCursor.style.position = 'absolute';
+        beatCursor.style.left = '0';
+        beatCursor.style.top = '0';
         beatCursor.style.transition = 'all 0s linear';
+        beatCursor.style.willChange = 'transform';
+        
         // add cursors to UI
         element.insertBefore(cursorWrapper, element.firstChild);
         cursorWrapper.appendChild(selectionWrapper);

--- a/src/platform/javascript/BrowserUiFacade.ts
+++ b/src/platform/javascript/BrowserUiFacade.ts
@@ -565,7 +565,13 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
         return b;
     }
 
+    private _scrollContainer: IContainer | null = null;
+
     public getScrollContainer(): IContainer {
+        if (this._scrollContainer) {
+            return this._scrollContainer;
+        }
+
         let scrollElement: HTMLElement =
             // tslint:disable-next-line: strict-type-predicates
             typeof this._api.settings.player.scrollElement === 'string'
@@ -587,7 +593,8 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
                 }
             }
         }
-        return new HtmlElementContainer(scrollElement);
+        this._scrollContainer = new HtmlElementContainer(scrollElement);
+        return this._scrollContainer;
     }
 
     public createSelectionElement(): IContainer | null {
@@ -605,38 +612,53 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
     }
 
     private internalScrollToY(element: HTMLElement, scrollTargetY: number, speed: number): void {
-        let startY: number = element.scrollTop;
-        let diff: number = scrollTargetY - startY;
-        let start: number = 0;
-        let step = (x: number) => {
-            if (start === 0) {
-                start = x;
-            }
-            let time: number = x - start;
-            let percent: number = Math.min(time / speed, 1);
-            element.scrollTop = (startY + diff * percent) | 0;
-            if (time < speed) {
-                window.requestAnimationFrame(step);
-            }
-        };
-        window.requestAnimationFrame(step);
+        if (this._api.settings.player.nativeBrowserSmoothScroll) {
+            element.scrollTo({
+                top: scrollTargetY,
+                behavior: 'smooth'
+            });
+        } else {
+            let startY: number = element.scrollTop;
+            let diff: number = scrollTargetY - startY;
+
+            let start: number = 0;
+            let step = (x: number) => {
+                if (start === 0) {
+                    start = x;
+                }
+                let time: number = x - start;
+                let percent: number = Math.min(time / speed, 1);
+                element.scrollTop = (startY + diff * percent) | 0;
+                if (time < speed) {
+                    window.requestAnimationFrame(step);
+                }
+            };
+            window.requestAnimationFrame(step);
+        }
     }
 
     private internalScrollToX(element: HTMLElement, scrollTargetX: number, speed: number): void {
-        let startX: number = element.scrollLeft;
-        let diff: number = scrollTargetX - startX;
-        let start: number = 0;
-        let step = (t: number) => {
-            if (start === 0) {
-                start = t;
-            }
-            let time: number = t - start;
-            let percent: number = Math.min(time / speed, 1);
-            element.scrollLeft = (startX + diff * percent) | 0;
-            if (time < speed) {
-                window.requestAnimationFrame(step);
-            }
-        };
-        window.requestAnimationFrame(step);
+        if (this._api.settings.player.nativeBrowserSmoothScroll) {
+            element.scrollTo({
+                left: scrollTargetX,
+                behavior: 'smooth'
+            });
+        } else {
+            let startX: number = element.scrollLeft;
+            let diff: number = scrollTargetX - startX;
+            let start: number = 0;
+            let step = (t: number) => {
+                if (start === 0) {
+                    start = t;
+                }
+                let time: number = t - start;
+                let percent: number = Math.min(time / speed, 1);
+                element.scrollLeft = (startX + diff * percent) | 0;
+                if (time < speed) {
+                    window.requestAnimationFrame(step);
+                }
+            };
+            window.requestAnimationFrame(step);
+        }
     }
 }

--- a/src/platform/javascript/BrowserUiFacade.ts
+++ b/src/platform/javascript/BrowserUiFacade.ts
@@ -40,6 +40,7 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
     private _totalResultCount: number = 0;
     private _initialTrackIndexes: number[] | null = null;
     private _intersectionObserver: IntersectionObserver;
+    private _barToElementLookup: Map<number, HTMLElement> = new Map<number, HTMLElement>();
 
     public rootContainerBecameVisible: IEventEmitter = new EventEmitter();
     public canRenderChanged: IEventEmitter = new EventEmitter();
@@ -84,10 +85,11 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
     }
 
     public constructor(rootElement: HTMLElement) {
-        if(Environment.webPlatform !== WebPlatform.Browser) {
-           throw new AlphaTabError(AlphaTabErrorType.General,
-            'Usage of AlphaTabApi is only possible in browser environments. For usage in node use the Low Level APIs'
-           );    
+        if (Environment.webPlatform !== WebPlatform.Browser) {
+            throw new AlphaTabError(
+                AlphaTabErrorType.General,
+                'Usage of AlphaTabApi is only possible in browser environments. For usage in node use the Low Level APIs'
+            );
         }
         rootElement.classList.add('alphaTab');
         this.rootContainer = new HtmlElementContainer(rootElement);
@@ -255,6 +257,7 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
     public initialRender(): void {
         this._api.renderer.preRender.on((_: boolean) => {
             this._totalResultCount = 0;
+            this._barToElementLookup.clear();
         });
 
         const initialRender = () => {
@@ -402,6 +405,12 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
                     placeholder.dataset['svg'] = body;
                     this._intersectionObserver.observe(placeholder);
                 }
+
+                // remember which bar is contained in which node for faster lookup
+                // on highlight/unhighlight
+                for (let i = renderResult.firstMasterBarIndex; i <= renderResult.lastMasterBarIndex; i++) {
+                    this._barToElementLookup.set(i, placeholder);
+                }
             } else {
                 if (this._totalResultCount < canvasElement.childElementCount) {
                     canvasElement.replaceChild(
@@ -417,13 +426,8 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
     }
 
     private replacePlaceholder(placeholder: HTMLElement, body: any) {
-        if (typeof placeholder.outerHTML === 'string') {
-            placeholder.outerHTML = body;
-        } else {
-            const display = document.createElement('div');
-            display.innerHTML = body;
-            placeholder.parentNode?.replaceChild(display.firstChild!, placeholder);
-        }
+        placeholder.innerHTML = body;
+        delete placeholder.dataset['svg'];
     }
 
     /**
@@ -466,20 +470,25 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
         });
     }
 
-    public highlightElements(groupId: string): void {
-        let element: HTMLElement = (this._api.container as HtmlElementContainer).element;
+    private _highlightedElements: HTMLElement[] = [];
+    public highlightElements(masterBarIndex: number, groupId: string): void {
+        const element = this._barToElementLookup.get(masterBarIndex)!;
         let elementsToHighlight: HTMLCollection = element.getElementsByClassName(groupId);
         for (let i: number = 0; i < elementsToHighlight.length; i++) {
             elementsToHighlight.item(i)!.classList.add('at-highlight');
+            this._highlightedElements.push(elementsToHighlight.item(i) as HTMLElement);
         }
     }
 
     public removeHighlights(): void {
-        let element: HTMLElement = (this._api.container as HtmlElementContainer).element;
-        let elements: HTMLCollection = element.getElementsByClassName('at-highlight');
-        while (elements.length > 0) {
-            elements.item(0)!.classList.remove('at-highlight');
+        const highlightedElements = this._highlightedElements;
+        if (!highlightedElements) {
+            return;
         }
+        for (const element of highlightedElements) {
+            element.classList.remove('at-highlight');
+        }
+        this._highlightedElements = [];
     }
 
     public destroyCursors(): void {

--- a/src/platform/javascript/HtmlElementContainer.ts
+++ b/src/platform/javascript/HtmlElementContainer.ts
@@ -8,7 +8,7 @@ import { Lazy } from '@src/util/Lazy';
  * @target web
  */
 export class HtmlElementContainer implements IContainer {
-    private static resizeObserver: Lazy<ResizeObserver> = new Lazy<ResizeObserver>(() => new ResizeObserver((entries:ResizeObserverEntry[]) => {
+    private static resizeObserver: Lazy<ResizeObserver> = new Lazy<ResizeObserver>(() => new ResizeObserver((entries: ResizeObserverEntry[]) => {
         for (const e of entries) {
             let evt = new CustomEvent('resize', {
                 detail: e
@@ -18,21 +18,25 @@ export class HtmlElementContainer implements IContainer {
     }));
 
     private _resizeListeners: number = 0;
+    private _top: number = 0;
+    private _left: number = 0;
 
     public get top(): number {
-        return parseFloat(this.element.style.top);
+        return this._top;
     }
 
     public set top(value: number) {
-        this.element.style.top = value + 'px';
+        this._top = value;
+        this.updateTranslate();
     }
 
     public get left(): number {
-        return parseFloat(this.element.style.top);
+        return this._left;
     }
 
     public set left(value: number) {
-        this.element.style.left = value + 'px';
+        this._left = value;
+        this.updateTranslate();
     }
 
     public get width(): number {
@@ -159,8 +163,13 @@ export class HtmlElementContainer implements IContainer {
     public transitionToX(duration: number, x: number): void {
         this.element.style.transition = 'all 0s linear';
         this.element.style.transitionDuration = duration + 'ms';
-        this.element.style.left = x + 'px';
+        this.left = x;
     }
+
+    private updateTranslate() {
+        this.element.style.transform = `translate(${this._left}px, ${this._top}px)`;
+    }
+    
 
     /**
      * This event occurs when the control was resized.

--- a/src/platform/javascript/HtmlElementContainer.ts
+++ b/src/platform/javascript/HtmlElementContainer.ts
@@ -2,6 +2,7 @@ import { IEventEmitter, IEventEmitterOfT } from '@src/EventEmitter';
 import { IContainer } from '@src/platform/IContainer';
 import { IMouseEventArgs } from '@src/platform/IMouseEventArgs';
 import { BrowserMouseEventArgs } from '@src/platform/javascript/BrowserMouseEventArgs';
+import { Bounds } from '@src/rendering/utils/Bounds';
 import { Lazy } from '@src/util/Lazy';
 
 /**
@@ -21,7 +22,7 @@ export class HtmlElementContainer implements IContainer {
     );
 
     private _resizeListeners: number = 0;
-    
+
     public get width(): number {
         return this.element.offsetWidth;
     }
@@ -117,19 +118,11 @@ export class HtmlElementContainer implements IContainer {
                 if (this._resizeListeners === 0) {
                     HtmlElementContainer.resizeObserver.value.observe(this.element);
                 }
-                this.element.addEventListener(
-                    'resize',
-                    value,
-                    true
-                );
+                this.element.addEventListener('resize', value, true);
                 this._resizeListeners++;
             },
             off: (value: any) => {
-                this.element.removeEventListener(
-                    'resize',
-                    value,
-                    true
-                );
+                this.element.removeEventListener('resize', value, true);
                 this._resizeListeners--;
                 if (this._resizeListeners <= 0) {
                     this._resizeListeners = 0;
@@ -144,34 +137,35 @@ export class HtmlElementContainer implements IContainer {
     }
 
     public transitionToX(duration: number, x: number): void {
-        this.element.style.transition = 'all 0s linear';
-        this.element.style.transitionDuration = duration + 'ms';
+        this.element.style.transition = `transform ${duration}ms linear`;
         this.setBounds(x, NaN, NaN, NaN);
     }
 
-    private _x:number = 0;
-    private _y:number = 0;
-    private _w:number = 0;
-    private _h:number = 0;
+    private _lastBounds: Bounds = new Bounds();
+
+    public getBounds() {
+        return this._lastBounds;
+    }
+
     public setBounds(x: number, y: number, w: number, h: number) {
-        if(isNaN(x)) { 
-            x = this._x;
+        if (isNaN(x)) {
+            x = this._lastBounds.x;
         }
-        if(isNaN(y)) { 
-            y = this._y;
+        if (isNaN(y)) {
+            y = this._lastBounds.y;
         }
-        if(isNaN(w)) { 
-            w = this._w;
+        if (isNaN(w)) {
+            w = this._lastBounds.w;
         }
-        if(isNaN(h)) { 
-            h = this._h;
+        if (isNaN(h)) {
+            h = this._lastBounds.h;
         }
         this.element.style.transform = `translate(${x}px, ${y}px) scale(${w}, ${h})`;
         this.element.style.transformOrigin = 'top left';
-        this._x = x;
-        this._y = y;
-        this._w = w;
-        this._h = h;
+        this._lastBounds.x = x;
+        this._lastBounds.y = y;
+        this._lastBounds.w = w;
+        this._lastBounds.h = h;
     }
 
     /**

--- a/src/platform/javascript/HtmlElementContainer.ts
+++ b/src/platform/javascript/HtmlElementContainer.ts
@@ -8,37 +8,20 @@ import { Lazy } from '@src/util/Lazy';
  * @target web
  */
 export class HtmlElementContainer implements IContainer {
-    private static resizeObserver: Lazy<ResizeObserver> = new Lazy<ResizeObserver>(() => new ResizeObserver((entries: ResizeObserverEntry[]) => {
-        for (const e of entries) {
-            let evt = new CustomEvent('resize', {
-                detail: e
-            });
-            e.target.dispatchEvent(evt);
-        }
-    }));
+    private static resizeObserver: Lazy<ResizeObserver> = new Lazy<ResizeObserver>(
+        () =>
+            new ResizeObserver((entries: ResizeObserverEntry[]) => {
+                for (const e of entries) {
+                    let evt = new CustomEvent('resize', {
+                        detail: e
+                    });
+                    e.target.dispatchEvent(evt);
+                }
+            })
+    );
 
     private _resizeListeners: number = 0;
-    private _top: number = 0;
-    private _left: number = 0;
-
-    public get top(): number {
-        return this._top;
-    }
-
-    public set top(value: number) {
-        this._top = value;
-        this.updateTranslate();
-    }
-
-    public get left(): number {
-        return this._left;
-    }
-
-    public set left(value: number) {
-        this._left = value;
-        this.updateTranslate();
-    }
-
+    
     public get width(): number {
         return this.element.offsetWidth;
     }
@@ -163,13 +146,33 @@ export class HtmlElementContainer implements IContainer {
     public transitionToX(duration: number, x: number): void {
         this.element.style.transition = 'all 0s linear';
         this.element.style.transitionDuration = duration + 'ms';
-        this.left = x;
+        this.setBounds(x, NaN, NaN, NaN);
     }
 
-    private updateTranslate() {
-        this.element.style.transform = `translate(${this._left}px, ${this._top}px)`;
+    private _x:number = 0;
+    private _y:number = 0;
+    private _w:number = 0;
+    private _h:number = 0;
+    public setBounds(x: number, y: number, w: number, h: number) {
+        if(isNaN(x)) { 
+            x = this._x;
+        }
+        if(isNaN(y)) { 
+            y = this._y;
+        }
+        if(isNaN(w)) { 
+            w = this._w;
+        }
+        if(isNaN(h)) { 
+            h = this._h;
+        }
+        this.element.style.transform = `translate(${x}px, ${y}px) scale(${w}, ${h})`;
+        this.element.style.transformOrigin = 'top left';
+        this._x = x;
+        this._y = y;
+        this._w = w;
+        this._h = h;
     }
-    
 
     /**
      * This event occurs when the control was resized.

--- a/src/synth/synthesis/TinySoundFont.ts
+++ b/src/synth/synthesis/TinySoundFont.ts
@@ -24,7 +24,6 @@ import { Voice } from '@src/synth/synthesis/Voice';
 import { VoiceEnvelopeSegment } from '@src/synth/synthesis/VoiceEnvelope';
 import { SynthHelper } from '@src/synth/SynthHelper';
 import { TypeConversions } from '@src/io/TypeConversions';
-import { Logger } from '@src/Logger';
 import { SynthConstants } from '@src/synth/SynthConstants';
 import { Midi20PerNotePitchBendEvent } from '@src/midi/Midi20PerNotePitchBendEvent';
 import { MetaEventType } from '@src/midi/MetaEvent';
@@ -145,7 +144,7 @@ export class TinySoundFont {
     }
 
     private processMidiMessage(e: MidiEvent): void {
-        Logger.debug('Midi', 'Processing midi ' + e.command);
+        // Logger.debug('Midi', 'Processing midi ' + e.command);
         const command: MidiEventType = e.command;
         const channel: number = e.channel;
         const data1: number = e.data1;

--- a/src/synth/synthesis/TinySoundFont.ts
+++ b/src/synth/synthesis/TinySoundFont.ts
@@ -144,7 +144,6 @@ export class TinySoundFont {
     }
 
     private processMidiMessage(e: MidiEvent): void {
-        // Logger.debug('Midi', 'Processing midi ' + e.command);
         const command: MidiEventType = e.command;
         const channel: number = e.channel;
         const data1: number = e.data1;


### PR DESCRIPTION
### Issues
Relates #480 

### Proposed changes
Try to use HTML5 Audio Worklets if available for audio output instead of the `ScriptProcessor`. 
So far it is a simple copy-paste of the old output implementation with the required adaptions. So far only the output is shifted to the worklet, we'll have to check if more offloading from the UI thread is possible as currently the synthesizing happens in a worker and all communication between worklet and WebWorker go via UI thread. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [ ] Changes are implemented
- [ ] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
