### PR TITLE
Improve WebPack Support (Step 1)

### DIFF
--- a/src/platform/javascript/BrowserUiFacade.ts
+++ b/src/platform/javascript/BrowserUiFacade.ts
@@ -498,7 +498,10 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
 
         let player: AlphaSynthWebWorkerApi | null = null;
         let supportsScriptProcessor: boolean = 'ScriptProcessorNode' in window;
-        let supportsAudioWorklets: boolean = window.isSecureContext && 'AudioWorkletNode' in window;
+
+        // Once https://github.com/webpack/webpack/issues/11543 is decided
+        // we can support audio worklets together with WebPack
+        let supportsAudioWorklets: boolean = window.isSecureContext && 'AudioWorkletNode' in window && !Environment.isWebPackBundled;
 
         if (supportsAudioWorklets) {
             Logger.debug('Player', 'Will use webworkers for synthesizing and web audio api with worklets for playback');


### PR DESCRIPTION
### Issues
Relates to #759 

### Proposed changes
Adds detection for WebPack bundling and 
1. activates WebPack compatible WebWorker creation
2. Disabling of Audio Worklets as they are currently not supported. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website
