### PR TITLE
Fix findNoteAtPos logic

### DIFF
--- a/src/rendering/utils/BeatBounds.ts
+++ b/src/rendering/utils/BeatBounds.ts
@@ -62,7 +62,7 @@ export class BeatBounds {
         for (let note of notes) {
             let bottom: number = note.noteHeadBounds.y + note.noteHeadBounds.h;
             let right: number = note.noteHeadBounds.x + note.noteHeadBounds.w;
-            if (note.noteHeadBounds.x >= x && note.noteHeadBounds.y >= y && x <= right && y <= bottom) {
+            if (note.noteHeadBounds.x <= x && note.noteHeadBounds.y <= y && x <= right && y <= bottom) {
                 return note.note;
             }
         }


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Fixes #744

### Proposed changes
<!-- Describe the proposed changes -->
Fixes logic on `findNoteAtPos` to correctly find the expected note. Here is a simple codepen demonstrating the fix:
https://codepen.io/gallegretti/pen/KKyqypL
As you click on the notes, the ids will be logged on the console


### Checklist
- [X] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [X] Changes are implemented
- [X] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website

