### PR TITLE
Avoid null when writing lyrics in GP

### DIFF
--- a/src/exporter/GpifWriter.ts
+++ b/src/exporter/GpifWriter.ts
@@ -237,7 +237,7 @@ export class GpifWriter {
     private writeDom(parent: XmlNode, score: Score) {
         const gpif = parent.addElement('GPIF');
 
-        // just some values at the time this was implemented, 
+        // just some values at the time this was implemented,
         gpif.addElement('GPVersion').innerText = '7';
         const gpRevision = gpif.addElement('GPRevision');
         gpRevision.innerText = '7';
@@ -1335,9 +1335,11 @@ export class GpifWriter {
                                 }
 
                                 const line = lines[l];
+                                const beatLyricsLine = beat.lyrics[l] || '';
+
                                 line.text = line.text == '[Empty]'
-                                    ? beat.lyrics[l]
-                                    : line.text + ' ' + beat.lyrics[l].split(' ').join('+');
+                                    ? beatLyricsLine
+                                    : line.text + ' ' + beatLyricsLine.split(' ').join('+');
                             }
                         }
                     }


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->

Fixes an issue w/ the GP exporter in regards to lyrics: `TypeError: Cannot read property 'split' of undefined`

```
    at GpifWriter.writeLyricsNode (webpack://@tabulous-xyz/metadata/./node_modules/@coderline/alphatab/dist/alphaTab.js?:41632:76)
    at GpifWriter.writeTrackNode (webpack://@tabulous-xyz/metadata/./node_modules/@coderline/alphatab/dist/alphaTab.js?:41338:18)
    at GpifWriter.writeTracksNode (webpack://@tabulous-xyz/metadata/./node_modules/@coderline/alphatab/dist/alphaTab.js?:41304:22)
    at GpifWriter.writeDom (webpack://@tabulous-xyz/metadata/./node_modules/@coderline/alphatab/dist/alphaTab.js?:40713:18)
    at GpifWriter.writeXml (webpack://@tabulous-xyz/metadata/./node_modules/@coderline/alphatab/dist/alphaTab.js?:40697:18)
    at Gp7Exporter.writeScore (webpack://@tabulous-xyz/metadata/./node_modules/@coderline/alphatab/dist/alphaTab.js?:43560:40)
    at Gp7Exporter.export (webpack://@tabulous-xyz/metadata/./node_modules/@coderline/alphatab/dist/alphaTab.js?:40638:18)
```

### Proposed changes

Coerce the current beat lines lyrics to be a blank string so that the `split/join` calls will essentially no-op instead of throwing `TypeError: Cannot read property 'split' of undefined`.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
