### PR TITLE
alphaTex Alternate Endings

### DIFF
--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -1788,24 +1788,24 @@ export class AlphaTexImporter extends ScoreImporter {
                 }
                 master.repeatCount = this._syData as number;
                 this._sy = this.newSy();
-            } else if (syData === 're') {
+            } else if (syData === 'ae') {
                 this._sy = this.newSy();
                 if (this._sy === AlphaTexSymbols.LParensis) {
                     this._sy = this.newSy();
                     if (this._sy !== AlphaTexSymbols.Number) {
-                        this.error('repeatending', AlphaTexSymbols.Number, true)
+                        this.error('alternateending', AlphaTexSymbols.Number, true)
                     }
                     this.applyAlternateEnding(master);
                     while (this._sy === AlphaTexSymbols.Number) {
                         this.applyAlternateEnding(master);
                     }
                     if (this._sy !== AlphaTexSymbols.RParensis) {
-                        this.error('repeatending-list', AlphaTexSymbols.RParensis, true);
+                        this.error('alternateending-list', AlphaTexSymbols.RParensis, true);
                     }
                     this._sy = this.newSy();
                 } else {
                     if (this._sy !== AlphaTexSymbols.Number) {
-                        this.error('repeatending', AlphaTexSymbols.Number, true)
+                        this.error('alternateending', AlphaTexSymbols.Number, true)
                     }
                     this.applyAlternateEnding(master);
                 }
@@ -1906,8 +1906,9 @@ export class AlphaTexImporter extends ScoreImporter {
         let num = this._syData as number;
         if (num < 1) {
             // Repeat numberings start from 1
-            this.error('repeatending', AlphaTexSymbols.Number, true)
+            this.error('alternateending', AlphaTexSymbols.Number, true)
         }
+        // Alternate endings bitflag starts from 0
         master.alternateEndings |= 1 << (num - 1);
         this._sy = this.newSy();
     }

--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -1564,7 +1564,7 @@ export class AlphaTexImporter extends ScoreImporter {
                     this._sy = this.newSy();
                 }
                 const points = note.bendPoints;
-                if(points != null){
+                if (points != null) {
                     while (points.length > 60) {
                         points.splice(points.length - 1, 1);
                     }

--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -1453,7 +1453,7 @@ export class AlphaTexImporter extends ScoreImporter {
         }
     }
 
-    private isNoteText(txt: string) {
+    private isNoteText(txt: string): boolean {
         return txt === 'x' || txt === '-' || txt === 'r';
     }
 
@@ -1583,7 +1583,6 @@ export class AlphaTexImporter extends ScoreImporter {
                         }
                     }
                 }
-               
                 if (this._sy !== AlphaTexSymbols.RParensis) {
                     this.error('bend-effect', AlphaTexSymbols.RParensis, true);
                 }
@@ -1789,6 +1788,27 @@ export class AlphaTexImporter extends ScoreImporter {
                 }
                 master.repeatCount = this._syData as number;
                 this._sy = this.newSy();
+            } else if (syData === 're') {
+                this._sy = this.newSy();
+                if (this._sy === AlphaTexSymbols.LParensis) {
+                    this._sy = this.newSy();
+                    if (this._sy !== AlphaTexSymbols.Number) {
+                        this.error('repeatending', AlphaTexSymbols.Number, true)
+                    }
+                    this.applyAlternateEnding(master);
+                    while (this._sy === AlphaTexSymbols.Number) {
+                        this.applyAlternateEnding(master);
+                    }
+                    if (this._sy !== AlphaTexSymbols.RParensis) {
+                        this.error('repeatending-list', AlphaTexSymbols.RParensis, true);
+                    }
+                    this._sy = this.newSy();
+                } else {
+                    if (this._sy !== AlphaTexSymbols.Number) {
+                        this.error('repeatending', AlphaTexSymbols.Number, true)
+                    }
+                    this.applyAlternateEnding(master);
+                }
             } else if (syData === 'ks') {
                 this._sy = this.newSy();
                 if (this._sy !== AlphaTexSymbols.String) {
@@ -1880,5 +1900,15 @@ export class AlphaTexImporter extends ScoreImporter {
             master.tempoAutomation = tempoAutomation;
         }
         return anyMeta;
+    }
+
+    private applyAlternateEnding(master: MasterBar): void {
+        let num = this._syData as number;
+        if (num < 1) {
+            // Repeat numberings start from 1
+            this.error('repeatending', AlphaTexSymbols.Number, true)
+        }
+        master.alternateEndings |= 1 << (num - 1);
+        this._sy = this.newSy();
     }
 }

