### PR TITLE
Add support for chord diagrams in MusicXML

### DIFF
--- a/src/importer/MusicXmlImporter.ts
+++ b/src/importer/MusicXmlImporter.ts
@@ -434,19 +434,19 @@ export class MusicXmlImporter extends ScoreImporter {
                                     case 'root-alter':
                                         switch (parseInt(rootChild.innerText)) {
                                             case -2:
-                                                rootAlter = ' bb';
+                                                rootAlter = 'bb';
                                                 break;
                                             case -1:
-                                                rootAlter = ' b';
+                                                rootAlter = 'b';
                                                 break;
                                             case 0:
                                                 rootAlter = '';
                                                 break;
                                             case 1:
-                                                rootAlter = ' #';
+                                                rootAlter = '#';
                                                 break;
                                             case 2:
-                                                rootAlter = ' ##';
+                                                rootAlter = '##';
                                                 break;
                                         }
                                         break;


### PR DESCRIPTION
Added support for frame elements to display chord diagrams. Also added some chord names to display for kind elements.
![image](https://user-images.githubusercontent.com/42806447/137685741-0fe00bcd-ce4f-477c-9aaf-18e39ec5b292.png)

### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Issue #667  Add support for chord diagrams in MusicXML
### Proposed changes
<!-- Describe the proposed changes -->
Add support for chord diagrams in MusicXML
### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] Existing builds tests pass
- [ ] New tests were added

## Further details
Issues displaying when discrepancy between staff.tuning and chord.strings.

This happens when using test file 71c-ChordsFrets.xml which has no staff-tuning element. 

![image](https://user-images.githubusercontent.com/42806447/137686419-376b79b8-a03a-47ec-b230-4b50fc290953.png)


If staff-tuning elements are added for 6 strings the C chord (which in this file has 10 strings) overflows:

![image](https://user-images.githubusercontent.com/42806447/137686677-8d48d820-db71-47ba-99f7-997ee755c3f4.png)

I don't know if there are any scores with varying numbers of strings in chord diagrams for the same part but quite few musicXML  didn't have staff-tuning element.

Replacing _chord.staff.tuning.length with _chord.strings.length in ChordDiagramGlyph.ts fixed this but I haven't checked if this affects drawing chord diagrams from other file types so not committing. 

![image](https://user-images.githubusercontent.com/42806447/137686232-e408ea2f-06a4-42d6-ae8b-e5cbe342dcaa.png)

Another option would be to not display chords with a different number of strings to staff.tuning or display them with the number of strings in staff.tuning.
