### PR TITLE
Add brushes and arpeggio to alphaTex

### DIFF
--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -1315,7 +1315,7 @@ export class AlphaTexImporter extends ScoreImporter {
             return true;
         }
         if (syData === 'bu' || syData === 'bd' || syData === 'au' || syData === 'ad') {
-            switch (this._syData) {
+            switch (syData) {
                 case 'bu':
                     beat.brushType = BrushType.BrushUp;
                     break;
@@ -1331,10 +1331,12 @@ export class AlphaTexImporter extends ScoreImporter {
             }
             this._sy = this.newSy();
             if (this._sy === AlphaTexSymbols.Number) {
+                // explicit duration
                 beat.brushDuration = (this._syData as number);
                 this._sy = this.newSy();
                 return true;
             }
+            // default to calcuated duration
             beat.updateDurations();
             if (syData === 'bu' || syData === 'bd') {
                 beat.brushDuration = beat.playbackDuration / (beat.notes.length > 4 ? beat.notes.length : 4);

--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -1339,7 +1339,7 @@ export class AlphaTexImporter extends ScoreImporter {
             // default to calcuated duration
             beat.updateDurations();
             if (syData === 'bu' || syData === 'bd') {
-                beat.brushDuration = beat.playbackDuration / (beat.notes.length > 4 ? beat.notes.length : 4);
+                beat.brushDuration = beat.playbackDuration / 4 / beat.notes.length;
             } else if (syData === 'au' || syData === 'ad') {
                 beat.brushDuration = beat.playbackDuration / beat.notes.length;
             }

--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -6,6 +6,7 @@ import { Automation, AutomationType } from '@src/model/Automation';
 import { Bar } from '@src/model/Bar';
 import { Beat } from '@src/model/Beat';
 import { BendPoint } from '@src/model/BendPoint';
+import { BrushType } from '@src/model/BrushType';
 import { Chord } from '@src/model/Chord';
 import { Clef } from '@src/model/Clef';
 import { CrescendoType } from '@src/model/CrescendoType';
@@ -1311,6 +1312,35 @@ export class AlphaTexImporter extends ScoreImporter {
                 return false;
             }
             this._sy = this.newSy();
+            return true;
+        }
+        if (syData === 'bu' || syData === 'bd' || syData === 'au' || syData === 'ad') {
+            switch (this._syData) {
+                case 'bu':
+                    beat.brushType = BrushType.BrushUp;
+                    break;
+                case 'bd':
+                    beat.brushType = BrushType.BrushDown;
+                    break;
+                case 'au':
+                    beat.brushType = BrushType.ArpeggioUp;
+                    break;
+                case 'ad':
+                    beat.brushType = BrushType.ArpeggioDown;
+                    break;
+            }
+            this._sy = this.newSy();
+            if (this._sy === AlphaTexSymbols.Number) {
+                beat.brushDuration = (this._syData as number);
+                this._sy = this.newSy();
+                return true;
+            }
+            beat.updateDurations();
+            if (syData === 'bu' || syData === 'bd') {
+                beat.brushDuration = beat.playbackDuration / (beat.notes.length > 4 ? beat.notes.length : 4);
+            } else if (syData === 'au' || syData === 'ad') {
+                beat.brushDuration = beat.playbackDuration / beat.notes.length;
+            }
             return true;
         }
         if (syData === 'ch') {

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -2,6 +2,7 @@ import { StaveProfile } from '@src/StaveProfile';
 import { AlphaTexImporter } from '@src/importer/AlphaTexImporter';
 import { UnsupportedFormatError } from '@src/importer/UnsupportedFormatError';
 import { Beat } from '@src/model/Beat';
+import { BrushType } from '@src/model/BrushType';
 import { Clef } from '@src/model/Clef';
 import { CrescendoType } from '@src/model/CrescendoType';
 import { Duration } from '@src/model/Duration';
@@ -151,6 +152,59 @@ describe('AlphaTexImporterTest', () => {
         expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].notes[0].fret).toEqual(3);
         expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].isTremolo).toEqual(true);
         expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].tremoloSpeed).toEqual(Duration.Sixteenth);
+    });
+
+    it('brushes-arpeggio', () => {
+        let tex: string = `
+            (1.1 2.2 3.3 4.4).4{bd 60} (1.1 2.2 3.3 4.4).8{bu 60} (1.1 2.2 3.3 4.4).2{ad 60} (1.1 2.2 3.3 4.4).16{au 60} r |
+            (1.1 2.2 3.3 4.4).4{bd 120} (1.1 2.2 3.3 4.4).8{bu 120} (1.1 2.2 3.3 4.4).2{ad 120} (1.1 2.2 3.3 4.4).16{au 120} r |
+            (1.1 2.2 3.3 4.4).4{bd} (1.1 2.2 3.3 4.4).8{bu} (1.1 2.2 3.3 4.4).2{ad} (1.1 2.2 3.3 4.4).16{au} r
+        `;
+        let score: Score = parseTex(tex);
+        expect(score.tracks.length).toEqual(1);
+        expect(score.masterBars.length).toEqual(3);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats.length).toEqual(5);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].brushType).toEqual(BrushType.BrushDown);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].playbackDuration).toEqual(960);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].brushDuration).toEqual(60);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[1].brushType).toEqual(BrushType.BrushUp);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[1].playbackDuration).toEqual(480);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[1].brushDuration).toEqual(60);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[2].brushType).toEqual(BrushType.ArpeggioDown);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[2].playbackDuration).toEqual(1920);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[2].brushDuration).toEqual(60);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[3].brushType).toEqual(BrushType.ArpeggioUp);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[3].playbackDuration).toEqual(240);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[3].brushDuration).toEqual(60);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[4].isRest).toEqual(true);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[4].brushType).toEqual(BrushType.None);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[4].playbackDuration).toEqual(240);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[4].brushDuration).toEqual(0);
+        expect(score.tracks[0].staves[0].bars[1].voices[0].beats.length).toEqual(5);
+        expect(score.tracks[0].staves[0].bars[1].voices[0].beats[0].brushType).toEqual(BrushType.BrushDown);
+        expect(score.tracks[0].staves[0].bars[1].voices[0].beats[0].brushDuration).toEqual(120);
+        expect(score.tracks[0].staves[0].bars[1].voices[0].beats[1].brushType).toEqual(BrushType.BrushUp);
+        expect(score.tracks[0].staves[0].bars[1].voices[0].beats[1].brushDuration).toEqual(120);
+        expect(score.tracks[0].staves[0].bars[1].voices[0].beats[2].brushType).toEqual(BrushType.ArpeggioDown);
+        expect(score.tracks[0].staves[0].bars[1].voices[0].beats[2].brushDuration).toEqual(120);
+        expect(score.tracks[0].staves[0].bars[1].voices[0].beats[3].brushType).toEqual(BrushType.ArpeggioUp);
+        expect(score.tracks[0].staves[0].bars[1].voices[0].beats[3].brushDuration).toEqual(120);
+        expect(score.tracks[0].staves[0].bars[1].voices[0].beats[4].isRest).toEqual(true);
+        expect(score.tracks[0].staves[0].bars[1].voices[0].beats[4].brushType).toEqual(BrushType.None);
+        expect(score.tracks[0].staves[0].bars[1].voices[0].beats[4].brushDuration).toEqual(0);
+        expect(score.tracks[0].staves[0].bars[2].voices[0].beats.length).toEqual(5);
+        expect(score.tracks[0].staves[0].bars[2].voices[0].beats[0].brushType).toEqual(BrushType.BrushDown);
+        expect(score.tracks[0].staves[0].bars[2].voices[0].beats[0].brushDuration).toEqual(60);
+        expect(score.tracks[0].staves[0].bars[2].voices[0].beats[1].brushType).toEqual(BrushType.BrushUp);
+        expect(score.tracks[0].staves[0].bars[2].voices[0].beats[1].brushDuration).toEqual(30);
+        expect(score.tracks[0].staves[0].bars[2].voices[0].beats[2].brushType).toEqual(BrushType.ArpeggioDown);
+        expect(score.tracks[0].staves[0].bars[2].voices[0].beats[2].brushDuration).toEqual(480);
+        expect(score.tracks[0].staves[0].bars[2].voices[0].beats[3].brushType).toEqual(BrushType.ArpeggioUp);
+        expect(score.tracks[0].staves[0].bars[2].voices[0].beats[3].brushDuration).toEqual(60);
+        expect(score.tracks[0].staves[0].bars[2].voices[0].beats[4].isRest).toEqual(true);
+        expect(score.tracks[0].staves[0].bars[2].voices[0].beats[4].brushType).toEqual(BrushType.None);
+        expect(score.tracks[0].staves[0].bars[2].voices[0].beats[4].brushDuration).toEqual(0);
+
     });
 
     it('hamonics-issue79', () => {
@@ -904,7 +958,7 @@ describe('AlphaTexImporterTest', () => {
         expect(score.tracks[0].name).toEqual("🎸");
         expect(score.tracks[0].staves[0].bars[0].voices[0].beats[2].lyrics![0]).toEqual("🤘");
     });
-    
+
     it('does-not-hang-on-backslash', () => {
         try {
             parseTex('\\title Test . 3.3 \\')


### PR DESCRIPTION
### Issues
Implements #505

### Proposed changes
Added the brush parsing to alphaTex.

The current approach for default values is to ensure that brushes don't play too slow, and letting arpeggios play evenly across the duration. It for sure feels like not all of the timings below are "correct" and need tweaking.
Here is some tex i used for testing:
```
.
\tempo 90
(1.1 2.2 3.3 4.4).4{bd 60} (1.1 2.2 3.3 4.4).8{bu 60} (1.1 2.2 3.3 4.4).2{ad 60} (1.1 2.2 3.3 4.4).16{au 60} r |
(1.1 2.2 3.3 4.4).4{bd 120} (1.1 2.2 3.3 4.4).8{bu 120} (1.1 2.2 3.3 4.4).2{ad 120} (1.1 2.2 3.3 4.4).16{au 120} r |
(1.1 2.2 3.3 4.4).4{bd 240} (1.1 2.2 3.3 4.4).8{bu 240} (1.1 2.2 3.3 4.4).2{ad 240} (1.1 2.2 3.3 4.4).16{au 240} r |
(1.1 2.2 3.3 4.4).4{bd} (1.1 2.2 3.3 4.4).8{bu} (1.1 2.2 3.3 4.4).2{ad} (1.1 2.2 3.3 4.4).16{au} r |
(1.1 2.2 3.3 4.4).4{bd} (1.1 2.2 3.3 4.4).8{bu} (1.1 2.2 3.3 4.4).2{ad} (1.1 2.2 3.3 4.4).16{au} r |
\tempo 120
(0.1 0.2 0.3 2.4 2.5 0.6).2*2{bd} | (0.1 0.2 0.3 2.4 2.5 0.6).4*4{bd} | (0.1 0.2 0.3 2.4 2.5 0.6).8*8{bd} |
(3.1 0.2 0.3 0.4).2*2{bd} | (3.1 0.2 0.3 0.4).4*4{bd} | (3.1 0.2 0.3 0.4).8*8{bd} |
(2.2 3.3 4.4).2*2{bd} | (2.2 3.3 4.4).4*4{bd} | (2.2 3.3 4.4).8*8{bd} |
(3.3 4.4).2*2{bd} | (3.3 4.4).4*4{bd} | (3.3 4.4).8*8{bd} |
(0.1 0.2 0.3 2.4 2.5 0.6).2*2{ad} | (0.1 0.2 0.3 2.4 2.5 0.6).4*4{ad} | (0.1 0.2 0.3 2.4 2.5 0.6).8*8{ad} |
(3.1 0.2 0.3 0.4).2*2{ad} | (3.1 0.2 0.3 0.4).4*4{ad} | (3.1 0.2 0.3 0.4).8*8{ad} |
(2.2 3.3 4.4).2*2{ad} | (2.2 3.3 4.4).4*4{ad} | (2.2 3.3 4.4).8*8{ad} |
(3.3 4.4).2*2{ad} | (3.3 4.4).4*4{ad} | (3.3 4.4).8*8{ad} |
\tempo 80
(5.2 5.3 7.4).4{ad} (5.2 5.3 7.4).4{au} (5.1 5.2 5.3).4{ad} (5.1 5.2 5.3).4{au} |
(8.1 10.2 9.3).4{ad} (8.1 10.2 9.3).4{au} (12.1 13.2 14.3).4{ad} 12.1.4 |
```

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [x] New tests were added

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website
  - _I can write a section for them once they are implemented._
