### PR TITLE
Clear buffered samples on audio settings change

### DIFF
--- a/src/synth/AlphaSynth.ts
+++ b/src/synth/AlphaSynth.ts
@@ -63,6 +63,7 @@ export class AlphaSynth implements IAlphaSynth {
     public set masterVolume(value: number) {
         value = Math.max(value, SynthConstants.MinVolume);
         this._synthesizer.masterVolume = value;
+        this.onAudioSettingsUpdate();
     }
 
     public get metronomeVolume(): number {
@@ -73,6 +74,7 @@ export class AlphaSynth implements IAlphaSynth {
         value = Math.max(value, SynthConstants.MinVolume);
         this._metronomeVolume = value;
         this._synthesizer.metronomeVolume = value;
+        this.onAudioSettingsUpdate();
     }
 
     public get countInVolume(): number {
@@ -100,7 +102,7 @@ export class AlphaSynth implements IAlphaSynth {
         value = SynthHelper.clamp(value, SynthConstants.MinPlaybackSpeed, SynthConstants.MaxPlaybackSpeed);
         let oldSpeed: number = this._sequencer.playbackSpeed;
         this._sequencer.playbackSpeed = value;
-        this.updateTimePosition(this._timePosition * (oldSpeed / value), true);
+        this.timePosition = this.timePosition * (oldSpeed / value);
     }
 
     public get tickPosition(): number {
@@ -348,6 +350,7 @@ export class AlphaSynth implements IAlphaSynth {
 
     public setChannelMute(channel: number, mute: boolean): void {
         this._synthesizer.channelSetMute(channel, mute);
+        this.onAudioSettingsUpdate();
     }
 
     public resetChannelStates(): void {
@@ -356,11 +359,19 @@ export class AlphaSynth implements IAlphaSynth {
 
     public setChannelSolo(channel: number, solo: boolean): void {
         this._synthesizer.channelSetSolo(channel, solo);
+        this.onAudioSettingsUpdate();
     }
 
     public setChannelVolume(channel: number, volume: number): void {
         volume = Math.max(volume, SynthConstants.MinVolume);
         this._synthesizer.channelSetMixVolume(channel, volume);
+        this.onAudioSettingsUpdate();
+    }
+    private onAudioSettingsUpdate() {
+        // seeking to the currently known position, will ensure we
+        // clear all audio buffers and re-generate the audio 
+        // which was not actually played yet. 
+        this.timePosition = this.timePosition;
     }
 
     private onSamplesPlayed(sampleCount: number): void {


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Fixes #657 

### Proposed changes
We need to reset the already buffered audio in case we make any audio related changes like muting tracks or changing volumes. Otherwise it can take a while until it gets applied. 

We do this clearing by simply seeking to the currently known time position. This will clear anything in the output buffers and trigger a regeneration of the audio. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