--- a/test/audio/MidiPlaybackController.test.ts
+++ b/test/audio/MidiPlaybackController.test.ts
@@ -76,4 +76,31 @@ describe('MidiPlaybackControllerTest', () => {
 
         expect(playedBars.join(',')).toEqual(expectedBars.join(','));
     });
+
+    it('alternate-endings-with-alphaTex', () => {
+        let tex: string = `
+            \\ro \\ae 1 1.1.1 | \\ae 2 2.1 | \\ae 3 3.1 |
+            4.3.4*4 |
+            \\ae 1 1.1.1 | \\ae 2 2.1 | \\ae 3 3.1 |
+            4.3.4*4 |
+            \\ae (1 3) 1.1.1 | \\ae 2 \\rc 3 2.1
+        `;
+        let importer: AlphaTexImporter = new AlphaTexImporter();
+        importer.initFromString(tex, new Settings());
+        let score: Score = importer.readScore();
+        let playedBars: number[] = [];
+        let controller: MidiPlaybackController = new MidiPlaybackController(score);
+        while (!controller.finished) {
+            let index: number = controller.index;
+            playedBars.push(index);
+            controller.processCurrent();
+            controller.moveNext();
+            if (playedBars.length > 50) {
+                fail('Too many bars generated');
+            }
+        }
+        let expectedBars: number[] = [0, 3, 4, 7, 8, 1, 3, 5, 7, 9, 2, 3, 6, 7, 8];
+
+        expect(playedBars.join(',')).toEqual(expectedBars.join(','));
+    });
 });

