### PR TITLE
Fixed flickering of beat cursor in firefox

### DIFF
--- a/src.csharp/AlphaTab.Windows/WinForms/ControlContainer.cs
+++ b/src.csharp/AlphaTab.Windows/WinForms/ControlContainer.cs
@@ -105,39 +105,12 @@ namespace AlphaTab.WinForms
             Control.Controls.Clear();
         }
 
-        private readonly Bounds _lastBounds = new Bounds();
-
-        public Bounds GetBounds()
-        {
-            return _lastBounds;
-        }
-
         public void SetBounds(double x, double y, double w, double h)
         {
-            if (double.IsNaN(x))
-            {
-                x = _lastBounds.X;
-            }
-            if (double.IsNaN(y))
-            {
-                y = _lastBounds.Y;
-            }
-            if (double.IsNaN(w))
-            {
-                w = _lastBounds.W;
-            }
-            if (double.IsNaN(h))
-            {
-                h = _lastBounds.H;
-            }
             Control.Left = (int)x;
             Control.Top = (int)y;
             Control.Width = (int)w;
             Control.Height = (int)h;
-            _lastBounds.X = x;
-            _lastBounds.Y = y;
-            _lastBounds.W = w;
-            _lastBounds.H = h;
         }
 
         public IEventEmitter Resize { get; set; }

--- a/src.csharp/AlphaTab.Windows/Wpf/FrameworkElementContainer.cs
+++ b/src.csharp/AlphaTab.Windows/Wpf/FrameworkElementContainer.cs
@@ -130,40 +130,12 @@ namespace AlphaTab.Wpf
             }
         }
 
-        private readonly Bounds _lastBounds = new Bounds();
-
-        public Bounds GetBounds()
-        {
-            return _lastBounds;
-        }
-
         public void SetBounds(double x, double y, double w, double h)
         {
-            if (double.IsNaN(x))
-            {
-                x = _lastBounds.X;
-            }
-            if (double.IsNaN(y))
-            {
-                y = _lastBounds.Y;
-            }
-            if (double.IsNaN(w))
-            {
-                w = _lastBounds.W;
-            }
-            if (double.IsNaN(h))
-            {
-                h = _lastBounds.H;
-            }
-
             Canvas.SetLeft(Control, x);
             Canvas.SetTop(Control, y);
             Control.Width = w;
             Control.Height = h;
-            _lastBounds.X = x;
-            _lastBounds.Y = y;
-            _lastBounds.W = w;
-            _lastBounds.H = h;
         }
 
         public IEventEmitter Resize { get; set; }

--- a/src/platform/IContainer.ts
+++ b/src/platform/IContainer.ts
@@ -1,6 +1,5 @@
 import { IEventEmitter, IEventEmitterOfT } from '@src/EventEmitter';
 import { IMouseEventArgs } from '@src/platform/IMouseEventArgs';
-import { Bounds } from '@src/rendering/utils/Bounds';
 
 /**
  * This interface represents a container control in the UI layer.

--- a/src/platform/IContainer.ts
+++ b/src/platform/IContainer.ts
@@ -52,12 +52,6 @@ export interface IContainer {
     setBounds(x: number, y: number, w: number, h: number): void;
 
     /**
-     * Gets the current position and size of the container. These
-     * values might be only filled correctly after a call to setBounds.
-     */
-    getBounds(): Bounds;
-
-    /**
      * Tells the control to move to the given X-position in the given time.
      * @param duration The milliseconds that should be needed to reach the new X-position
      * @param x The new X-position

--- a/src/platform/javascript/HtmlElementContainer.ts
+++ b/src/platform/javascript/HtmlElementContainer.ts
@@ -143,10 +143,6 @@ export class HtmlElementContainer implements IContainer {
 
     private _lastBounds: Bounds = new Bounds();
 
-    public getBounds() {
-        return this._lastBounds;
-    }
-
     public setBounds(x: number, y: number, w: number, h: number) {
         if (isNaN(x)) {
             x = this._lastBounds.x;


### PR DESCRIPTION
### Issues
Fixes #648

### Proposed changes
Fixes a newly introduced issue where in FireFox the cursor was flickering back sometimes. This was due to some animation timing issue. One of the previously introduced optimizations does not play well with these animations so I had to remove it again. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
