### PR TITLE
Allow skia library load to fail gracefully

### DIFF
--- a/src.csharp/AlphaTab/Platform/CSharp/SkiaCanvas.cs
+++ b/src.csharp/AlphaTab/Platform/CSharp/SkiaCanvas.cs
@@ -36,21 +36,28 @@ namespace AlphaTab.Platform.CSharp
                 default:
                     var libSkiaSharpPath =
                         Path.GetDirectoryName(typeof(SkiaCanvas).Assembly.Location);
-                    var platformName = IntPtr.Size == 4 ? "win-x86" : "win-x64";
-                    libSkiaSharpPath = Path.Combine(libSkiaSharpPath, "runtimes", platformName,
-                        "native", "libSkiaSharp.dll");
+                    try
+                    {
+                        var platformName = IntPtr.Size == 4 ? "win-x86" : "win-x64";
+                        libSkiaSharpPath = Path.Combine(libSkiaSharpPath, "runtimes", platformName,
+                            "native", "libSkiaSharp.dll");
 
-                    Logger.Debug("Skia", "Loading native lib from '" + libSkiaSharpPath + "'");
-                    var lib = LoadLibrary(libSkiaSharpPath);
-                    if (lib == IntPtr.Zero)
-                    {
-                        Logger.Warning("Skia",
-                            "Loading native lib from '" + libSkiaSharpPath + "' failed");
+                        Logger.Debug("Skia", "Loading native lib from '" + libSkiaSharpPath + "'");
+                        var lib = LoadLibrary(libSkiaSharpPath);
+                        if (lib == IntPtr.Zero)
+                        {
+                            Logger.Warning("Skia",
+                                "Loading native lib from '" + libSkiaSharpPath + "' failed");
+                        }
+                        else
+                        {
+                            Logger.Debug("Skia",
+                                "Loading native lib from '" + libSkiaSharpPath + "' successful");
+                        }
                     }
-                    else
+                    catch
                     {
-                        Logger.Debug("Skia",
-                            "Loading native lib from '" + libSkiaSharpPath + "' successful");
+                        Logger.Warning("Skia", $"Loading native lib from '{libSkiaSharpPath}' failed");
                     }
 
                     break;


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Fixes #774 

### Proposed changes
The current SkiaCanvas implementation fails when an exception is thrown locating the libSkiaCanvas library. This change emits a warning instead of an exception and proceeds. This enables the use of the SkiaCanvas renderer in Avalonia UI (see tablature section of test app https://scalex.soundshed.com/)

### Checklist
- [ X] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [ X] Changes are implemented
- [ X] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