--- a/test/audio/MidiPlaybackController.test.ts
+++ b/test/audio/MidiPlaybackController.test.ts
@@ -6,13 +6,16 @@ import { Logger } from '@src/Logger';
 import { GpImporterTestHelper } from '@test/importer/GpImporterTestHelper';
 
 describe('MidiPlaybackControllerTest', () => {
-    const testRepeat: ((score: Score, expectedIndexes: number[]) => void) = (score: Score, expectedIndexes: number[]): void => {
+    const testRepeat: ((score: Score, expectedIndexes: number[], maxBars: number) => void) = (score: Score, expectedIndexes: number[], maxBars: number): void => {
         let controller: MidiPlaybackController = new MidiPlaybackController(score);
         let i: number = 0;
         while (!controller.finished) {
             let index: number = controller.index;
             controller.processCurrent();
             if (controller.shouldPlay) {
+                if (i > maxBars) {
+                    fail('Too many bars generated');
+                }
                 Logger.debug('Test', `Checking index ${i}, expected[${expectedIndexes[i]}]`, i, expectedIndexes[i]);
                 expect(index).toEqual(expectedIndexes[i]);
                 i++;
@@ -23,57 +26,42 @@ describe('MidiPlaybackControllerTest', () => {
         expect(controller.finished).toBe(true);
     };
 
-    it('repeat-close', async () => {
-        const reader = await GpImporterTestHelper.prepareImporterWithFile('audio/repeat-close.gp5');
+    const testGuitarProRepeat: ((file: string, expectedBars: number[], maxBars: number) => Promise<void>) = async (file: string, expectedBars: number[], maxBars: number): Promise<void> => {
+        let reader = await GpImporterTestHelper.prepareImporterWithFile(file);
         let score: Score = reader.readScore();
-        let expectedIndexes = [0, 1, 0, 1, 2];
-        testRepeat(score, expectedIndexes);
-    });
-
-    it('repeat-close-multi', async () => {
-        const reader = await GpImporterTestHelper.prepareImporterWithFile('audio/repeat-close-multi.gp5');
-        let score: Score = reader.readScore();
-        let expectedIndexes = [0, 1, 0, 1, 0, 1, 0, 1, 2];
-        testRepeat(score, expectedIndexes);
-    });
-
-    it('repeat-close-without-start-at-beginning', async () => {
-        const reader = await GpImporterTestHelper.prepareImporterWithFile(
-            'audio/repeat-close-without-start-at-beginning.gp5'
-        );
-        let score: Score = reader.readScore();
-        let expectedIndexes = [0, 1, 0, 1];
-        testRepeat(score, expectedIndexes);
-    });
-
-    it('repeat-close-alternate-endings', async () => {
-        const reader = await GpImporterTestHelper.prepareImporterWithFile(
-            'audio/repeat-close-alternate-endings.gp5'
-        );
-        let score: Score = reader.readScore();
-        let expectedIndexes = [0, 1, 0, 2, 3, 0, 1, 0, 4];
-        testRepeat(score, expectedIndexes);
-    });
+        testRepeat(score, expectedBars, maxBars);
+    }
 
     const testAlphaTexRepeat: ((tex: string, expectedBars: number[], maxBars: number) => void) = (tex: string, expectedBars: number[], maxBars: number): void => {
         let importer: AlphaTexImporter = new AlphaTexImporter();
         importer.initFromString(tex, new Settings());
         let score: Score = importer.readScore();
-        let playedBars: number[] = [];
-        let controller: MidiPlaybackController = new MidiPlaybackController(score);
-        while (!controller.finished) {
-            let index: number = controller.index;
-            controller.processCurrent();
-            if (controller.shouldPlay) {
-                playedBars.push(index);
-            }
-            controller.moveNext();
-            if (playedBars.length > maxBars) {
-                fail('Too many bars generated');
-            }
-        }
-        expect(playedBars.join(',')).toEqual(expectedBars.join(','));
+        testRepeat(score, expectedBars, maxBars);
     }
+
+    it('repeat-close', async () => {
+        let file = 'audio/repeat-close.gp5';
+        let expectedIndexes = [0, 1, 0, 1, 2];
+        testGuitarProRepeat(file, expectedIndexes, 20);
+    });
+
+    it('repeat-close-multi', async () => {
+        let file = 'audio/repeat-close-multi.gp5';
+        let expectedIndexes = [0, 1, 0, 1, 0, 1, 0, 1, 2];
+        testGuitarProRepeat(file, expectedIndexes, 20);
+    });
+
+    it('repeat-close-without-start-at-beginning', async () => {
+        let file = 'audio/repeat-close-without-start-at-beginning.gp5';
+        let expectedIndexes = [0, 1, 0, 1];
+        testGuitarProRepeat(file, expectedIndexes, 20);
+    });
+
+    it('repeat-close-alternate-endings', async () => {
+        let file = 'audio/repeat-close-alternate-endings.gp5';
+        let expectedIndexes = [0, 1, 0, 2, 3, 0, 1, 0, 4];
+        testGuitarProRepeat(file, expectedIndexes, 20);
+    });
 
     it('repeat-with-alphaTex', () => {
         let tex: string =

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -769,11 +769,58 @@ describe('AlphaTexImporterTest', () => {
         let tex: string =
             '\\ro 1.3 2.3 3.3 4.3 | 5.3 6.3 7.3 8.3 | \\rc 2 1.3 2.3 3.3 4.3 | \\ro \\rc 3 1.3 2.3 3.3 4.3 |';
         let score: Score = parseTex(tex);
+        expect(score.masterBars[0].isRepeatStart).toBe(true);
+        expect(score.masterBars[1].isRepeatStart).toBe(false);
+        expect(score.masterBars[2].isRepeatStart).toBe(false);
+        expect(score.masterBars[3].isRepeatStart).toBe(true);
         expect(score.masterBars[0].repeatCount).toEqual(0);
         expect(score.masterBars[1].repeatCount).toEqual(0);
         expect(score.masterBars[2].repeatCount).toEqual(2);
         expect(score.masterBars[3].repeatCount).toEqual(3);
     });
+
+    it('alternate-endings', () => {
+        let tex: string = '\\ro 4.3*4 | \\ae (1 2 3) 6.3*4 | \\ae 4 \\rc 4 6.3 6.3 6.3 5.3 |';
+        let score: Score = parseTex(tex);
+        expect(score.masterBars[0].isRepeatStart).toBe(true);
+        expect(score.masterBars[1].isRepeatStart).toBe(false);
+        expect(score.masterBars[2].isRepeatStart).toBe(false);
+        expect(score.masterBars[0].repeatCount).toEqual(0);
+        expect(score.masterBars[1].repeatCount).toEqual(0);
+        expect(score.masterBars[2].repeatCount).toEqual(4);
+        expect(score.masterBars[0].alternateEndings).toEqual(0b0000);
+        expect(score.masterBars[1].alternateEndings).toEqual(0b0111);
+        expect(score.masterBars[2].alternateEndings).toEqual(0b1000);
+    })
+
+    it('random-alternate-endings', () => {
+        let tex: string = `
+            \\ro \\ae 1 1.1.1 | \\ae 2 2.1 | \\ae 3 3.1 |
+            4.3.4*4 |
+            \\ae 1 1.1.1 | \\ae 2 2.1 | \\ae 3 3.1 |
+            4.3.4*4 |
+            \\ae (1 3) 1.1.1 | \\ae 2 \\rc 3 2.1 |
+        `;
+        let score: Score = parseTex(tex);
+        expect(score.masterBars[0].isRepeatStart).toBe(true);
+        for (let i = 1; i <= 9; i++) {
+            expect(score.masterBars[i].isRepeatStart).toBe(false);
+        }
+        for (let i = 0; i <= 8; i++) {
+            expect(score.masterBars[i].repeatCount).toEqual(0);
+        }
+        expect(score.masterBars[9].repeatCount).toEqual(3);
+        expect(score.masterBars[0].alternateEndings).toEqual(0b001);
+        expect(score.masterBars[1].alternateEndings).toEqual(0b010);
+        expect(score.masterBars[2].alternateEndings).toEqual(0b100);
+        expect(score.masterBars[3].alternateEndings).toEqual(0b000);
+        expect(score.masterBars[4].alternateEndings).toEqual(0b001);
+        expect(score.masterBars[5].alternateEndings).toEqual(0b010);
+        expect(score.masterBars[6].alternateEndings).toEqual(0b100);
+        expect(score.masterBars[7].alternateEndings).toEqual(0b000);
+        expect(score.masterBars[8].alternateEndings).toEqual(0b101);
+        expect(score.masterBars[9].alternateEndings).toEqual(0b010);
+    })
 
     it('default-transposition-on-instruments', () => {
         let tex: string = `

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -951,7 +951,7 @@ describe('AlphaTexImporterTest', () => {
         expect(score.tracks[0].name).toEqual("🎸");
         expect(score.tracks[0].staves[0].bars[0].voices[0].beats[2].lyrics![0]).toEqual("🤘");
     });
-    
+
     it('does-not-hang-on-backslash', () => {
         try {
             parseTex('\\title Test . 3.3 \\')
@@ -961,7 +961,7 @@ describe('AlphaTexImporterTest', () => {
         }
     })
 
-    function runSectionNoteSymbolTest(noteSymbol:string) {
+    function runSectionNoteSymbolTest(noteSymbol: string) {
         const score = parseTex(`1.3.4 * 4 | \\section Verse ${noteSymbol}.1 | 2.3.4*4`);
 
         expect(score.masterBars.length).toEqual(3);


### PR DESCRIPTION
### Issues
Fixes #671 

### Proposed changes
The `\ae` bar meta tag for alphaTex can be used to mark bars as alternate endings in a repeat.
Syntax examples: `\ae (1 2 3)` and `\ae 4`.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [x] New tests were added
  - Two tests for parsing the tag.
  - A new test for `MidiPlaybackController` added but needs a fix for passing. 

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website
  - *I can write a section for this once the feature has been released.*
