### PR TITLE
Added event for changed playback ranges.

### DIFF
--- a/src.csharp/AlphaTab/Platform/CSharp/AlphaSynthWorkerApiBase.cs
+++ b/src.csharp/AlphaTab/Platform/CSharp/AlphaSynthWorkerApiBase.cs
@@ -36,6 +36,7 @@ namespace AlphaTab.Platform.CSharp
             Player.MidiLoadFailed.On(OnMidiLoadFailed);
             Player.ReadyForPlayback.On(OnReadyForPlayback);
             Player.MidiEventsPlayed.On(OnMidiEventsPlayed);
+            Player.PlaybackRangeChanged.On(OnPlaybackRangeChanged);
 
             DispatchOnUiThread(OnReady);
         }
@@ -186,6 +187,7 @@ namespace AlphaTab.Platform.CSharp
         public IEventEmitterOfT<PlayerStateChangedEventArgs> StateChanged { get; } = new EventEmitterOfT<PlayerStateChangedEventArgs>();
         public IEventEmitterOfT<PositionChangedEventArgs> PositionChanged { get; } = new EventEmitterOfT<PositionChangedEventArgs>();
         public IEventEmitterOfT<MidiEventsPlayedEventArgs> MidiEventsPlayed { get; } = new EventEmitterOfT<MidiEventsPlayedEventArgs>();
+        public IEventEmitterOfT<PlaybackRangeChangedEventArgs> PlaybackRangeChanged { get; } = new EventEmitterOfT<PlaybackRangeChangedEventArgs>();
 
         protected virtual void OnReady()
         {
@@ -235,6 +237,11 @@ namespace AlphaTab.Platform.CSharp
         protected virtual void OnPositionChanged(PositionChangedEventArgs obj)
         {
             DispatchOnUiThread(() => ((EventEmitterOfT<PositionChangedEventArgs>)PositionChanged).Trigger(obj));
+        }
+
+        protected virtual void OnPlaybackRangeChanged(PlaybackRangeChangedEventArgs obj)
+        {
+            DispatchOnUiThread(() => ((EventEmitterOfT<PlaybackRangeChangedEventArgs>)PlaybackRangeChanged).Trigger(obj));
         }
     }
 }

--- a/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidThreadAlphaSynthWorkerPlayer.kt
+++ b/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidThreadAlphaSynthWorkerPlayer.kt
@@ -107,6 +107,9 @@ internal class AndroidThreadAlphaSynthWorkerPlayer : IAlphaSynth, Runnable {
         player.midiEventsPlayed.on {
             _uiInvoke { onMidiEventsPlayed(it) }
         }
+        player.playbackRangeChanged.on {
+            _uiInvoke { onPlaybackRangeChanged(it) }
+        }
 
         _uiInvoke { onReady() }
     }
