### PR TITLE
Ensure we don't interpret note symbols as section text

### DIFF
--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -1451,6 +1451,10 @@ export class AlphaTexImporter extends ScoreImporter {
         }
     }
 
+    private isNoteText(txt: string) {
+        return txt === 'x'  || txt === '-' || txt === 'r';
+    }
+
     private note(beat: Beat): boolean {
         // fret.string
         let isDead: boolean = false;
@@ -1823,7 +1827,7 @@ export class AlphaTexImporter extends ScoreImporter {
                 let text: string = this._syData as string;
                 this._sy = this.newSy();
                 let marker: string = '';
-                if (this._sy === AlphaTexSymbols.String) {
+                if (this._sy === AlphaTexSymbols.String && !this.isNoteText((this._syData as string).toLowerCase())) {
                     marker = text;
                     text = this._syData as string;
                     this._sy = this.newSy();

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -913,7 +913,7 @@ describe('AlphaTexImporterTest', () => {
         }
     })
 
-    function runSectionNoteSymbolTest(noteSymbol:String) {
+    function runSectionNoteSymbolTest(noteSymbol:string) {
         const score = parseTex(`1.3.4 * 4 | \\section Verse ${noteSymbol}.1 | 2.3.4*4`);
 
         expect(score.masterBars.length).toEqual(3);

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -912,4 +912,19 @@ describe('AlphaTexImporterTest', () => {
             // success
         }
     })
+
+    function runSectionNoteSymbolTest(noteSymbol:String) {
+        const score = parseTex(`1.3.4 * 4 | \\section Verse ${noteSymbol}.1 | 2.3.4*4`);
+
+        expect(score.masterBars.length).toEqual(3);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats.length).toEqual(4);
+        expect(score.masterBars[1].section!.text).toEqual('Verse');
+        expect(score.tracks[0].staves[0].bars[1].voices[0].beats.length).toEqual(1);
+    }
+
+    it('does-not-interpret-note-symbols-on-section', () => {
+        runSectionNoteSymbolTest('r');
+        runSectionNoteSymbolTest('-');
+        runSectionNoteSymbolTest('x');
+    })
 });


### PR DESCRIPTION
### Issues
Fixes #683

### Proposed changes
Ignore note specific symbols when interpreting optional section text/marker combination in alphaTex

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [x] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
