### PR TITLE
Add replaceChildren polyfill for older iOS versions

### DIFF
--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -535,6 +535,15 @@ export class Environment {
             if (!('IntersectionObserver' in Environment.globalThis)) {
                 (Environment.globalThis as any).IntersectionObserver = IntersectionObserverPolyfill;
             }
+
+            if(!('replaceChildren' in Element.prototype)) {
+                Element.prototype.replaceChildren = function (...nodes: (Node | string)[]) {
+                    this.innerHTML = '';
+                    this.append(...nodes);
+                };
+                Document.prototype.replaceChildren = Element.prototype.replaceChildren;
+                DocumentFragment.prototype.replaceChildren = Element.prototype.replaceChildren;
+            }
         }
     }
 


### PR DESCRIPTION
### Issues
Fixes #836

### Proposed changes
It seems some older iOS / iPadOS versions don't support `Element.replaceChildren`. Added a polyfill.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
