### PR TITLE
Fix wrong comparison of start/end in reverse selection scenarios

### DIFF
--- a/src/AlphaTabApiBase.ts
+++ b/src/AlphaTabApiBase.ts
@@ -1082,7 +1082,7 @@ export class AlphaTabApiBase<TSettings> {
             // for the selection ensure start < end
             if (this._selectionEnd) {
                 let startTick: number = this._selectionStart!.beat.absolutePlaybackStart;
-                let endTick: number = this._selectionStart!.beat.absolutePlaybackStart;
+                let endTick: number = this._selectionEnd!.beat.absolutePlaybackStart;
                 if (endTick < startTick) {
                     let t: SelectionInfo = this._selectionStart!;
                     this._selectionStart = this._selectionEnd;


### PR DESCRIPTION
### Issues
Fixes #733

### Proposed changes
<!-- Describe the proposed changes -->

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
