### PR TITLE
Update readme and targeted versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,6 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version:  |
-            5.0.x
             6.0.x
       - run: npm install
       - run: npm run build-csharp-ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version:  |
-            5.0.x
             6.0.x
         
       - run: npm install
@@ -134,7 +133,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version:  |
-            5.0.x
             6.0.x
         
       - run: npm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version:  |
-            5.0.x
             6.0.x
         env:
           NUGET_AUTH_TOKEN: ${{secrets.NUGET_API_KEY}}

--- a/README.md
+++ b/README.md
@@ -27,26 +27,26 @@ alphaTab mostly focuses on web based platforms allowing music notation to be emb
 
 alphaTab can load music notation from various sources like Guitar Pro 3-7, AlphaTex and MusicXML (experimental) and render them into beautiful music sheets right within your browser (or application). Using a built in midi synthesizer named alphaSynth the music sheets can also be played in your browser.
 
-* load GuitarPro 3-5, GuitarPro 6, AlphaTex or MusicXML (experimental)
-* render as SVG, HTML5 canvas, GDI+,...
+* load GuitarPro 3-5, GuitarPro 6, Guitar Pro 7, AlphaTex or MusicXML (experimental)
+* render as SVG or Raster Graphics (raster graphics depends on platform: HTML5 canvas, GDI+, SkiaSharp, Android Canvas)...
 * display single or multiple instruments as standard music notation and guitar tablatures consisting of song information, repeats, alternate endings, guitar tunints, clefs, key signatures, time signatures, notes, rests, accidentals, drum tabs, piano grand staff, tied notes, grace notes, dead notes, ghost notes, markers, tempos, lyrics, chords, vibratos, dynamics, tap/slap/pop, fade-in, let-ring, palm-mute, string bends, whammy bar, tremolo picking, strokes, slides, trills, pick strokes, tuplets, fingering, triplet feels,...
 * adapt to your responsive design by dynamic resizing
-* play the music sheet via HTML5 Web Audio API (only if browser supports it)
+* play the music sheet via built-in Midi+SoundFont2 Synthesizer (output depends on platform: HTML5 Web Audio, NAudio, Android AudioTrack)
 
 # Officially Supported Platforms
 
- Platform | Support | Since
-----------|---------|------|
-Browsers using `script` includes (UMD) | Full experience including low level APIs, Background Workers, Audio Playback, SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. | 1.0 (released :check:)
-Browsers using ES6 Modules (ESM) | Full experience including low level APIs, Background Workers, Audio Playback, SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. | 1.3 ()
-Node.js using `require` (UMD) | Access to all low level APIs and SVG rendering | 1.0
-Node.js using `import` (ESM) | Access to all low level APIs and SVG rendering | 1.3
-.net standard 2.0 | Access to all low level APIs and multiple render engines (SVG, GDI+, SkiaSharp) | 1.0
-.netcoreapp3.1 (WPF) | Full experience including low level APIs, Background Workers, Audio Playback (through NAudio), SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. | 1.0
-.netcoreapp3.1 (WinForms) | Full experience including low level APIs, Background Workers, Audio Playback (through NAudio), SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. Reduced UI level integration related to transparency and animations. | 1.0
-.net6.0-windows (WPF) | Full experience including low level APIs, Background Workers, Audio Playback (through NAudio), SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. | 1.3
-.net6.0-windows (WinForms) | Full experience including low level APIs, Background Workers, Audio Playback (through NAudio), SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. Reduced UI level integration related to transparency and animations. | 1.3
-Android (Kotlin) | Full experience including low level APIs, Background Workers, Audio Playback, Android Canvas and SVG rendering. UI level integration for user interaction and automatic resizing. Reduced UI level integration related to transparency and animations. | 1.3
+ Platform | Support | Availability |
+----------|---------|-------|
+Browsers using `script` includes (UMD) | Full experience including low level APIs, Background Workers, Audio Playback, SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. | 1.0-latest
+Node.js using `require` (UMD) | Access to all low level APIs and SVG rendering | 1.0-latest
+.net standard 2.0 | Access to all low level APIs and multiple render engines (SVG, GDI+, SkiaSharp) | 1.0-latest
+.netcoreapp3.1 (WPF) | Full experience including low level APIs, Background Workers, Audio Playback (through NAudio), SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. | 1.0-1.2.2
+.netcoreapp3.1 (WinForms) | Full experience including low level APIs, Background Workers, Audio Playback (through NAudio), SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. Reduced UI level integration related to transparency and animations. | 1.0-1.2.2
+Browsers using ES6 Modules (ESM) | Full experience including low level APIs, Background Workers, Audio Playback, SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. | 1.3 (pre-release :warning:)
+Node.js using `import` (ESM) | Access to all low level APIs and SVG rendering | 1.3 (pre-release :warning:)
+.net6.0-windows (WPF) | Full experience including low level APIs, Background Workers, Audio Playback (through NAudio), SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. | 1.3 (pre-release :warning:)
+.net6.0-windows (WinForms) | Full experience including low level APIs, Background Workers, Audio Playback (through NAudio), SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. Reduced UI level integration related to transparency and animations. | 1.3 (pre-release :warning:)
+Android (Kotlin) | Full experience including low level APIs, Background Workers, Audio Playback, Android Canvas and SVG rendering. UI level integration for user interaction and automatic resizing. Reduced UI level integration related to transparency and animations. | 1.3 (pre-release :warning:)
 
 # Thanks to...
 
