### PR TITLE
Centralize worker creation logic and improved webpack handling

### DIFF
--- a/src/platform/javascript/AlphaSynthWebWorkerApi.ts
+++ b/src/platform/javascript/AlphaSynthWebWorkerApi.ts
@@ -213,13 +213,7 @@ export class AlphaSynthWebWorkerApi implements IAlphaSynth {
         try {
             this._synth = Environment.createAlphaTabWorker(alphaSynthScriptFile);
         } catch (e) {
-            // fallback to direct worker
-            try {
-                this._synth = new Worker(alphaSynthScriptFile);
-            } catch (e2) {
-                Logger.error('AlphaSynth', 'Failed to create WebWorker: ' + e2);
-                return;
-            }
+            Logger.error('AlphaSynth', 'Failed to create WebWorker: ' + e);
         }
         this._synth.addEventListener('message', this.handleWorkerMessage.bind(this), false);
         this._synth.postMessage({

--- a/src/platform/javascript/AlphaTabWorkerScoreRenderer.ts
+++ b/src/platform/javascript/AlphaTabWorkerScoreRenderer.ts
@@ -23,21 +23,12 @@ export class AlphaTabWorkerScoreRenderer<T> implements IScoreRenderer {
     public constructor(api: AlphaTabApiBase<T>, settings: Settings) {
         this._api = api;
 
-        if (!settings.core.scriptFile) {
-            Logger.error('Rendering', `Could not detect alphaTab script file, cannot initialize renderer`);
-            return;
-        }
-
         // first try blob worker
         try {
             this._worker = Environment.createAlphaTabWorker(settings.core.scriptFile);
         } catch (e) {
-            try {
-                this._worker = new Worker(settings.core.scriptFile);
-            } catch (e2) {
-                Logger.error('Rendering', `Failed to create WebWorker: ${e}`);
-                return;
-            }
+            Logger.error('Rendering', `Failed to create WebWorker: ${e}`);
+            return;
         }
         this._worker.postMessage({
             cmd: 'alphaTab.initialize',


### PR DESCRIPTION
### Issues
Relates to #759

### Proposed changes
Move the check for a detected scriptfile so that in WebPack cases it does not need to be set. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