@@ -253,6 +256,8 @@ internal class AndroidThreadAlphaSynthWorkerPlayer : IAlphaSynth, Runnable {
         EventEmitterOfT()
     override val midiEventsPlayed: IEventEmitterOfT<MidiEventsPlayedEventArgs> =
         EventEmitterOfT()
+    override val playbackRangeChanged: IEventEmitterOfT<PlaybackRangeChangedEventArgs> =
+        EventEmitterOfT()
 
 
     private fun onReady() {
@@ -293,5 +298,9 @@ internal class AndroidThreadAlphaSynthWorkerPlayer : IAlphaSynth, Runnable {
 
     private fun onPositionChanged(obj: PositionChangedEventArgs) {
         _uiInvoke { (positionChanged as EventEmitterOfT<PositionChangedEventArgs>).trigger(obj) }
+    }
+
+    private fun onPlaybackRangeChanged(obj: PlaybackRangeChangedEventArgs) {
+        _uiInvoke { (playbackRangeChanged as EventEmitterOfT<PlaybackRangeChangedEventArgs>).trigger(obj) }
     }
 }

--- a/src/AlphaTabApiBase.ts
+++ b/src/AlphaTabApiBase.ts
@@ -42,6 +42,7 @@ import { AlphaTabError, AlphaTabErrorType } from '@src/AlphaTabError';
 import { Note } from '@src/model/Note';
 import { MidiEventType } from '@src/midi/MidiEvent';
 import { MidiEventsPlayedEventArgs } from '@src/synth/MidiEventsPlayedEventArgs';
+import { PlaybackRangeChangedEventArgs } from './synth/PlaybackRangeChangedEventArgs';
 
 class SelectionInfo {
     public beat: Beat;
@@ -579,6 +580,7 @@ export class AlphaTabApiBase<TSettings> {
         this.player.stateChanged.on(this.onPlayerStateChanged.bind(this));
         this.player.positionChanged.on(this.onPlayerPositionChanged.bind(this));
         this.player.midiEventsPlayed.on(this.onMidiEventsPlayed.bind(this));
+        this.player.playbackRangeChanged.on(this.onPlaybackRangeChanged.bind(this));
         this.player.finished.on(this.onPlayerFinished.bind(this));
         if (this.settings.player.enableCursor) {
             this.setupCursors();
@@ -775,6 +777,7 @@ export class AlphaTabApiBase<TSettings> {
         this._playerState = PlayerState.Paused;
         // we need to update our position caches if we render a tablature
         this.renderer.postRenderFinished.on(() => {
+            debugger;
             this.cursorUpdateTick(this._previousTick, false, this._previousTick > 10);
         });
         if (this.player) {
@@ -1412,5 +1415,15 @@ export class AlphaTabApiBase<TSettings> {
         }
         (this.midiEventsPlayed as EventEmitterOfT<MidiEventsPlayedEventArgs>).trigger(e);
         this.uiFacade.triggerEvent(this.container, 'midiEventsPlayed', e);
+    }
+
+    public playbackRangeChanged: IEventEmitterOfT<PlaybackRangeChangedEventArgs> =
+        new EventEmitterOfT<PlaybackRangeChangedEventArgs>();
+    private onPlaybackRangeChanged(e: PlaybackRangeChangedEventArgs): void {
+        if (this._isDestroyed) {
+            return;
+        }
+        (this.playbackRangeChanged as EventEmitterOfT<PlaybackRangeChangedEventArgs>).trigger(e);
+        this.uiFacade.triggerEvent(this.container, 'playbackRangeChanged', e);
     }
 }

--- a/src/AlphaTabApiBase.ts
+++ b/src/AlphaTabApiBase.ts
@@ -42,7 +42,7 @@ import { AlphaTabError, AlphaTabErrorType } from '@src/AlphaTabError';
 import { Note } from '@src/model/Note';
 import { MidiEventType } from '@src/midi/MidiEvent';
 import { MidiEventsPlayedEventArgs } from '@src/synth/MidiEventsPlayedEventArgs';
-import { PlaybackRangeChangedEventArgs } from './synth/PlaybackRangeChangedEventArgs';
+import { PlaybackRangeChangedEventArgs } from '@src/synth/PlaybackRangeChangedEventArgs';
 
 class SelectionInfo {
     public beat: Beat;

--- a/src/platform/javascript/AlphaSynthWebWorker.ts
+++ b/src/platform/javascript/AlphaSynthWebWorker.ts
@@ -7,6 +7,7 @@ import { IWorkerScope } from '@src/platform/javascript/IWorkerScope';
 import { Logger } from '@src/Logger';
 import { Environment } from '@src/Environment';
 import { MidiEventsPlayedEventArgs } from '@src/synth/MidiEventsPlayedEventArgs';
+import { PlaybackRangeChangedEventArgs } from '@src/synth/PlaybackRangeChangedEventArgs';
 
 /**
  * This class implements a HTML5 WebWorker based version of alphaSynth
@@ -32,6 +33,7 @@ export class AlphaSynthWebWorker {
         this._player.midiLoadFailed.on(this.onMidiLoadFailed.bind(this));
         this._player.readyForPlayback.on(this.onReadyForPlayback.bind(this));
         this._player.midiEventsPlayed.on(this.onMidiEventsPlayed.bind(this));
+        this._player.playbackRangeChanged.on(this.onPlaybackRangeChanged.bind(this));
         this._main.postMessage({
             cmd: 'alphaSynth.ready'
         });
@@ -211,6 +213,13 @@ export class AlphaSynthWebWorker {
         this._main.postMessage({
             cmd: 'alphaSynth.midiEventsPlayed',
             events: args.events.map(JsonConverter.midiEventToJsObject)
+        });
+    }
+
+    public onPlaybackRangeChanged(args: PlaybackRangeChangedEventArgs): void {
+        this._main.postMessage({
+            cmd: 'alphaSynth.playbackRangeChanged',
+            playbackRange: args.playbackRange
         });
     }
 }

--- a/src/platform/javascript/AlphaSynthWebWorkerApi.ts
+++ b/src/platform/javascript/AlphaSynthWebWorkerApi.ts
@@ -16,6 +16,7 @@ import { FileLoadError } from '@src/FileLoadError';
 import { MidiEventsPlayedEventArgs } from '@src/synth/MidiEventsPlayedEventArgs';
 import { MidiEventType } from '@src/midi/MidiEvent';
 import { Environment } from '@src/Environment';
+import { PlaybackRangeChangedEventArgs } from '@src/synth/PlaybackRangeChangedEventArgs';
 
 /**
  * a WebWorker based alphaSynth which uses the given player as output.
@@ -375,6 +376,12 @@ export class AlphaSynthWebWorkerApi implements IAlphaSynth {
                     new PlayerStateChangedEventArgs(data.state, data.stopped)
                 );
                 break;
+            case 'alphaSynth.playbackRangeChanged':
+                this._playbackRange = (data as PlaybackRangeChangedEventArgs).playbackRange;
+                (this.playbackRangeChanged as EventEmitterOfT<PlaybackRangeChangedEventArgs>).trigger(
+                    new PlaybackRangeChangedEventArgs(this._playbackRange)
+                );
+                break;            
             case 'alphaSynth.finished':
                 (this.finished as EventEmitter).trigger();
                 break;
@@ -441,6 +448,9 @@ export class AlphaSynthWebWorkerApi implements IAlphaSynth {
     >(); 
     readonly midiEventsPlayed: IEventEmitterOfT<MidiEventsPlayedEventArgs> = new EventEmitterOfT<
         MidiEventsPlayedEventArgs
+    >();
+    readonly playbackRangeChanged: IEventEmitterOfT<PlaybackRangeChangedEventArgs> = new EventEmitterOfT<
+        PlaybackRangeChangedEventArgs
     >();
 
     //

--- a/src/synth/AlphaSynth.ts
+++ b/src/synth/AlphaSynth.ts
@@ -18,7 +18,7 @@ import { SynthEvent } from '@src/synth/synthesis/SynthEvent';
 import { Queue } from '@src/synth/ds/Queue';
 import { MidiEventsPlayedEventArgs } from '@src/synth/MidiEventsPlayedEventArgs';
 import { MidiEvent, MidiEventType } from '@src/midi/MidiEvent';
-import { PlaybackRangeChangedEventArgs } from './PlaybackRangeChangedEventArgs';
+import { PlaybackRangeChangedEventArgs } from '@src/synth/PlaybackRangeChangedEventArgs';
 
 /**
  * This is the main synthesizer component which can be used to

--- a/src/synth/AlphaSynth.ts
+++ b/src/synth/AlphaSynth.ts
@@ -18,6 +18,7 @@ import { SynthEvent } from '@src/synth/synthesis/SynthEvent';
 import { Queue } from '@src/synth/ds/Queue';
 import { MidiEventsPlayedEventArgs } from '@src/synth/MidiEventsPlayedEventArgs';
 import { MidiEvent, MidiEventType } from '@src/midi/MidiEvent';
+import { PlaybackRangeChangedEventArgs } from './PlaybackRangeChangedEventArgs';
 
 /**
  * This is the main synthesizer component which can be used to
@@ -139,6 +140,9 @@ export class AlphaSynth implements IAlphaSynth {
         if (value) {
             this.tickPosition = value.startTick;
         }
+        (this.playbackRangeChanged as EventEmitterOfT<PlaybackRangeChangedEventArgs>).trigger(
+            new PlaybackRangeChangedEventArgs(value)
+        );
     }
 
     public get isLooping(): boolean {
@@ -459,4 +463,5 @@ export class AlphaSynth implements IAlphaSynth {
     readonly stateChanged: IEventEmitterOfT<PlayerStateChangedEventArgs> = new EventEmitterOfT<PlayerStateChangedEventArgs>();
     readonly positionChanged: IEventEmitterOfT<PositionChangedEventArgs> = new EventEmitterOfT<PositionChangedEventArgs>();
     readonly midiEventsPlayed: IEventEmitterOfT<MidiEventsPlayedEventArgs> = new EventEmitterOfT<MidiEventsPlayedEventArgs>();
+    readonly playbackRangeChanged: IEventEmitterOfT<PlaybackRangeChangedEventArgs> = new EventEmitterOfT<PlaybackRangeChangedEventArgs>();
 }

--- a/src/synth/IAlphaSynth.ts
+++ b/src/synth/IAlphaSynth.ts
@@ -2,6 +2,7 @@ import { MidiFile } from '@src/midi/MidiFile';
 import { PlaybackRange } from '@src/synth/PlaybackRange';
 import { PlayerState } from '@src/synth/PlayerState';
 import { PlayerStateChangedEventArgs } from '@src/synth/PlayerStateChangedEventArgs';
+import { PlaybackRangeChangedEventArgs } from '@src/synth/PlaybackRangeChangedEventArgs';
 import { PositionChangedEventArgs } from '@src/synth/PositionChangedEventArgs';
 import { IEventEmitter, IEventEmitterOfT } from '@src/EventEmitter';
 import { LogLevel } from '@src/LogLevel';
@@ -204,4 +205,9 @@ export interface IAlphaSynth {
      * The event is fired when certain midi events were sent to the audio output device for playback.
      */
     readonly midiEventsPlayed: IEventEmitterOfT<MidiEventsPlayedEventArgs>;
+
+    /**
+     * The event is fired when the playback range within the player was updated.
+     */
+    readonly playbackRangeChanged: IEventEmitterOfT<PlaybackRangeChangedEventArgs>;
 }

--- a/src/synth/PlaybackRangeChangedEventArgs.ts
+++ b/src/synth/PlaybackRangeChangedEventArgs.ts
@@ -1,0 +1,19 @@
+import { PlaybackRange } from '@src/synth/PlaybackRange';
+
+/**
+ * Represents the info when the playback range changed.
+ */
+export class PlaybackRangeChangedEventArgs {
+    /**
+     * The new playback range.
+     */
+    public readonly playbackRange: PlaybackRange | null;
+
+    /**
+     * Initializes a new instance of the {@link PlaybackRangeChangedEventArgs} class.
+     * @param range The range.
+     */
+    public constructor(playbackRange: PlaybackRange | null) {
+        this.playbackRange = playbackRange;
+    }
+}

--- a/src/synth/index.ts
+++ b/src/synth/index.ts
@@ -2,5 +2,6 @@ export { AlphaSynth } from '@src/synth/AlphaSynth';
 export { PlaybackRange } from '@src/synth/PlaybackRange';
 export { PlayerState } from '@src/synth/PlayerState';
 export { PlayerStateChangedEventArgs } from '@src/synth/PlayerStateChangedEventArgs';
+export { PlaybackRangeChangedEventArgs } from '@src/synth/PlaybackRangeChangedEventArgs';
 export { PositionChangedEventArgs } from '@src/synth/PositionChangedEventArgs';
 export { AlphaSynthWebWorkerApi } from '@src/platform/javascript/AlphaSynthWebWorkerApi';


### PR DESCRIPTION
### Issues
Relates to #732

### Proposed changes
Exposes a new event which is fired whenever the playback range in the player updates. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website
