### PR TITLE
Drop manual loading of native Skia lib

### DIFF
--- a/src.csharp/AlphaTab/Platform/CSharp/SkiaCanvas.cs
+++ b/src.csharp/AlphaTab/Platform/CSharp/SkiaCanvas.cs
@@ -19,43 +19,8 @@ namespace AlphaTab.Platform.CSharp
         private static readonly SKTypeface MusicFont;
         private const int MusicFontSize = 34;
 
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        private static extern IntPtr LoadLibrary(string libname);
-
         static SkiaCanvas()
         {
-            // https://github.com/mono/SkiaSharp/issues/713
-            // https://github.com/mono/SkiaSharp/issues/572
-            // manually load skia lib
-            switch (System.Environment.OSVersion.Platform)
-            {
-                case PlatformID.MacOSX:
-                case PlatformID.Unix:
-                    // I think unix platforms should be fine, to be tested
-                    break;
-                default:
-                    var libSkiaSharpPath =
-                        Path.GetDirectoryName(typeof(SkiaCanvas).Assembly.Location);
-                    var platformName = IntPtr.Size == 4 ? "win-x86" : "win-x64";
-                    libSkiaSharpPath = Path.Combine(libSkiaSharpPath, "runtimes", platformName,
-                        "native", "libSkiaSharp.dll");
-
-                    Logger.Debug("Skia", "Loading native lib from '" + libSkiaSharpPath + "'");
-                    var lib = LoadLibrary(libSkiaSharpPath);
-                    if (lib == IntPtr.Zero)
-                    {
-                        Logger.Warning("Skia",
-                            "Loading native lib from '" + libSkiaSharpPath + "' failed");
-                    }
-                    else
-                    {
-                        Logger.Debug("Skia",
-                            "Loading native lib from '" + libSkiaSharpPath + "' successful");
-                    }
-
-                    break;
-            }
-
             // attempt to load correct skia native lib
             var type = typeof(SkiaCanvas).GetTypeInfo();
             using var bravura =


### PR DESCRIPTION
### Issues
Fixes #774

### Proposed changes
As discussed in https://github.com/CoderLine/alphaTab/pull/775 Since 2.80.0 SkiaSharp is loading properly the native libs internally. We don't need our custom code. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
