### PR TITLE
Add: Logic for parsing trill ornament.

### DIFF
--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -57,6 +57,7 @@ import { WebPlatform } from '@src/platform/javascript/WebPlatform';
 import { IntersectionObserverPolyfill } from '@src/platform/javascript/IntersectionObserverPolyfill';
 import { AlphaSynthWebWorklet } from '@src/platform/javascript/AlphaSynthAudioWorkletOutput';
 import { AlphaTabError, AlphaTabErrorType } from './AlphaTabError';
+import { TurnEffectInfo } from './rendering/effects/TurnEffectInfo';
 
 export class LayoutEngineFactory {
     public readonly vertical: boolean;
@@ -394,6 +395,7 @@ export class Environment {
                 new FermataEffectInfo(),
                 new WhammyBarEffectInfo(),
                 new TrillEffectInfo(),
+                new TurnEffectInfo(),
                 new OttaviaEffectInfo(true),
                 new WideBeatVibratoEffectInfo(),
                 new SlightBeatVibratoEffectInfo(),
@@ -409,6 +411,7 @@ export class Environment {
                 new DynamicsEffectInfo(),
                 new LyricsEffectInfo(),
                 new TrillEffectInfo(),
+                new TurnEffectInfo(),
                 new WideBeatVibratoEffectInfo(),
                 new SlightBeatVibratoEffectInfo(),
                 new WideNoteVibratoEffectInfo(),
@@ -441,6 +444,7 @@ export class Environment {
                 new FermataEffectInfo(),
                 new WhammyBarEffectInfo(),
                 new TrillEffectInfo(),
+                new TurnEffectInfo(),
                 new OttaviaEffectInfo(true),
                 new WideBeatVibratoEffectInfo(),
                 new SlightBeatVibratoEffectInfo(),
@@ -470,6 +474,7 @@ export class Environment {
             new ChordsEffectInfo(),
             new FermataEffectInfo(),
             new TrillEffectInfo(),
+            new TurnEffectInfo(),
             new WideBeatVibratoEffectInfo(),
             new SlightBeatVibratoEffectInfo(),
             new WideNoteVibratoEffectInfo(),

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -58,6 +58,7 @@ import { IntersectionObserverPolyfill } from '@src/platform/javascript/Intersect
 import { AlphaSynthWebWorklet } from '@src/platform/javascript/AlphaSynthAudioWorkletOutput';
 import { AlphaTabError, AlphaTabErrorType } from './AlphaTabError';
 import { TurnEffectInfo } from './rendering/effects/TurnEffectInfo';
+import { InvertedTurnEffectInfo } from './rendering/effects/InvertedTurnEffectInfo';
 
 export class LayoutEngineFactory {
     public readonly vertical: boolean;
@@ -396,6 +397,7 @@ export class Environment {
                 new WhammyBarEffectInfo(),
                 new TrillEffectInfo(),
                 new TurnEffectInfo(),
+                new InvertedTurnEffectInfo(),
                 new OttaviaEffectInfo(true),
                 new WideBeatVibratoEffectInfo(),
                 new SlightBeatVibratoEffectInfo(),
@@ -412,6 +414,7 @@ export class Environment {
                 new LyricsEffectInfo(),
                 new TrillEffectInfo(),
                 new TurnEffectInfo(),
+                new InvertedTurnEffectInfo(),
                 new WideBeatVibratoEffectInfo(),
                 new SlightBeatVibratoEffectInfo(),
                 new WideNoteVibratoEffectInfo(),
@@ -445,6 +448,7 @@ export class Environment {
                 new WhammyBarEffectInfo(),
                 new TrillEffectInfo(),
                 new TurnEffectInfo(),
+                new InvertedTurnEffectInfo(),
                 new OttaviaEffectInfo(true),
                 new WideBeatVibratoEffectInfo(),
                 new SlightBeatVibratoEffectInfo(),
@@ -475,6 +479,7 @@ export class Environment {
             new FermataEffectInfo(),
             new TrillEffectInfo(),
             new TurnEffectInfo(),
+            new InvertedTurnEffectInfo(),
             new WideBeatVibratoEffectInfo(),
             new SlightBeatVibratoEffectInfo(),
             new WideNoteVibratoEffectInfo(),

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -59,6 +59,8 @@ import { AlphaSynthWebWorklet } from '@src/platform/javascript/AlphaSynthAudioWo
 import { AlphaTabError, AlphaTabErrorType } from './AlphaTabError';
 import { TurnEffectInfo } from './rendering/effects/TurnEffectInfo';
 import { InvertedTurnEffectInfo } from './rendering/effects/InvertedTurnEffectInfo';
+import { MordentEffectInfo } from './rendering/effects/MordentEffectInfo';
+import { InvertedMordentEffectInfo } from './rendering/effects/InvertedMordentEffectInfo';
 
 export class LayoutEngineFactory {
     public readonly vertical: boolean;
@@ -398,6 +400,8 @@ export class Environment {
                 new TrillEffectInfo(),
                 new TurnEffectInfo(),
                 new InvertedTurnEffectInfo(),
+                new MordentEffectInfo(),
+                new InvertedMordentEffectInfo(),
                 new OttaviaEffectInfo(true),
                 new WideBeatVibratoEffectInfo(),
                 new SlightBeatVibratoEffectInfo(),
@@ -415,6 +419,8 @@ export class Environment {
                 new TrillEffectInfo(),
                 new TurnEffectInfo(),
                 new InvertedTurnEffectInfo(),
+                new MordentEffectInfo(),
+                new InvertedMordentEffectInfo(),
                 new WideBeatVibratoEffectInfo(),
                 new SlightBeatVibratoEffectInfo(),
                 new WideNoteVibratoEffectInfo(),
@@ -449,6 +455,8 @@ export class Environment {
                 new TrillEffectInfo(),
                 new TurnEffectInfo(),
                 new InvertedTurnEffectInfo(),
+                new MordentEffectInfo(),
+                new InvertedMordentEffectInfo(),
                 new OttaviaEffectInfo(true),
                 new WideBeatVibratoEffectInfo(),
                 new SlightBeatVibratoEffectInfo(),
@@ -480,6 +488,8 @@ export class Environment {
             new TrillEffectInfo(),
             new TurnEffectInfo(),
             new InvertedTurnEffectInfo(),
+            new MordentEffectInfo(),
+            new InvertedMordentEffectInfo(),
             new WideBeatVibratoEffectInfo(),
             new SlightBeatVibratoEffectInfo(),
             new WideNoteVibratoEffectInfo(),

--- a/src/NotationSettings.ts
+++ b/src/NotationSettings.ts
@@ -264,6 +264,11 @@ export enum NotationElement {
     EffectTrill,
 
     /**
+     * The turn symbol shown above the staff.
+     */
+    EffectTurn,
+
+    /**
      * The triplet feel symbol shown above the staff.
      */
     EffectTripletFeel,

--- a/src/NotationSettings.ts
+++ b/src/NotationSettings.ts
@@ -269,6 +269,11 @@ export enum NotationElement {
     EffectTurn,
 
     /**
+     * The turn symbol shown above the staff.
+     */
+    EffectInvertedTurn,
+
+    /**
      * The triplet feel symbol shown above the staff.
      */
     EffectTripletFeel,

--- a/src/NotationSettings.ts
+++ b/src/NotationSettings.ts
@@ -269,9 +269,19 @@ export enum NotationElement {
     EffectTurn,
 
     /**
-     * The turn symbol shown above the staff.
+     * The inverted turn symbol shown above the staff.
      */
     EffectInvertedTurn,
+
+    /**
+     * The mordent symbol shown above the staff.
+     */
+    EffectMordent,
+
+     /**
+      * The inverted mordent symbol shown above the staff.
+      */
+    EffectInvertedMordent,
 
     /**
      * The triplet feel symbol shown above the staff.

--- a/src/generated/model/NoteCloner.ts
+++ b/src/generated/model/NoteCloner.ts
@@ -46,6 +46,8 @@ export class NoteCloner {
         clone.trillSpeed = original.trillSpeed; 
         clone.turnValue = original.turnValue; 
         clone.turnSpeed = original.turnSpeed; 
+        clone.invertedTurnValue = original.invertedTurnValue; 
+        clone.invertedTurnSpeed = original.invertedTurnSpeed; 
         clone.durationPercent = original.durationPercent; 
         clone.accidentalMode = original.accidentalMode; 
         clone.dynamics = original.dynamics; 

--- a/src/generated/model/NoteCloner.ts
+++ b/src/generated/model/NoteCloner.ts
@@ -44,6 +44,8 @@ export class NoteCloner {
         clone.isFingering = original.isFingering; 
         clone.trillValue = original.trillValue; 
         clone.trillSpeed = original.trillSpeed; 
+        clone.turnValue = original.turnValue; 
+        clone.turnSpeed = original.turnSpeed; 
         clone.durationPercent = original.durationPercent; 
         clone.accidentalMode = original.accidentalMode; 
         clone.dynamics = original.dynamics; 

--- a/src/generated/model/NoteSerializer.ts
+++ b/src/generated/model/NoteSerializer.ts
@@ -63,6 +63,8 @@ export class NoteSerializer {
         o.set("isfingering", obj.isFingering); 
         o.set("trillvalue", obj.trillValue); 
         o.set("trillspeed", obj.trillSpeed as number); 
+        o.set("turnvalue", obj.turnValue); 
+        o.set("turnspeed", obj.turnSpeed as number); 
         o.set("durationpercent", obj.durationPercent); 
         o.set("accidentalmode", obj.accidentalMode as number); 
         o.set("dynamics", obj.dynamics as number); 
@@ -170,6 +172,12 @@ export class NoteSerializer {
                 return true;
             case "trillspeed":
                 obj.trillSpeed = JsonHelper.parseEnum<Duration>(v, Duration)!;
+                return true;
+            case "turnvalue":
+                obj.turnValue = v! as number;
+                return true;
+            case "turnspeed":
+                obj.turnSpeed = JsonHelper.parseEnum<Duration>(v, Duration)!;
                 return true;
             case "durationpercent":
                 obj.durationPercent = v! as number;

--- a/src/generated/model/NoteSerializer.ts
+++ b/src/generated/model/NoteSerializer.ts
@@ -65,6 +65,8 @@ export class NoteSerializer {
         o.set("trillspeed", obj.trillSpeed as number); 
         o.set("turnvalue", obj.turnValue); 
         o.set("turnspeed", obj.turnSpeed as number); 
+        o.set("invertedturnvalue", obj.invertedTurnValue); 
+        o.set("invertedturnspeed", obj.invertedTurnSpeed as number); 
         o.set("durationpercent", obj.durationPercent); 
         o.set("accidentalmode", obj.accidentalMode as number); 
         o.set("dynamics", obj.dynamics as number); 
@@ -178,6 +180,12 @@ export class NoteSerializer {
                 return true;
             case "turnspeed":
                 obj.turnSpeed = JsonHelper.parseEnum<Duration>(v, Duration)!;
+                return true;
+            case "invertedturnvalue":
+                obj.invertedTurnValue = v! as number;
+                return true;
+            case "invertedturnspeed":
+                obj.invertedTurnSpeed = JsonHelper.parseEnum<Duration>(v, Duration)!;
                 return true;
             case "durationpercent":
                 obj.durationPercent = v! as number;

--- a/src/importer/MusicXmlImporter.ts
+++ b/src/importer/MusicXmlImporter.ts
@@ -886,20 +886,7 @@ export class MusicXmlImporter extends ScoreImporter {
                         }
                         break;
                     case 'trill-mark':
-                            let trillStep: string = (c.attributes.get('trill-step') as string)?.toLowerCase();
-                            switch(trillStep){
-                                case 'unison':
-                                    note.trillValue = 0;
-                                    break;
-                                case 'half':
-                                    note.trillValue = 1;
-                                    break;
-                                case 'whole':
-                                    note.trillValue = 2;
-                                    break;
-                                default:
-                                    note.trillValue = 1;
-                            }
+                            note.trillValue = this.parseTrillStep(c);
                             // note.trillSpeed = Duration.ThirtySecond;
                         break;
                     case 'mordent':
@@ -916,10 +903,7 @@ export class MusicXmlImporter extends ScoreImporter {
                         break;
                     case 'vertical-turn': // Fallthrough.
                     case 'turn':
-                        // TODO: set turn properties.
-                        // Function:
-                        //  START:trill-step(up), unison, trill-step(down), END:unison.
-                        // Placement: above the note.
+                        note.turnValue = this.parseTrillStep(c);
                         break;
                     case 'delayed-turn':
                         // TODO: set delayed-turn properties.
@@ -962,6 +946,20 @@ export class MusicXmlImporter extends ScoreImporter {
                 }
             }
         }
+    }
+
+    private parseTrillStep(element: XmlNode): number{
+        let trillStep: string = (element.attributes.get('trill-step') as string)?.toLowerCase();
+        switch(trillStep){
+            case 'unison':
+                return 0;
+            case 'half':
+                return 1;
+            case 'whole':
+                return 2;
+            default:
+                return 2;
+        }                     
     }
 
     private parseTechnical(element: XmlNode, note: Note): void {

--- a/src/importer/MusicXmlImporter.ts
+++ b/src/importer/MusicXmlImporter.ts
@@ -902,6 +902,63 @@ export class MusicXmlImporter extends ScoreImporter {
                             }
                             // note.trillSpeed = Duration.ThirtySecond;
                         break;
+                    case 'mordent':
+                        // TODO: set mordent properties.
+                        // Function:
+                        //  START:unison, trill-step(down), END:unison.
+                        // Placement: above the note.
+                        break;
+                    case 'inverted-mordent':
+                        // TODO: set iverted mordent properties.
+                        // Function:
+                        //  START:unison, trill-step(up), END:unison.
+                        // Placement: above the note.
+                        break;
+                    case 'vertical-turn': // Fallthrough.
+                    case 'turn':
+                        // TODO: set turn properties.
+                        // Function:
+                        //  START:trill-step(up), unison, trill-step(down), END:unison.
+                        // Placement: above the note.
+                        break;
+                    case 'delayed-turn':
+                        // TODO: set delayed-turn properties.
+                        // Can be thought of as an invisible 'turn' ornamented note between two
+                        // regualr notes.
+                        // Placement: above staff between two notes.
+                        break;
+                    case 'inverted-vertical-turn': // Fallthrough.
+                    case 'inverted-turn':
+                        // TODO: set inverted turn properties.
+                        // START:trill-step(down), unison, trill-step(up), END:unison.   
+                        // Placement: above the note.
+                        break;
+                    case 'delayed-inverted-turn':
+                        // TODO: set delayed-inverted-turn properties.
+                        // Can be thought of as an invisible 'inverted-turn' note between two
+                        // regualr notes. 
+                        // Placement: above staff between two notes.
+                        break;
+                    case 'schleifer':                        case 'schleifer':
+                        // TODO: set schleifer properties.
+                        // A diatonic (current scale) slide between two notes.
+                        // Placement: on staff (middle) between two notes.
+                        break;
+                    case 'haydn':
+                        // A turn with different interpretations.
+                        // Page 9 (pdf:10) here can show the different uses:
+                        // https://content.alfred.com/catpages/00-1100.pdf
+                        break;
+                    case 'wavy-line':
+                        // Can be:
+                        //  - Part of a trill symbol.
+                        //  - Alone, could be considered as a vibrato symbol.
+                        break;
+                    case 'other-ornament':
+                        // Ornaments not part of the MusicXML standard.
+                    // TODO: Adapt the importer to most popular musicxml exporters in the wild.
+                    // Ex: Sibelius, Musescore, Noteflight, forte, finale, etc.
+                        break;
                 }
             }
         }

--- a/src/importer/MusicXmlImporter.ts
+++ b/src/importer/MusicXmlImporter.ts
@@ -939,7 +939,7 @@ export class MusicXmlImporter extends ScoreImporter {
                         // regualr notes. 
                         // Placement: above staff between two notes.
                         break;
-                    case 'schleifer':                        case 'schleifer':
+                    case 'schleifer':
                         // TODO: set schleifer properties.
                         // A diatonic (current scale) slide between two notes.
                         // Placement: on staff (middle) between two notes.

--- a/src/importer/MusicXmlImporter.ts
+++ b/src/importer/MusicXmlImporter.ts
@@ -913,9 +913,7 @@ export class MusicXmlImporter extends ScoreImporter {
                         break;
                     case 'inverted-vertical-turn': // Fallthrough.
                     case 'inverted-turn':
-                        // TODO: set inverted turn properties.
-                        // START:trill-step(down), unison, trill-step(up), END:unison.   
-                        // Placement: above the note.
+                        note.invertedTurnValue = this.parseTrillStep(c);
                         break;
                     case 'delayed-inverted-turn':
                         // TODO: set delayed-inverted-turn properties.

--- a/src/importer/MusicXmlImporter.ts
+++ b/src/importer/MusicXmlImporter.ts
@@ -885,6 +885,23 @@ export class MusicXmlImporter extends ScoreImporter {
                                 break;
                         }
                         break;
+                    case 'trill-mark':
+                            let trillStep: string = (c.attributes.get('trill-step') as string).toLowerCase();
+                            switch(trillStep){
+                                case 'unison':
+                                    note.trillValue = 0;
+                                    break;
+                                case 'half':
+                                    note.trillValue = 1;
+                                    break;
+                                case 'whole':
+                                    note.trillValue = 2;
+                                    break;
+                                default:
+                                    note.trillValue = 1;
+                            }
+                            // note.trillSpeed = Duration.ThirtySecond;
+                        break;
                 }
             }
         }

--- a/src/importer/MusicXmlImporter.ts
+++ b/src/importer/MusicXmlImporter.ts
@@ -890,16 +890,10 @@ export class MusicXmlImporter extends ScoreImporter {
                             // note.trillSpeed = Duration.ThirtySecond;
                         break;
                     case 'mordent':
-                        // TODO: set mordent properties.
-                        // Function:
-                        //  START:unison, trill-step(down), END:unison.
-                        // Placement: above the note.
+                        note.mordentValue = this.parseTrillStep(c);
                         break;
                     case 'inverted-mordent':
-                        // TODO: set iverted mordent properties.
-                        // Function:
-                        //  START:unison, trill-step(up), END:unison.
-                        // Placement: above the note.
+                        note.invertedMordentValue = this.parseTrillStep(c);
                         break;
                     case 'vertical-turn': // Fallthrough.
                     case 'turn':

--- a/src/importer/MusicXmlImporter.ts
+++ b/src/importer/MusicXmlImporter.ts
@@ -886,7 +886,7 @@ export class MusicXmlImporter extends ScoreImporter {
                         }
                         break;
                     case 'trill-mark':
-                            let trillStep: string = (c.attributes.get('trill-step') as string).toLowerCase();
+                            let trillStep: string = (c.attributes.get('trill-step') as string)?.toLowerCase();
                             switch(trillStep){
                                 case 'unison':
                                     note.trillValue = 0;

--- a/src/midi/MidiFileGenerator.ts
+++ b/src/midi/MidiFileGenerator.ts
@@ -472,6 +472,14 @@ export class MidiFileGenerator {
             return;
         }
 
+        //      
+        // Turn
+        if (note.isInvertedTurn && !staff.isPercussion) {
+            this.generateTurn(note, noteStart, noteDuration, noteKey, dynamicValue, channel, true);
+            // no further generation needed
+            return;
+        }
+
         //
         // Tremolo Picking
         if (note.beat.isTremolo) {

--- a/src/model/MelodicMotion.ts
+++ b/src/model/MelodicMotion.ts
@@ -1,13 +1,17 @@
 /**
- * Lists all melodic motions of a note.
+ * Lists all Melodic Motion types.
  */
  export enum MelodicMotion {
     /**
-     * Falling melodic motion. 
+     * No melodic motion indicated.
      */
-    Descending,
+    None,
     /**
-     * Rising melodic motion. 
+     * Ascending direction indicated.
      */
     Ascending,
- }
+    /**
+     * Descending direction indicated.
+     */
+    Descending
+}

--- a/src/model/MelodicMotion.ts
+++ b/src/model/MelodicMotion.ts
@@ -1,0 +1,13 @@
+/**
+ * Lists all melodic motions of a note.
+ */
+ export enum MelodicMotion {
+    /**
+     * Falling melodic motion. 
+     */
+    Descending,
+    /**
+     * Rising melodic motion. 
+     */
+    Ascending,
+ }

--- a/src/model/MusicFontSymbol.ts
+++ b/src/model/MusicFontSymbol.ts
@@ -118,6 +118,8 @@ export enum MusicFontSymbol {
     OrnamentTrill = 0xe566,
     OrnamentTurn = 0xe567,
     OrnamentInvertedTurn = 0xe568,
+    OrnamentMordent = 0xe56c,
+    OrnamentInvertedMordent = 0xe56d,
 
     StringsDownBow = 0xe610,
     StringsUpBow = 0xe612,

--- a/src/model/MusicFontSymbol.ts
+++ b/src/model/MusicFontSymbol.ts
@@ -116,6 +116,7 @@ export enum MusicFontSymbol {
     DynamicFFF = 0xe530,
 
     OrnamentTrill = 0xe566,
+    OrnamentTurn = 0xe567,
 
     StringsDownBow = 0xe610,
     StringsUpBow = 0xe612,

--- a/src/model/MusicFontSymbol.ts
+++ b/src/model/MusicFontSymbol.ts
@@ -117,6 +117,7 @@ export enum MusicFontSymbol {
 
     OrnamentTrill = 0xe566,
     OrnamentTurn = 0xe567,
+    OrnamentInvertedTurn = 0xe568,
 
     StringsDownBow = 0xe610,
     StringsUpBow = 0xe612,

--- a/src/model/Note.ts
+++ b/src/model/Note.ts
@@ -479,6 +479,44 @@ export class Note {
      */
     public invertedTurnSpeed: Duration = Duration.ThirtySecond;
      
+
+    /**
+     * Gets or sets the target note value for the Mordent ornament effect.
+     */
+    public mordentValue: number = -1;
+
+    public get mordentFret(): number { // Valid?
+        return this.mordentValue - this.stringTuning;
+    }
+
+    public get isMordent(): boolean {
+        return this.mordentValue >= 0;
+    }
+
+    /**
+     * Gets or sets the speed of the mordent ornament effect.
+     */
+    public MordentSpeed: Duration = Duration.ThirtySecond;
+
+    /**
+     * Gets or sets the target note value for the inverted mordent ornament effect.
+     */
+    public invertedMordentValue: number = -1;
+
+    public get invertedMordentFret(): number { // Valid?
+        return this.invertedMordentValue - this.stringTuning;
+    }
+
+    public get isInvertedMordent(): boolean {
+        return this.invertedTurnValue >= 0;
+    }
+
+    /**
+     * Gets or sets the speed of the inverted mordent ornament effect.
+     */
+    public invertedMordentSpeed: Duration = Duration.ThirtySecond;
+     
+         
     /**
      * Gets or sets the percentual duration of the note relative to the overall beat duration .
      */

--- a/src/model/Note.ts
+++ b/src/model/Note.ts
@@ -20,6 +20,7 @@ import { Logger } from '@src/Logger';
 import { ModelUtils } from '@src/model/ModelUtils';
 import { PickStroke } from '@src/model/PickStroke';
 import { PercussionMapper } from '@src/model/PercussionMapper';
+import { MelodicMotion } from './MelodicMotion';
 
 class NoteIdBag {
     public tieDestinationNoteId: number = -1;
@@ -437,10 +438,34 @@ export class Note {
         return this.trillValue >= 0;
     }
 
+
     /**
      * Gets or sets the speed of the trill effect.
      */
     public trillSpeed: Duration = Duration.ThirtySecond;
+
+    /**
+     * Gets or sets the target note value for the turn effect.
+     */
+    public turnValue: number = -1;
+
+    /*public get trillFret(): number {
+        return this.trillValue - this.stringTuning;
+    }*/
+
+    public get isTurn(): boolean {
+        return this.turnValue >= 0;
+    }
+
+    /**
+     * Gets or sets the speed of the turn ornament effect.
+     */
+    public turnSpeed: Duration = Duration.Sixteenth;
+
+    /**
+     * Gets or sets the speed of the turn ornament effect.
+     */
+    public turnDirection: MelodicMotion = MelodicMotion.Ascending;
 
     /**
      * Gets or sets the percentual duration of the note relative to the overall beat duration .

--- a/src/model/Note.ts
+++ b/src/model/Note.ts
@@ -448,7 +448,7 @@ export class Note {
      */
     public turnValue: number = -1;
 
-    public get turnFret(): number { // Plausible?
+    public get turnFret(): number { // Valid?
         return this.turnValue - this.stringTuning;
     }
 
@@ -461,6 +461,24 @@ export class Note {
      */
     public turnSpeed: Duration = Duration.ThirtySecond;
 
+    /**
+     * Gets or sets the target note value for the inverted turn ornament effect.
+     */
+    public invertedTurnValue: number = -1;
+
+    public get invertedTurnFret(): number { // Valid?
+        return this.invertedTurnValue - this.stringTuning;
+    }
+
+    public get isInvertedTurn(): boolean {
+        return this.invertedTurnValue >= 0;
+    }
+
+    /**
+     * Gets or sets the speed of the inverted turn ornament effect.
+     */
+    public invertedTurnSpeed: Duration = Duration.ThirtySecond;
+     
     /**
      * Gets or sets the percentual duration of the note relative to the overall beat duration .
      */

--- a/src/model/Note.ts
+++ b/src/model/Note.ts
@@ -20,7 +20,6 @@ import { Logger } from '@src/Logger';
 import { ModelUtils } from '@src/model/ModelUtils';
 import { PickStroke } from '@src/model/PickStroke';
 import { PercussionMapper } from '@src/model/PercussionMapper';
-import { MelodicMotion } from './MelodicMotion';
 
 class NoteIdBag {
     public tieDestinationNoteId: number = -1;
@@ -445,13 +444,13 @@ export class Note {
     public trillSpeed: Duration = Duration.ThirtySecond;
 
     /**
-     * Gets or sets the target note value for the turn effect.
+     * Gets or sets the target note value for the turn ornament effect.
      */
     public turnValue: number = -1;
 
-    /*public get trillFret(): number {
-        return this.trillValue - this.stringTuning;
-    }*/
+    public get turnFret(): number { // Plausible?
+        return this.turnValue - this.stringTuning;
+    }
 
     public get isTurn(): boolean {
         return this.turnValue >= 0;
@@ -460,12 +459,7 @@ export class Note {
     /**
      * Gets or sets the speed of the turn ornament effect.
      */
-    public turnSpeed: Duration = Duration.Sixteenth;
-
-    /**
-     * Gets or sets the speed of the turn ornament effect.
-     */
-    public turnDirection: MelodicMotion = MelodicMotion.Ascending;
+    public turnSpeed: Duration = Duration.ThirtySecond;
 
     /**
      * Gets or sets the percentual duration of the note relative to the overall beat duration .

--- a/src/rendering/effects/InvertedMordentEffectInfo.ts
+++ b/src/rendering/effects/InvertedMordentEffectInfo.ts
@@ -1,0 +1,26 @@
+import { Beat } from '@src/model/Beat';
+import { Note } from '@src/model/Note';
+import { BarRendererBase } from '@src/rendering/BarRendererBase';
+import { EffectBarGlyphSizing } from '@src/rendering/EffectBarGlyphSizing';
+import { NoteEffectInfoBase } from '@src/rendering/effects/NoteEffectInfoBase';
+import { EffectGlyph } from '@src/rendering/glyphs/EffectGlyph';
+import { NotationElement } from '@src/NotationSettings';
+import { InvertedMordentGlyph } from '../glyphs/InvertedMordentGlyph';
+
+export class InvertedMordentEffectInfo extends NoteEffectInfoBase {
+    public get notationElement(): NotationElement {
+        return NotationElement.EffectInvertedMordent;
+    }
+
+    protected shouldCreateGlyphForNote(note: Note): boolean {
+        return note.isInvertedMordent;
+    }
+
+    public get sizingMode(): EffectBarGlyphSizing {
+        return EffectBarGlyphSizing.SingleOnBeat;
+    }
+
+    public createNewGlyph(renderer: BarRendererBase, beat: Beat): EffectGlyph {
+        return new InvertedMordentGlyph(0, 0);
+    }
+}

--- a/src/rendering/effects/InvertedTurnEffectInfo.ts
+++ b/src/rendering/effects/InvertedTurnEffectInfo.ts
@@ -1,0 +1,26 @@
+import { Beat } from '@src/model/Beat';
+import { Note } from '@src/model/Note';
+import { BarRendererBase } from '@src/rendering/BarRendererBase';
+import { EffectBarGlyphSizing } from '@src/rendering/EffectBarGlyphSizing';
+import { NoteEffectInfoBase } from '@src/rendering/effects/NoteEffectInfoBase';
+import { EffectGlyph } from '@src/rendering/glyphs/EffectGlyph';
+import { InvertedTurnGlyph } from '../glyphs/InvertedTurnGlyph';
+import { NotationElement } from '@src/NotationSettings';
+
+export class InvertedTurnEffectInfo extends NoteEffectInfoBase {
+    public get notationElement(): NotationElement {
+        return NotationElement.EffectInvertedTurn;
+    }
+
+    protected shouldCreateGlyphForNote(note: Note): boolean {
+        return note.isInvertedTurn;
+    }
+
+    public get sizingMode(): EffectBarGlyphSizing {
+        return EffectBarGlyphSizing.SingleOnBeat;
+    }
+
+    public createNewGlyph(renderer: BarRendererBase, beat: Beat): EffectGlyph {
+        return new InvertedTurnGlyph(0, 0);
+    }
+}

--- a/src/rendering/effects/MordentEffectInfo.ts
+++ b/src/rendering/effects/MordentEffectInfo.ts
@@ -1,0 +1,26 @@
+import { Beat } from '@src/model/Beat';
+import { Note } from '@src/model/Note';
+import { BarRendererBase } from '@src/rendering/BarRendererBase';
+import { EffectBarGlyphSizing } from '@src/rendering/EffectBarGlyphSizing';
+import { NoteEffectInfoBase } from '@src/rendering/effects/NoteEffectInfoBase';
+import { EffectGlyph } from '@src/rendering/glyphs/EffectGlyph';
+import { NotationElement } from '@src/NotationSettings';
+import { MordentGlyph } from '../glyphs/MordentGlyph';
+
+export class MordentEffectInfo extends NoteEffectInfoBase {
+    public get notationElement(): NotationElement {
+        return NotationElement.EffectMordent;
+    }
+
+    protected shouldCreateGlyphForNote(note: Note): boolean {
+        return note.isMordent;
+    }
+
+    public get sizingMode(): EffectBarGlyphSizing {
+        return EffectBarGlyphSizing.SingleOnBeat;
+    }
+
+    public createNewGlyph(renderer: BarRendererBase, beat: Beat): EffectGlyph {
+        return new MordentGlyph(0, 0);
+    }
+}

--- a/src/rendering/effects/TurnEffectInfo.ts
+++ b/src/rendering/effects/TurnEffectInfo.ts
@@ -1,0 +1,26 @@
+import { Beat } from '@src/model/Beat';
+import { Note } from '@src/model/Note';
+import { BarRendererBase } from '@src/rendering/BarRendererBase';
+import { EffectBarGlyphSizing } from '@src/rendering/EffectBarGlyphSizing';
+import { NoteEffectInfoBase } from '@src/rendering/effects/NoteEffectInfoBase';
+import { EffectGlyph } from '@src/rendering/glyphs/EffectGlyph';
+import { TurnGlyph } from '@src/rendering/glyphs/TurnGlyph';
+import { NotationElement } from '@src/NotationSettings';
+
+export class TurnEffectInfo extends NoteEffectInfoBase {
+    public get notationElement(): NotationElement {
+        return NotationElement.EffectTurn;
+    }
+
+    protected shouldCreateGlyphForNote(note: Note): boolean {
+        return note.isTurn;
+    }
+
+    public get sizingMode(): EffectBarGlyphSizing {
+        return EffectBarGlyphSizing.SingleOnBeat;
+    }
+
+    public createNewGlyph(renderer: BarRendererBase, beat: Beat): EffectGlyph {
+        return new TurnGlyph(0, 0);
+    }
+}

--- a/src/rendering/glyphs/EffectGlyph.ts
+++ b/src/rendering/glyphs/EffectGlyph.ts
@@ -7,7 +7,7 @@ import { Glyph } from '@src/rendering/glyphs/Glyph';
  */
 export class EffectGlyph extends Glyph {
     /**
-     * Gets or sets the beat where the glyph belongs to.
+     * Gets or sets the beat wherere the glyph belongs to.
      */
     public beat: Beat | null = null;
 

--- a/src/rendering/glyphs/InvertedMordentGlyph.ts
+++ b/src/rendering/glyphs/InvertedMordentGlyph.ts
@@ -1,0 +1,21 @@
+import { MusicFontSymbol } from '@src/model';
+import { ICanvas } from '@src/platform/ICanvas';
+import { EffectGlyph } from '@src/rendering/glyphs/EffectGlyph';
+import { RenderingResources } from '@src/RenderingResources';
+
+export class InvertedMordentGlyph extends EffectGlyph {
+    public constructor(x: number, y: number) {
+        super(x, y);
+    }
+
+    public override doLayout(): void {
+        super.doLayout();
+        this.height = 20 * this.scale;
+    }
+
+    public override paint(cx: number, cy: number, canvas: ICanvas): void {
+        let res: RenderingResources = this.renderer.resources;
+        canvas.font = res.markerFont;
+        canvas.fillMusicFontSymbol(cx, cy,this.scale,MusicFontSymbol.OrnamentInvertedMordent);
+    }
+}

--- a/src/rendering/glyphs/InvertedTurnGlyph.ts
+++ b/src/rendering/glyphs/InvertedTurnGlyph.ts
@@ -1,0 +1,21 @@
+import { MusicFontSymbol } from '@src/model';
+import { ICanvas } from '@src/platform/ICanvas';
+import { EffectGlyph } from '@src/rendering/glyphs/EffectGlyph';
+import { RenderingResources } from '@src/RenderingResources';
+
+export class InvertedTurnGlyph extends EffectGlyph {
+    public constructor(x: number, y: number) {
+        super(x, y);
+    }
+
+    public override doLayout(): void {
+        super.doLayout();
+        this.height = 20 * this.scale;
+    }
+
+    public override paint(cx: number, cy: number, canvas: ICanvas): void {
+        let res: RenderingResources = this.renderer.resources;
+        canvas.font = res.markerFont;
+        canvas.fillMusicFontSymbol(cx, cy,this.scale,MusicFontSymbol.OrnamentInvertedTurn);
+    }
+}

--- a/src/rendering/glyphs/MordentGlyph.ts
+++ b/src/rendering/glyphs/MordentGlyph.ts
@@ -1,0 +1,21 @@
+import { MusicFontSymbol } from '@src/model';
+import { ICanvas } from '@src/platform/ICanvas';
+import { EffectGlyph } from '@src/rendering/glyphs/EffectGlyph';
+import { RenderingResources } from '@src/RenderingResources';
+
+export class MordentGlyph extends EffectGlyph {
+    public constructor(x: number, y: number) {
+        super(x, y);
+    }
+
+    public override doLayout(): void {
+        super.doLayout();
+        this.height = 20 * this.scale;
+    }
+
+    public override paint(cx: number, cy: number, canvas: ICanvas): void {
+        let res: RenderingResources = this.renderer.resources;
+        canvas.font = res.markerFont;
+        canvas.fillMusicFontSymbol(cx, cy,this.scale,MusicFontSymbol.OrnamentMordent);
+    }
+}

--- a/src/rendering/glyphs/TurnGlyph.ts
+++ b/src/rendering/glyphs/TurnGlyph.ts
@@ -1,0 +1,21 @@
+import { MusicFontSymbol } from '@src/model';
+import { ICanvas } from '@src/platform/ICanvas';
+import { EffectGlyph } from '@src/rendering/glyphs/EffectGlyph';
+import { RenderingResources } from '@src/RenderingResources';
+
+export class TurnGlyph extends EffectGlyph {
+    public constructor(x: number, y: number) {
+        super(x, y);
+    }
+
+    public override doLayout(): void {
+        super.doLayout();
+        this.height = 20 * this.scale;
+    }
+
+    public override paint(cx: number, cy: number, canvas: ICanvas): void {
+        let res: RenderingResources = this.renderer.resources;
+        canvas.font = res.markerFont;
+        canvas.fillMusicFontSymbol(cx, cy,this.scale,MusicFontSymbol.OrnamentTurn);
+    }
+}


### PR DESCRIPTION
The duration for trills can be subjective or period specific. The default duration seems fitting for most cases.

### Issues
Trills are ignored (not parsed).
### Proposed changes
Added trill parsing logic within ornaments-parser method.
Note: Other ornaments seem to be unsupported by alphaTab (not part of the Note class).

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
