### PR TITLE
Rework state handling of one-time-midi

### DIFF
--- a/src.csharp/AlphaTab.Windows/NAudioSynthOutput.cs
+++ b/src.csharp/AlphaTab.Windows/NAudioSynthOutput.cs
@@ -128,13 +128,14 @@ namespace AlphaTab
         public override int Read(float[] buffer, int offset, int count)
         {
             var read = new Float32Array(count);
-            _circularBuffer.Read(read, 0, System.Math.Min(read.Length, _circularBuffer.Count));
+            
+            var samplesFromBuffer = _circularBuffer.Read(read, 0, System.Math.Min(read.Length, _circularBuffer.Count));
 
             Buffer.BlockCopy(read.Data, 0, buffer, offset * sizeof(float),
                 count * sizeof(float));
 
             var samples = count / 2;
-            ((EventEmitterOfT<double>) SamplesPlayed).Trigger(samples);
+            ((EventEmitterOfT<double>) SamplesPlayed).Trigger(samples / SynthConstants.AudioChannels);
 
             RequestBuffers();
 

--- a/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidAudioWorker.kt
+++ b/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidAudioWorker.kt
@@ -48,12 +48,12 @@ internal class AndroidAudioWorker(
     private fun writeSamples() {
         while (!_stopped) {
             if (_track.playState == AudioTrack.PLAYSTATE_PLAYING) {
-                _output.read(_buffer, 0, _buffer.size)
+                val samplesFromBuffer = _output.read(_buffer, 0, _buffer.size)
                 if (_previousPosition == -1) {
                     _previousPosition = _track.playbackHeadPosition
                     _track.getTimestamp(_timestamp)
                 }
-                _track.write(_buffer, 0, _buffer.size, AudioTrack.WRITE_BLOCKING)
+                _track.write(_buffer, 0, samplesFromBuffer, AudioTrack.WRITE_BLOCKING)
             } else {
                 _playingSemaphore.acquire() // wait for playing to start
                 _playingSemaphore.release() // release semaphore for others

--- a/src/AlphaTabApiBase.ts
+++ b/src/AlphaTabApiBase.ts
@@ -777,7 +777,6 @@ export class AlphaTabApiBase<TSettings> {
         this._playerState = PlayerState.Paused;
         // we need to update our position caches if we render a tablature
         this.renderer.postRenderFinished.on(() => {
-            debugger;
             this.cursorUpdateTick(this._previousTick, false, this._previousTick > 10);
         });
         if (this.player) {

--- a/src/AlphaTabApiBase.ts
+++ b/src/AlphaTabApiBase.ts
@@ -995,7 +995,7 @@ export class AlphaTabApiBase<TSettings> {
                         if (
                             nextBeatBoundings &&
                             nextBeatBoundings.barBounds.masterBarBounds.staveGroupBounds ===
-                                barBoundings.staveGroupBounds
+                            barBoundings.staveGroupBounds
                         ) {
                             nextBeatX = nextBeatBoundings.visualBounds.x;
                         }
@@ -1033,12 +1033,17 @@ export class AlphaTabApiBase<TSettings> {
     }
 
     private _beatMouseDown: boolean = false;
+    private _noteMouseDown: boolean = false;
     private _selectionStart: SelectionInfo | null = null;
     private _selectionEnd: SelectionInfo | null = null;
 
     public beatMouseDown: IEventEmitterOfT<Beat> = new EventEmitterOfT<Beat>();
     public beatMouseMove: IEventEmitterOfT<Beat> = new EventEmitterOfT<Beat>();
     public beatMouseUp: IEventEmitterOfT<Beat | null> = new EventEmitterOfT<Beat | null>();
+
+    public noteMouseDown: IEventEmitterOfT<Note> = new EventEmitterOfT<Note>();
+    public noteMouseMove: IEventEmitterOfT<Note> = new EventEmitterOfT<Note>();
+    public noteMouseUp: IEventEmitterOfT<Note | null> = new EventEmitterOfT<Note | null>();
 
     private onBeatMouseDown(originalEvent: IMouseEventArgs, beat: Beat): void {
         if (this._isDestroyed) {
@@ -1058,6 +1063,16 @@ export class AlphaTabApiBase<TSettings> {
         this.uiFacade.triggerEvent(this.container, 'beatMouseDown', beat, originalEvent);
     }
 
+    private onNoteMouseDown(originalEvent: IMouseEventArgs, note: Note): void {
+        if (this._isDestroyed) {
+            return;
+        }
+
+        this._noteMouseDown = true;
+        (this.noteMouseDown as EventEmitterOfT<Note>).trigger(note);
+        this.uiFacade.triggerEvent(this.container, 'noteMouseDown', note, originalEvent);
+    }
+
     private onBeatMouseMove(originalEvent: IMouseEventArgs, beat: Beat): void {
         if (this._isDestroyed) {
             return;
@@ -1071,6 +1086,15 @@ export class AlphaTabApiBase<TSettings> {
         }
         (this.beatMouseMove as EventEmitterOfT<Beat>).trigger(beat);
         this.uiFacade.triggerEvent(this.container, 'beatMouseMove', beat, originalEvent);
+    }
+
+    private onNoteMouseMove(originalEvent: IMouseEventArgs, note: Note): void {
+        if (this._isDestroyed) {
+            return;
+        }
+
+        (this.noteMouseMove as EventEmitterOfT<Note>).trigger(note);
+        this.uiFacade.triggerEvent(this.container, 'noteMouseMove', note, originalEvent);
     }
 
     private onBeatMouseUp(originalEvent: IMouseEventArgs, beat: Beat | null): void {
@@ -1128,6 +1152,17 @@ export class AlphaTabApiBase<TSettings> {
         this._beatMouseDown = false;
     }
 
+
+    private onNoteMouseUp(originalEvent: IMouseEventArgs, note: Note | null): void {
+        if (this._isDestroyed) {
+            return;
+        }
+
+        (this.noteMouseUp as EventEmitterOfT<Note | null>).trigger(note);
+        this.uiFacade.triggerEvent(this.container, 'noteMouseUp', note, originalEvent);
+        this._noteMouseDown = false;
+    }
+
     private updateSelectionCursor(range: PlaybackRange | null) {
         if (!this._tickCache) {
             return;
@@ -1158,6 +1193,14 @@ export class AlphaTabApiBase<TSettings> {
             let beat: Beat | null = this.renderer.boundsLookup?.getBeatAtPos(relX, relY) ?? null;
             if (beat) {
                 this.onBeatMouseDown(e, beat);
+
+                if (this.settings.core.includeNoteBounds) {
+                    const note = this.renderer.boundsLookup?.getNoteAtPos(beat, relX, relY);
+                    if (note) {
+                        this.onNoteMouseDown(e, note);
+                    }
+                }
+
             }
         });
         this.canvasElement.mouseMove.on(e => {
@@ -1169,6 +1212,13 @@ export class AlphaTabApiBase<TSettings> {
             let beat: Beat | null = this.renderer.boundsLookup?.getBeatAtPos(relX, relY) ?? null;
             if (beat) {
                 this.onBeatMouseMove(e, beat);
+
+                if (this._noteMouseDown) {
+                    const note = this.renderer.boundsLookup?.getNoteAtPos(beat, relX, relY);
+                    if (note) {
+                        this.onNoteMouseMove(e, note);
+                    }
+                }
             }
         });
         this.canvasElement.mouseUp.on(e => {
@@ -1182,6 +1232,16 @@ export class AlphaTabApiBase<TSettings> {
             let relY: number = e.getY(this.canvasElement);
             let beat: Beat | null = this.renderer.boundsLookup?.getBeatAtPos(relX, relY) ?? null;
             this.onBeatMouseUp(e, beat);
+
+            if (this._noteMouseDown) {
+                if (beat) {
+                    const note = this.renderer.boundsLookup?.getNoteAtPos(beat, relX, relY) ?? null;
+                    this.onNoteMouseUp(e, note);
+                }
+                else {
+                    this.onNoteMouseUp(e, null);
+                }
+            }
         });
         this.renderer.postRenderFinished.on(() => {
             if (

--- a/src/midi/MidiFileGenerator.ts
+++ b/src/midi/MidiFileGenerator.ts
@@ -1362,7 +1362,7 @@ export class MidiFileGenerator {
         this.prepareSingleBeat(note.beat);
         this.generateNote(
             note,
-            -note.beat.playbackStart,
+            0,
             note.beat.playbackDuration,
             new Int32Array(note.beat.voice.bar.staff.tuning.length)
         );

--- a/src/platform/javascript/AlphaSynthAudioWorkletOutput.ts
+++ b/src/platform/javascript/AlphaSynthAudioWorkletOutput.ts
@@ -3,6 +3,7 @@ import { Environment } from '@src/Environment';
 import { Logger } from '@src/Logger';
 import { AlphaSynthWorkerSynthOutput } from '@src/platform/javascript/AlphaSynthWorkerSynthOutput';
 import { AlphaSynthWebAudioOutputBase } from '@src/platform/javascript/AlphaSynthWebAudioOutputBase';
+import { SynthConstants } from '@src/synth/SynthConstants';
 
 /**
  * @target web
@@ -58,7 +59,7 @@ export class AlphaSynthWebWorklet {
                 constructor(...args: any[]) {
                     super(...args);
 
-                    Logger.info('WebAudio', 'creating processor');
+                    Logger.debug('WebAudio', 'creating processor');
 
                     this._bufferCount = Math.floor(
                         (AlphaSynthWebWorkletProcessor.TotalBufferTimeInMilliseconds *
@@ -110,7 +111,7 @@ export class AlphaSynthWebWorklet {
                         buffer = new Float32Array(samples);
                         this._outputBuffer = buffer;
                     }
-                    this._circularBuffer.read(buffer, 0, Math.min(buffer.length, this._circularBuffer.count));
+                    const samplesFromBuffer = this._circularBuffer.read(buffer, 0, Math.min(buffer.length, this._circularBuffer.count));
                     let s: number = 0;
                     for (let i: number = 0; i < left.length; i++) {
                         left[i] = buffer[s++];
@@ -118,7 +119,7 @@ export class AlphaSynthWebWorklet {
                     }
                     this.port.postMessage({
                         cmd: AlphaSynthWorkerSynthOutput.CmdOutputSamplesPlayed,
-                        samples: left.length
+                        samples: samplesFromBuffer / SynthConstants.AudioChannels
                     });
                     this.requestBuffers();
 

--- a/src/platform/javascript/AlphaSynthScriptProcessorOutput.ts
+++ b/src/platform/javascript/AlphaSynthScriptProcessorOutput.ts
@@ -1,5 +1,6 @@
 import { CircularSampleBuffer } from '@src/synth/ds/CircularSampleBuffer';
 import { AlphaSynthWebAudioOutputBase } from '@src/platform/javascript/AlphaSynthWebAudioOutputBase';
+import { SynthConstants } from '@src/synth/SynthConstants';
 
 // tslint:disable: deprecation
 
@@ -86,13 +87,13 @@ export class AlphaSynthScriptProcessorOutput extends AlphaSynthWebAudioOutputBas
             buffer = new Float32Array(samples);
             this._outputBuffer = buffer;
         }
-        this._circularBuffer.read(buffer, 0, Math.min(buffer.length, this._circularBuffer.count));
+        const samplesFromBuffer = this._circularBuffer.read(buffer, 0, Math.min(buffer.length, this._circularBuffer.count));
         let s: number = 0;
         for (let i: number = 0; i < left.length; i++) {
             left[i] = buffer[s++];
             right[i] = buffer[s++];
         }
-        this.onSamplesPlayed(left.length);
+        this.onSamplesPlayed(samplesFromBuffer / SynthConstants.AudioChannels);
         this.requestBuffers();
     }
 }

--- a/src/platform/javascript/BrowserUiFacade.ts
+++ b/src/platform/javascript/BrowserUiFacade.ts
@@ -472,7 +472,9 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
             // remember which bar is contained in which node for faster lookup
             // on highlight/unhighlight
             for (let i = renderResult.firstMasterBarIndex; i <= renderResult.lastMasterBarIndex; i++) {
-                this._barToElementLookup.set(i, placeholder);
+                if(i >= 0) {
+                    this._barToElementLookup.set(i, placeholder);
+                }
             }
 
             if (this._api.settings.core.enableLazyLoading) {

--- a/src/rendering/RenderFinishedEventArgs.ts
+++ b/src/rendering/RenderFinishedEventArgs.ts
@@ -42,12 +42,12 @@ export class RenderFinishedEventArgs {
     /**
      * Gets or sets the index of the first masterbar that was rendered in this result.
      */
-    public firstMasterBarIndex: number = 0;
+    public firstMasterBarIndex: number = -1;
 
     /**
      * Gets or sets the index of the last masterbar that was rendered in this result.
      */
-    public lastMasterBarIndex: number = 0;
+    public lastMasterBarIndex: number = -1;
 
     /**
      * Gets or sets the render engine specific result object which contains the rendered music sheet.

--- a/src/rendering/glyphs/NoteNumberGlyph.ts
+++ b/src/rendering/glyphs/NoteNumberGlyph.ts
@@ -112,6 +112,6 @@ export class NoteNumberGlyph extends Glyph {
         noteBounds.noteHeadBounds.y = cy + this.y - this.height/2;
         noteBounds.noteHeadBounds.w = this.width;
         noteBounds.noteHeadBounds.h = this.height;
-        this.renderer.scoreRenderer.boundsLookup!.addNote(noteBounds);
+        beatBounds.addNote(noteBounds);
     }
 }

--- a/src/rendering/layout/PageViewLayout.ts
+++ b/src/rendering/layout/PageViewLayout.ts
@@ -122,8 +122,6 @@ export class PageViewLayout extends ScoreLayout {
         e.height = tuningHeight;
         e.totalWidth = this.width;
         e.totalHeight = totalHeight < 0 ? y + e.height : totalHeight;
-        e.firstMasterBarIndex = -1;
-        e.lastMasterBarIndex = -1;
 
         this.registerPartial(e, (canvas: ICanvas) => {
             canvas.color = res.scoreInfoColor;
@@ -151,8 +149,6 @@ export class PageViewLayout extends ScoreLayout {
         e.height = diagramHeight;
         e.totalWidth = this.width;
         e.totalHeight = totalHeight < 0 ? y + diagramHeight : totalHeight;
-        e.firstMasterBarIndex = -1;
-        e.lastMasterBarIndex = -1;
 
         this.registerPartial(e, (canvas: ICanvas) => {
             canvas.color = res.scoreInfoColor;
@@ -218,8 +214,6 @@ export class PageViewLayout extends ScoreLayout {
         e.height = infoHeight;
         e.totalWidth = this.width;
         e.totalHeight = totalHeight < 0 ? y + e.height : totalHeight;
-        e.firstMasterBarIndex = -1;
-        e.lastMasterBarIndex = -1;
         this.registerPartial(e, (canvas: ICanvas) => {
             canvas.color = res.scoreInfoColor;
             canvas.textAlign = TextAlign.Center;

--- a/src/rendering/utils/BoundsLookup.ts
+++ b/src/rendering/utils/BoundsLookup.ts
@@ -222,6 +222,11 @@ export class BoundsLookup {
         return all ? all[0] : null;
     }
 
+    /**
+     * Tries to find the bounds of a given beat.
+     * @param beat The beat to find.
+     * @returns The beat bounds if it was rendered, or null if no boundary information is available.
+     */
     public findBeats(beat: Beat): BeatBounds[] | null {
         let id: number = beat.id;
         if (this._beatLookup.has(id)) {

--- a/src/rendering/utils/BoundsLookup.ts
+++ b/src/rendering/utils/BoundsLookup.ts
@@ -128,7 +128,7 @@ export class BoundsLookup {
         return json;
     }
 
-    private _beatLookup: Map<number, BeatBounds> = new Map();
+    private _beatLookup: Map<number, BeatBounds[]> = new Map();
     private _masterBarLookup: Map<number, MasterBarBounds> = new Map();
     private _currentStaveGroup: StaveGroupBounds | null = null;
     /**
@@ -149,15 +149,6 @@ export class BoundsLookup {
             t.finish();
         }
         this.isFinished = true;
-    }
-
-    /**
-     * Adds a new note to the lookup.
-     * @param bounds The note bounds to add.
-     */
-    public addNote(bounds: NoteBounds): void {
-        let beat = this.findBeat(bounds.note.beat);
-        beat!.addNote(bounds);
     }
 
     /**
@@ -190,7 +181,10 @@ export class BoundsLookup {
      * @param bounds The beat bounds to add.
      */
     public addBeat(bounds: BeatBounds): void {
-        this._beatLookup.set(bounds.beat.id, bounds);
+        if (!this._beatLookup.has(bounds.beat.id)) {
+            this._beatLookup.set(bounds.beat.id, []);
+        }
+        this._beatLookup.get(bounds.beat.id)?.push(bounds);
     }
 
     /**
@@ -224,6 +218,11 @@ export class BoundsLookup {
      * @returns The beat bounds if it was rendered, or null if no boundary information is available.
      */
     public findBeat(beat: Beat): BeatBounds | null {
+        const all = this.findBeats(beat);
+        return all ? all[0] : null;
+    }
+
+    public findBeats(beat: Beat): BeatBounds[] | null {
         let id: number = beat.id;
         if (this._beatLookup.has(id)) {
             return this._beatLookup.get(id)!;
@@ -281,10 +280,15 @@ export class BoundsLookup {
      * @returns The note at the given position within the beat.
      */
     public getNoteAtPos(beat: Beat, x: number, y: number): Note | null {
-        let beatBounds: BeatBounds | null = this.findBeat(beat);
-        if (!beatBounds) {
-            return null;
+        const beatBounds = this.findBeats(beat);
+        if (beatBounds) {
+            for (const b of beatBounds) {
+                const note = b.findNoteAtPos(x, y);
+                if (note) {
+                    return note;
+                }
+            }
         }
-        return beatBounds.findNoteAtPos(x, y);
+        return null;
     }
 }

--- a/src/synth/AlphaSynth.ts
+++ b/src/synth/AlphaSynth.ts
@@ -218,7 +218,6 @@ export class AlphaSynth implements IAlphaSynth {
                     samples = samples.subarray(0, bufferPos);
                 }
                 this._notPlayedSamples += samples.length;
-                Logger.debug('AlphaSynth', `NotPlayedSamples ${this._notPlayedSamples} (+${samples.length})`);
                 this.output.addSamples(samples);
             }
         });
@@ -412,10 +411,6 @@ export class AlphaSynth implements IAlphaSynth {
         }
         let playedMillis: number = (sampleCount / this._synthesizer.outSampleRate) * 1000;
         this._notPlayedSamples -= sampleCount * SynthConstants.AudioChannels;
-        Logger.debug(
-            'AlphaSynth',
-            `NotPlayedSamples ${this._notPlayedSamples} (-${sampleCount * SynthConstants.AudioChannels})`
-        );
         this.updateTimePosition(this._timePosition + playedMillis, false);
         this.checkForFinish();
     }


### PR DESCRIPTION
### Issues
Fixes #758

### Proposed changes
Reworks quite some internals of the synthesizer to ensure that the one time midi playback behind playBeat and playBeat are working correctly. it suffered from following issues: 

- Seeking during playback interfered with the playback position of the one time midi while it should seek on the main song midi. When playing notes/beats on mouse click, there happened a playback and seeking which messed up a lot of internals. 
- Multiple subsequent requests of playing one time midis before they actually finished also messed up some internal states. 
- The synth outputs reported also played samples if there weren't enough samples in the buffer. This wrongly advanced the internal player time axis. 
- The bounds lookup had a wrong assumption that there is only one bounds for a beat, but there can be multiple, due to this `findNoteAt` did not work correctly.
- There was a wrong time value passed to the midi note generation of playNote leading the note to never being played. 

- New: Events when a note is clicked. These events are available if the note bounds are included. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website
