### PR TITLE
Make audio buffer configurable

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -47,7 +47,8 @@ module.exports = function (config) {
             clearContext: false,
             jasmine: {
                 random: false,
-                stopSpecOnExpectationFailure: false
+                stopSpecOnExpectationFailure: false.valueOf,
+                timeoutInterval: 30000
             }
         },
 

--- a/src.csharp/AlphaTab.Windows/NAudioSynthOutput.cs
+++ b/src.csharp/AlphaTab.Windows/NAudioSynthOutput.cs
@@ -14,7 +14,6 @@ namespace AlphaTab
     {
         private const int BufferSize = 4096;
         private const int PreferredSampleRate = 44100;
-        private const int TotalBufferTimeInMilliseconds = 5000;
         
         private DirectSoundOut _context;
         private CircularSampleBuffer _circularBuffer;
@@ -41,10 +40,10 @@ namespace AlphaTab
 
 
         /// <inheritdoc />
-        public void Open()
+        public void Open(double bufferTimeInMilliseconds)
         {
             _bufferCount = (int)(
-                (TotalBufferTimeInMilliseconds * PreferredSampleRate) /
+                (bufferTimeInMilliseconds * PreferredSampleRate) /
                 1000 /
                 BufferSize
             );

--- a/src.csharp/AlphaTab/Platform/CSharp/AlphaSynthWorkerApiBase.cs
+++ b/src.csharp/AlphaTab/Platform/CSharp/AlphaSynthWorkerApiBase.cs
@@ -10,13 +10,15 @@ namespace AlphaTab.Platform.CSharp
     {
         private readonly ISynthOutput _output;
         private LogLevel _logLevel;
+        private double _bufferTimeInMilliseconds;
 
         protected AlphaSynth Player;
 
-        protected AlphaSynthWorkerApiBase(ISynthOutput output, LogLevel logLevel)
+        protected AlphaSynthWorkerApiBase(ISynthOutput output, LogLevel logLevel, double bufferTimeInMilliseconds)
         {
             _output = output;
             _logLevel = logLevel;
+            _bufferTimeInMilliseconds = bufferTimeInMilliseconds;
             Player = null!;
         }
 
@@ -26,7 +28,7 @@ namespace AlphaTab.Platform.CSharp
 
         protected void Initialize()
         {
-            Player = new AlphaSynth(_output);
+            Player = new AlphaSynth(_output, _bufferTimeInMilliseconds);
             Player.PositionChanged.On(OnPositionChanged);
             Player.StateChanged.On(OnStateChanged);
             Player.Finished.On(OnFinished);

--- a/src.csharp/AlphaTab/Platform/CSharp/ManagedThreadAlphaSynthWorkerApi.cs
+++ b/src.csharp/AlphaTab/Platform/CSharp/ManagedThreadAlphaSynthWorkerApi.cs
@@ -13,8 +13,8 @@ namespace AlphaTab.Platform.CSharp
         private CancellationTokenSource _workerCancellationToken;
         private readonly ManualResetEventSlim? _threadStartedEvent;
 
-        public ManagedThreadAlphaSynthWorkerApi(ISynthOutput output, LogLevel logLevel, Action<Action> uiInvoke)
-            : base(output, logLevel)
+        public ManagedThreadAlphaSynthWorkerApi(ISynthOutput output, LogLevel logLevel, Action<Action> uiInvoke, double bufferTimeInMilliseconds)
+            : base(output, logLevel, bufferTimeInMilliseconds)
         {
             _uiInvoke = uiInvoke;
 

--- a/src.csharp/AlphaTab/Platform/CSharp/ManagedUiFacade.cs
+++ b/src.csharp/AlphaTab/Platform/CSharp/ManagedUiFacade.cs
@@ -44,7 +44,7 @@ namespace AlphaTab.Platform.CSharp
         public IAlphaSynth CreateWorkerPlayer()
         {
             var player = new ManagedThreadAlphaSynthWorkerApi(CreateSynthOutput(),
-                Api.Settings.Core.LogLevel, BeginInvoke);
+                Api.Settings.Core.LogLevel, BeginInvoke, Api.Settings.Player.BufferTimeInMilliseconds);
             player.Ready.On(() =>
             {
                 using (var sf = OpenDefaultSoundFont())

--- a/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidSynthOutput.kt
+++ b/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidSynthOutput.kt
@@ -16,7 +16,6 @@ internal class AndroidSynthOutput(
     companion object {
         private const val BufferSize = 4096
         private const val PreferredSampleRate = 44100
-        private const val TotalBufferTimeInMilliseconds = 5000
     }
 
     private var _bufferCount = 0
@@ -31,10 +30,10 @@ internal class AndroidSynthOutput(
     override fun activate() {
     }
 
-    override fun open() {
-        _bufferCount = (TotalBufferTimeInMilliseconds * PreferredSampleRate /
+    override fun open(bufferTimeInMilliseconds: double) {
+        _bufferCount = (bufferTimeInMilliseconds * PreferredSampleRate /
             1000 /
-            BufferSize)
+            BufferSize).toInt()
         _circularBuffer = CircularSampleBuffer((BufferSize * _bufferCount).toDouble())
 
         _audioContext = AndroidAudioWorker(

--- a/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidSynthOutput.kt
+++ b/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidSynthOutput.kt
@@ -30,7 +30,7 @@ internal class AndroidSynthOutput(
     override fun activate() {
     }
 
-    override fun open(bufferTimeInMilliseconds: double) {
+    override fun open(bufferTimeInMilliseconds: Double) {
         _bufferCount = (bufferTimeInMilliseconds * PreferredSampleRate /
             1000 /
             BufferSize).toInt()

--- a/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidThreadAlphaSynthWorkerPlayer.kt
+++ b/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidThreadAlphaSynthWorkerPlayer.kt
@@ -37,7 +37,7 @@ internal class AndroidThreadAlphaSynthWorkerPlayer : IAlphaSynth, Runnable {
         bufferTimeInMilliseconds: Double
     ) {
         _logLevel = logLevel
-        __bufferTimeInMilliseconds = bufferTimeInMilliseconds
+        _bufferTimeInMilliseconds = bufferTimeInMilliseconds
         _output = output
         _uiInvoke = uiInvoke
         _threadStartedEvent = Semaphore(1)

--- a/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidThreadAlphaSynthWorkerPlayer.kt
+++ b/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidThreadAlphaSynthWorkerPlayer.kt
@@ -28,13 +28,13 @@ internal class AndroidThreadAlphaSynthWorkerPlayer : IAlphaSynth, Runnable {
     private var _player: AlphaSynth? = null
     private val _output: ISynthOutput
     private var _logLevel: LogLevel
-    private var _bufferTimeInMilliseconds: double
+    private var _bufferTimeInMilliseconds: Double
 
     constructor(
         logLevel: LogLevel,
         output: ISynthOutput,
         uiInvoke: (action: (() -> Unit)) -> Unit,
-        bufferTimeInMilliseconds: double
+        bufferTimeInMilliseconds: Double
     ) {
         _logLevel = logLevel
         __bufferTimeInMilliseconds = bufferTimeInMilliseconds

--- a/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidThreadAlphaSynthWorkerPlayer.kt
+++ b/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidThreadAlphaSynthWorkerPlayer.kt
@@ -28,13 +28,16 @@ internal class AndroidThreadAlphaSynthWorkerPlayer : IAlphaSynth, Runnable {
     private var _player: AlphaSynth? = null
     private val _output: ISynthOutput
     private var _logLevel: LogLevel
+    private var _bufferTimeInMilliseconds: double
 
     constructor(
         logLevel: LogLevel,
         output: ISynthOutput,
-        uiInvoke: (action: (() -> Unit)) -> Unit
+        uiInvoke: (action: (() -> Unit)) -> Unit,
+        bufferTimeInMilliseconds: double
     ) {
         _logLevel = logLevel
+        __bufferTimeInMilliseconds = bufferTimeInMilliseconds
         _output = output
         _uiInvoke = uiInvoke
         _threadStartedEvent = Semaphore(1)
@@ -78,7 +81,7 @@ internal class AndroidThreadAlphaSynthWorkerPlayer : IAlphaSynth, Runnable {
     }
 
     private fun initialize() {
-        val player = AlphaSynth(_output)
+        val player = AlphaSynth(_output, _bufferTimeInMilliseconds)
         _player = player
         player.positionChanged.on {
             _uiInvoke { onPositionChanged(it) }

--- a/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidUiFacade.kt
+++ b/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidUiFacade.kt
@@ -158,7 +158,8 @@ internal class AndroidUiFacade : IUiFacade<AlphaTabView> {
             AndroidSynthOutput {
                 player!!.addToWorker(it)
             },
-            this::beginInvoke
+            this::beginInvoke,
+            api.settings.player.bufferTimeInMilliseconds
         )
         player.ready.on {
             val soundFont = openDefaultSoundFont()

--- a/src/PlayerSettings.ts
+++ b/src/PlayerSettings.ts
@@ -186,4 +186,11 @@ export class PlayerSettings {
      * Gets or sets whether the triplet feel should be applied/played during audio playback.
      */
     public playTripletFeel: boolean = true;
+
+    /**
+     * Gets or sets how many milliseconds of audio samples should be buffered in total. 
+     * Larger buffers cause a delay from when audio settings like volumes will be applied. 
+     * Smaller buffers can cause audio crackling due to constant buffering that is happening.
+     */
+    public bufferTimeInMilliseconds:number = 500;
 }

--- a/src/generated/PlayerSettingsSerializer.ts
+++ b/src/generated/PlayerSettingsSerializer.ts
@@ -37,6 +37,7 @@ export class PlayerSettingsSerializer {
         o.set("vibrato", VibratoPlaybackSettingsSerializer.toJson(obj.vibrato)); 
         o.set("slide", SlidePlaybackSettingsSerializer.toJson(obj.slide)); 
         o.set("playtripletfeel", obj.playTripletFeel); 
+        o.set("buffertimeinmilliseconds", obj.bufferTimeInMilliseconds); 
         return o; 
     }
     public static setProperty(obj: PlayerSettings, property: string, v: unknown): boolean {
@@ -87,6 +88,9 @@ export class PlayerSettingsSerializer {
                 return true;
             case "playtripletfeel":
                 obj.playTripletFeel = v! as boolean;
+                return true;
+            case "buffertimeinmilliseconds":
+                obj.bufferTimeInMilliseconds = v! as number;
                 return true;
         } 
         if (["vibrato"].indexOf(property) >= 0) {

--- a/src/platform/javascript/AlphaSynthScriptProcessorOutput.ts
+++ b/src/platform/javascript/AlphaSynthScriptProcessorOutput.ts
@@ -15,12 +15,10 @@ export class AlphaSynthScriptProcessorOutput extends AlphaSynthWebAudioOutputBas
     private _bufferCount: number = 0;
     private _requestedBufferCount: number = 0;
 
-    public override open() {
-        super.open();
+    public override open(bufferTimeInMilliseconds: number) {
+        super.open(bufferTimeInMilliseconds);
         this._bufferCount = Math.floor(
-            (AlphaSynthWebAudioOutputBase.TotalBufferTimeInMilliseconds * this.sampleRate) /
-                1000 /
-                AlphaSynthWebAudioOutputBase.BufferSize
+            (bufferTimeInMilliseconds * this.sampleRate) / 1000 / AlphaSynthWebAudioOutputBase.BufferSize
         );
         this._circularBuffer = new CircularSampleBuffer(AlphaSynthWebAudioOutputBase.BufferSize * this._bufferCount);
         this.onReady();
@@ -87,7 +85,11 @@ export class AlphaSynthScriptProcessorOutput extends AlphaSynthWebAudioOutputBas
             buffer = new Float32Array(samples);
             this._outputBuffer = buffer;
         }
-        const samplesFromBuffer = this._circularBuffer.read(buffer, 0, Math.min(buffer.length, this._circularBuffer.count));
+        const samplesFromBuffer = this._circularBuffer.read(
+            buffer,
+            0,
+            Math.min(buffer.length, this._circularBuffer.count)
+        );
         let s: number = 0;
         for (let i: number = 0; i < left.length; i++) {
             left[i] = buffer[s++];

--- a/src/platform/javascript/AlphaSynthWebAudioOutputBase.ts
+++ b/src/platform/javascript/AlphaSynthWebAudioOutputBase.ts
@@ -12,7 +12,6 @@ declare var webkitAudioContext: any;
 export abstract class AlphaSynthWebAudioOutputBase implements ISynthOutput {
     protected static readonly BufferSize: number = 4096;
     protected static readonly PreferredSampleRate: number = 44100;
-    protected static readonly TotalBufferTimeInMilliseconds: number = 5000;
 
     protected _context: AudioContext | null = null;
     protected _buffer: AudioBuffer | null = null;
@@ -75,7 +74,7 @@ export abstract class AlphaSynthWebAudioOutputBase implements ISynthOutput {
         throw new AlphaTabError(AlphaTabErrorType.General, 'AudioContext not found');
     }
 
-    public open(): void {
+    public open(bufferTimeInMilliseconds: number): void {
         this.patchIosSampleRate();
         this._context = this.createAudioContext();
         let ctx: any = this._context;
@@ -83,7 +82,7 @@ export abstract class AlphaSynthWebAudioOutputBase implements ISynthOutput {
             this.registerResumeHandler();
         }
     }
-    
+
     private registerResumeHandler() {
         this._resumeHandler = (() => {
             this.activate(() => {
@@ -93,7 +92,7 @@ export abstract class AlphaSynthWebAudioOutputBase implements ISynthOutput {
         document.body.addEventListener('touchend', this._resumeHandler, false);
         document.body.addEventListener('click', this._resumeHandler, false);
     }
-    
+
     private unregisterResumeHandler() {
         const resumeHandler = this._resumeHandler;
         if (resumeHandler) {

--- a/src/platform/javascript/AlphaSynthWebWorker.ts
+++ b/src/platform/javascript/AlphaSynthWebWorker.ts
@@ -18,11 +18,11 @@ export class AlphaSynthWebWorker {
     private _player: AlphaSynth;
     private _main: IWorkerScope;
 
-    public constructor(main: IWorkerScope) {
+    public constructor(main: IWorkerScope, bufferTimeInMilliseconds:number) {
         this._main = main;
         this._main.addEventListener('message', this.handleMessage.bind(this));
 
-        this._player = new AlphaSynth(new AlphaSynthWorkerSynthOutput());
+        this._player = new AlphaSynth(new AlphaSynthWorkerSynthOutput(), bufferTimeInMilliseconds);
         this._player.positionChanged.on(this.onPositionChanged.bind(this));
         this._player.stateChanged.on(this.onPlayerStateChanged.bind(this));
         this._player.finished.on(this.onFinished.bind(this));
@@ -48,7 +48,7 @@ export class AlphaSynthWebWorker {
                 case 'alphaSynth.initialize':
                     AlphaSynthWorkerSynthOutput.preferredSampleRate = data.sampleRate;
                     Logger.logLevel = data.logLevel;
-                    Environment.globalThis.alphaSynthWebWorker = new AlphaSynthWebWorker(main);
+                    Environment.globalThis.alphaSynthWebWorker = new AlphaSynthWebWorker(main, data.bufferTimeInMilliseconds);
                     break;
             }
         });

--- a/src/platform/javascript/BrowserUiFacade.ts
+++ b/src/platform/javascript/BrowserUiFacade.ts
@@ -472,7 +472,7 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
             // remember which bar is contained in which node for faster lookup
             // on highlight/unhighlight
             for (let i = renderResult.firstMasterBarIndex; i <= renderResult.lastMasterBarIndex; i++) {
-                if(i >= 0) {
+                if (i >= 0) {
                     this._barToElementLookup.set(i, placeholder);
                 }
             }
@@ -511,14 +511,16 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
             player = new AlphaSynthWebWorkerApi(
                 new AlphaSynthAudioWorkletOutput(),
                 alphaSynthScriptFile,
-                this._api.settings.core.logLevel
+                this._api.settings.core.logLevel,
+                this._api.settings.player.bufferTimeInMilliseconds
             );
         } else if (supportsScriptProcessor) {
             Logger.debug('Player', 'Will use webworkers for synthesizing and web audio api for playback');
             player = new AlphaSynthWebWorkerApi(
                 new AlphaSynthScriptProcessorOutput(),
                 alphaSynthScriptFile,
-                this._api.settings.core.logLevel
+                this._api.settings.core.logLevel,
+                this._api.settings.player.bufferTimeInMilliseconds
             );
         }
 

--- a/src/synth/AlphaSynth.ts
+++ b/src/synth/AlphaSynth.ts
@@ -65,7 +65,6 @@ export class AlphaSynth implements IAlphaSynth {
     public set masterVolume(value: number) {
         value = Math.max(value, SynthConstants.MinVolume);
         this._synthesizer.masterVolume = value;
-        this.onAudioSettingsUpdate();
     }
 
     public get metronomeVolume(): number {
@@ -76,7 +75,6 @@ export class AlphaSynth implements IAlphaSynth {
         value = Math.max(value, SynthConstants.MinVolume);
         this._metronomeVolume = value;
         this._synthesizer.metronomeVolume = value;
-        this.onAudioSettingsUpdate();
     }
 
     public get countInVolume(): number {
@@ -167,7 +165,7 @@ export class AlphaSynth implements IAlphaSynth {
      * Initializes a new instance of the {@link AlphaSynth} class.
      * @param output The output to use for playing the generated samples.
      */
-    public constructor(output: ISynthOutput) {
+    public constructor(output: ISynthOutput, bufferTimeInMilliseconds: number) {
         Logger.debug('AlphaSynth', 'Initializing player');
         this.state = PlayerState.Paused;
 
@@ -222,7 +220,7 @@ export class AlphaSynth implements IAlphaSynth {
             }
         });
         this.output.samplesPlayed.on(this.onSamplesPlayed.bind(this));
-        this.output.open();
+        this.output.open(bufferTimeInMilliseconds);
     }
 
     public play(): boolean {
@@ -315,7 +313,7 @@ export class AlphaSynth implements IAlphaSynth {
 
         this.output.play();
     }
-  
+
     public resetSoundFonts(): void {
         this.stop();
         this._synthesizer.resetPresets();
@@ -381,7 +379,6 @@ export class AlphaSynth implements IAlphaSynth {
 
     public setChannelMute(channel: number, mute: boolean): void {
         this._synthesizer.channelSetMute(channel, mute);
-        this.onAudioSettingsUpdate();
     }
 
     public resetChannelStates(): void {
@@ -390,19 +387,11 @@ export class AlphaSynth implements IAlphaSynth {
 
     public setChannelSolo(channel: number, solo: boolean): void {
         this._synthesizer.channelSetSolo(channel, solo);
-        this.onAudioSettingsUpdate();
     }
 
     public setChannelVolume(channel: number, volume: number): void {
         volume = Math.max(volume, SynthConstants.MinVolume);
         this._synthesizer.channelSetMixVolume(channel, volume);
-        this.onAudioSettingsUpdate();
-    }
-    private onAudioSettingsUpdate() {
-        // seeking to the currently known position, will ensure we
-        // clear all audio buffers and re-generate the audio
-        // which was not actually played yet.
-        this.timePosition = this.timePosition;
     }
 
     private onSamplesPlayed(sampleCount: number): void {

--- a/src/synth/ISynthOutput.ts
+++ b/src/synth/ISynthOutput.ts
@@ -14,7 +14,7 @@ export interface ISynthOutput {
     /**
      * Called when the output should be opened.
      */
-    open(): void;
+    open(bufferTimeInMilliseconds: number): void;
 
     /**
      * Called when the output should start the playback.

--- a/test/audio/AlphaSynth.test.ts
+++ b/test/audio/AlphaSynth.test.ts
@@ -24,7 +24,7 @@ describe('AlphaSynthTests', () => {
         let gen: MidiFileGenerator = new MidiFileGenerator(score, null, new AlphaSynthMidiFileHandler(midi));
         gen.generate();
         let testOutput: TestOutput = new TestOutput();
-        let synth: AlphaSynth = new AlphaSynth(testOutput);
+        let synth: AlphaSynth = new AlphaSynth(testOutput, 500);
         synth.loadSoundFont(data, false);
         synth.loadMidiFile(midi);
         synth.play();

--- a/test/audio/TestOutput.ts
+++ b/test/audio/TestOutput.ts
@@ -8,7 +8,7 @@ export class TestOutput implements ISynthOutput {
         return 44100;
     }
 
-    public open(): void {
+    public open(bufferTimeInMilliseconds: number): void {
         this.samples = [];
         (this.ready as EventEmitter).trigger();
     }


### PR DESCRIPTION
### Issues
Fixes #736

### Proposed changes
Exposes a new setting which makes the audio buffering configurable. This should allows integrators to optimize the buffering for their devices. Default is reduced to 500ms which should provide a good experience between delay on setting updates, and no crackling sounds due to buffering

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website
