### PR TITLE
Restore API compatibility for Settings.fillFromJson

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -3,6 +3,7 @@ import { DisplaySettings } from '@src/DisplaySettings';
 import { ImporterSettings } from '@src/ImporterSettings';
 import { FingeringMode, NotationMode, NotationSettings, NotationElement } from '@src/NotationSettings';
 import { PlayerSettings } from '@src/PlayerSettings';
+import { SettingsSerializer } from '@src/generated/SettingsSerializer';
 
 /**
  * This public class contains instance specific settings for alphaTab
@@ -56,5 +57,12 @@ export class Settings {
         let settings: Settings = new Settings();
         settings.setSongBookModeSettings();
         return settings;
+    }
+
+    /**
+     * @target web
+     */
+    public fillFromJson(json: any): void {
+        SettingsSerializer.fromJson(this, json);
     }
 }


### PR DESCRIPTION
### Issues
Fixes #674 

### Proposed changes
Re-add the method from alphaTab 1.1 which allowed filling an existing Settings object from a given JSON object.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
