### PR TITLE
Clear various settings during print to avoid double print.

### DIFF
--- a/src/platform/javascript/AlphaTabApi.ts
+++ b/src/platform/javascript/AlphaTabApi.ts
@@ -69,6 +69,13 @@ export class AlphaTabApi extends AlphaTabApiBase<any|Settings> {
         let settings: Settings = JsonConverter.jsObjectToSettings(JsonConverter.settingsToJsObject(this.settings));
         settings.core.enableLazyLoading = false;
         settings.core.useWorkers = false;
+        settings.core.file = null;
+        settings.core.tracks = null;
+        settings.player.enableCursor = false;
+        settings.player.enablePlayer = false;
+        settings.player.enableElementHighlighting = false;
+        settings.player.enableUserInteraction = false;
+        settings.player.soundFont = null;
         settings.display.scale = 0.8;
         settings.display.stretchForce = 0.8;
         SettingsSerializer.fromJson(settings, additionalSettings);


### PR DESCRIPTION
### Issues
Fixes #844

### Proposed changes
Actually #844 had a wrong assumption that we have double render events on load. But this problem was already addressed in 1.3 and it is not reproducible anymore. But we had the issue that during print we do not clear some settings which must be cleared for printing. Due to this we first rendered the tracks as displayed currently, and then the default file loading kicked in and rendered it again. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