@@ -56,7 +56,7 @@ Android (Kotlin) | Full experience including low level APIs, Background Workers,
 <a href="https://www.browserstack.com" target="_blank"><img src="img/BrowserStack.png?raw=true" width="400" align="center"/></a>
 </p>
 
-... our friends at JetBrains for a Open Source License of ther products. This allows me to develop all the flavors of alphaTab with the latest and createst coding and debugging assistance.
+... our friends at JetBrains for a Open Source License of their products. This allows me to develop all the flavors of alphaTab with the latest and greatest coding and debugging assistance.
 
 <p align="center">
 <a href="https://www.jetbrains.com/" target="_blank"><img src="https://resources.jetbrains.com/storage/products/company/brand/logos/jb_beam.png" width="150" align="center"/></a><br />

--- a/README.md
+++ b/README.md
@@ -17,25 +17,13 @@ To get started follow our guides and tutorials at:
 
 ## Build Status
 
-> Until the official 1.0 release we recommend to use pre release versions based on the `develop` branch.
-
 &nbsp; | &nbsp;
 --- | ---
 **Build** | ![Build](https://github.com/CoderLine/alphaTab/workflows/Build/badge.svg?branch=develop)
-**Documentation** | [![Documentation](https://img.shields.io/badge/docs-master-brightgreen.svg)](https://www2.alphatab.net/)
-
-# Downloads
-
-The latest binaries based  are available for download at either npmjs.org or NuGet.org.
-Use the links below to grab the binaries from the latest builds. We recommend using package managers to pull the files to your projects. 
-
-&nbsp; | &nbsp;
---- | --- |
-**JavaScript** | [NPM](https://www.npmjs.com/package/@coderline/alphatab)
-**.net** | [NuGet](https://www.nuget.org/profiles/CoderLine)
+**Documentation** | [![Documentation](https://img.shields.io/badge/docs-master-brightgreen.svg)](https://www.alphatab.net/)
 
 # Features
-alphaTab mostly focuses on web based platforms allowing music notation to be embedded into websites and browser based apps but is designed to be used also from .net based platforms like Windows, UWP and Xamarin.
+alphaTab mostly focuses on web based platforms allowing music notation to be embedded into websites and browser based apps but is designed to be used also from various other platforms like .net and Android either as a platform native integration or through runtime specific JavaScript engines. 
 
 alphaTab can load music notation from various sources like Guitar Pro 3-7, AlphaTex and MusicXML (experimental) and render them into beautiful music sheets right within your browser (or application). Using a built in midi synthesizer named alphaSynth the music sheets can also be played in your browser.
 
@@ -45,12 +33,34 @@ alphaTab can load music notation from various sources like Guitar Pro 3-7, Alpha
 * adapt to your responsive design by dynamic resizing
 * play the music sheet via HTML5 Web Audio API (only if browser supports it)
 
+# Officially Supported Platforms
+
+ Platform | Support | Since
+----------|---------|------|
+Browsers using `script` includes (UMD) | Full experience including low level APIs, Background Workers, Audio Playback, SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. | 1.0 (released :check:)
+Browsers using ES6 Modules (ESM) | Full experience including low level APIs, Background Workers, Audio Playback, SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. | 1.3 ()
+Node.js using `require` (UMD) | Access to all low level APIs and SVG rendering | 1.0
+Node.js using `import` (ESM) | Access to all low level APIs and SVG rendering | 1.3
+.net standard 2.0 | Access to all low level APIs and multiple render engines (SVG, GDI+, SkiaSharp) | 1.0
+.netcoreapp3.1 (WPF) | Full experience including low level APIs, Background Workers, Audio Playback (through NAudio), SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. | 1.0
+.netcoreapp3.1 (WinForms) | Full experience including low level APIs, Background Workers, Audio Playback (through NAudio), SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. Reduced UI level integration related to transparency and animations. | 1.0
+.net6.0-windows (WPF) | Full experience including low level APIs, Background Workers, Audio Playback (through NAudio), SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. | 1.3
+.net6.0-windows (WinForms) | Full experience including low level APIs, Background Workers, Audio Playback (through NAudio), SVG and HTML5 rendering. UI level integration for user interaction and automatic resizing. Reduced UI level integration related to transparency and animations. | 1.3
+Android (Kotlin) | Full experience including low level APIs, Background Workers, Audio Playback, Android Canvas and SVG rendering. UI level integration for user interaction and automatic resizing. Reduced UI level integration related to transparency and animations. | 1.3
+
 # Thanks to...
 
-... the guys of BrowserStack for a free plan. This allows me to test alphaTab on all browsers on all operating systems. Only with this I can ensure that alphaTab is shown to all your visitors as expected.
+... our friends of BrowserStack for a free plan. This allows me to test alphaTab on all browsers on all operating systems. Only with this I can ensure that alphaTab is shown to all your visitors as expected.
 
 <p align="center">
 <a href="https://www.browserstack.com" target="_blank"><img src="img/BrowserStack.png?raw=true" width="400" align="center"/></a>
+</p>
+
+... our friends at JetBrains for a Open Source License of ther products. This allows me to develop all the flavors of alphaTab with the latest and createst coding and debugging assistance.
+
+<p align="center">
+<a href="https://www.jetbrains.com/" target="_blank"><img src="https://resources.jetbrains.com/storage/products/company/brand/logos/jb_beam.png" width="150" align="center"/></a><br />
+Copyright © 2000-2022 JetBrains s.r.o. JetBrains and the JetBrains logo are registered trademarks of JetBrains s.r.o.
 </p>
 
 ... to [Bernhard Schelling](https://github.com/schellingb/TinySoundFont) the author of TinySoundFont and [Steve Folta](https://github.com/stevefolta/SFZero) the author of SFZero for providing the core of the synthesis engine.

--- a/src.csharp/AlphaTab.Test/AlphaTab.Test.csproj
+++ b/src.csharp/AlphaTab.Test/AlphaTab.Test.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <RootNamespace>AlphaTab</RootNamespace>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
         <LangVersion>8</LangVersion>

--- a/src.csharp/AlphaTab.Windows/AlphaTab.Windows.csproj
+++ b/src.csharp/AlphaTab.Windows/AlphaTab.Windows.csproj
@@ -6,7 +6,7 @@
         <PackageId>AlphaTab.Windows</PackageId>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <TargetFrameworks>netcoreapp3.1;net5.0-windows;net6.0-windows</TargetFrameworks>
+        <TargetFrameworks>net6.0-windows</TargetFrameworks>
         <UseWPF>true</UseWPF>
         <UseWindowsForms>true</UseWindowsForms>
         <NoWarn>$(NoWarn);NU5105</NoWarn>


### PR DESCRIPTION
### Issues
Fixes (none)

### Proposed changes
Updated some outdated information on the readme and enriched it a bit. Also dropped .netcore 3.x and .net 5 support in favor of .netstandard2.0 (Core) and .net6.0-windows (Windows)

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
