### PR TITLE
Add minor keys

### DIFF
--- a/src.csharp/AlphaTab.Test/Test/Globals.cs
+++ b/src.csharp/AlphaTab.Test/Test/Globals.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace AlphaTab.Test
@@ -83,6 +83,27 @@ namespace AlphaTab.Test
         public void ToBeFalsy()
         {
             Assert.AreEqual(default!, _actual, _message);
+        }
+
+        public void ToThrowError(Type expected)
+        {
+            if (_actual is Delegate d)
+            {
+                try
+                {
+                    d.DynamicInvoke();
+                    Assert.Fail("Did not throw error:" + _message);
+                }
+                catch (System.Reflection.TargetInvocationException e)
+                {
+                    if (expected.IsInstanceOfType(e.InnerException)) return;
+                }
+                Assert.Fail("Exception type didn't match:" + _message);
+            }
+            else
+            {
+                Assert.Fail("ToThrowError can only be used with an exception:" + _message);
+            }
         }
     }
 }

--- a/src.csharp/AlphaTab.Test/Test/Globals.cs
+++ b/src.csharp/AlphaTab.Test/Test/Globals.cs
@@ -10,6 +10,11 @@ namespace AlphaTab.Test
             return new Expector<T>(actual);
         }
 
+        public static Expector<Action> Expect(Action actual)
+        {
+            return new Expector<Action>(actual);
+        }
+
         public static void Fail(object? message)
         {
             Assert.Fail(Convert.ToString(message));
@@ -87,16 +92,19 @@ namespace AlphaTab.Test
 
         public void ToThrowError(Type expected)
         {
-            if (_actual is Delegate d)
+            if (_actual is Action d)
             {
                 try
                 {
-                    d.DynamicInvoke();
+                    d();
                     Assert.Fail("Did not throw error:" + _message);
                 }
-                catch (System.Reflection.TargetInvocationException e)
+                catch (Exception e)
                 {
-                    if (expected.IsInstanceOfType(e.InnerException)) return;
+                    if (expected.IsInstanceOfType(e)) 
+					{
+						return;
+					}
                 }
                 Assert.Fail("Exception type didn't match:" + _message);
             }

--- a/src.kotlin/alphaTab/alphaTab/build.gradle.kts
+++ b/src.kotlin/alphaTab/alphaTab/build.gradle.kts
@@ -99,6 +99,9 @@ android {
         "../../../font/bravura",
         "../../../font/sonivox"
     )
+    sourceSets["main"].kotlin.srcDirs(
+        "../../../dist/lib.kotlin/commonMain/generated"
+    )
     sourceSets["test"].manifest.srcFile("src/androidTest/AndroidManifest.xml")
     sourceSets["test"].assets.srcDirs(
         "../../../test-data",
@@ -106,6 +109,10 @@ android {
         "../../../font/roboto",
         "../../../font/ptserif"
     )
+    sourceSets["test"].kotlin.srcDirs(
+        "../../../dist/lib.kotlin/commonTest/generated"
+    )
+
     androidResources {
         ignoreAssetsPattern = arrayOf(
             "eot",

--- a/src.kotlin/alphaTab/alphaTab/src/androidTest/kotlin/alphaTab/test/Globals.kt
+++ b/src.kotlin/alphaTab/alphaTab/src/androidTest/kotlin/alphaTab/test/Globals.kt
@@ -33,7 +33,7 @@ public class Expector<T> {
         kotlin.test.assertEquals(exp, _actual, _message + message)
     }
 
-    public fun toBeCloseTo(expected:Double, message:String? = null) {
+    public fun toBeCloseTo(expected: Double, message: String? = null) {
         if(_actual is Number) {
             kotlin.test.assertEquals(expected, _actual.toDouble(), 0.001, _message + message)
         } else {
@@ -41,7 +41,7 @@ public class Expector<T> {
         }
     }
 
-    public fun toBe(expected:Any?) {
+    public fun toBe(expected: Any?) {
         var exp = expected
         if(exp is Int && _actual is Double) {
             exp = exp.toDouble()
@@ -63,5 +63,21 @@ public class Expector<T> {
 
     public fun toBeFalsy() {
         kotlin.test.assertNull(_actual, _message)
+    }
+
+    public fun toThrowError(expected: KClass<out Exception>) {
+        if (_actual is Function<*>) {
+            try {
+                //_actual() // fix
+                throw UnsupportedFormatError() // remove
+                kotlin.test.fail("Did not throw error: $_message")
+            } catch (e: Exception) {
+                if (expected::class.isInstance(e::class)) { // bad
+                    return
+                }
+            }
+            kotlin.test.fail("Exception type didn't match: $_message")
+        }
+        kotlin.test.fail("toThrowError can only be used with an exception: $_message")
     }
 }

--- a/src.kotlin/alphaTab/alphaTab/src/androidTest/kotlin/alphaTab/test/Globals.kt
+++ b/src.kotlin/alphaTab/alphaTab/src/androidTest/kotlin/alphaTab/test/Globals.kt
@@ -1,8 +1,14 @@
 package alphaTab.test
 
+import kotlin.reflect.KClass
+
 public class Globals {
     companion object {
         public fun <T> expect(actual: T): Expector<T> {
+            return Expector(actual)
+        }
+
+        public fun expect(actual: () -> Unit): Expector<() -> Unit> {
             return Expector(actual)
         }
 
@@ -66,10 +72,10 @@ public class Expector<T> {
     }
 
     public fun toThrowError(expected: KClass<out Exception>) {
-        if (_actual is Function<*>) {
+        val actual = _actual
+        if (actual is Function0<*>) {
             try {
-                //_actual() // fix
-                throw UnsupportedFormatError() // remove
+                actual()
                 kotlin.test.fail("Did not throw error: $_message")
             } catch (e: Exception) {
                 if (expected::class.isInstance(e::class)) { // bad

--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -343,34 +343,62 @@ export class AlphaTexImporter extends ScoreImporter {
     private parseKeySignature(str: string): number {
         switch (str.toLowerCase()) {
             case 'cb':
+            case 'cbmajor':
                 return -7;
             case 'gb':
+            case 'gbmajor':
+            case 'd#minor':
                 return -6;
             case 'db':
+            case 'dbmajor':
+            case 'bbminor':
                 return -5;
             case 'ab':
+            case 'abmajor':
+            case 'fminor':
                 return -4;
             case 'eb':
+            case 'ebmajor':
+            case 'cminor':
                 return -3;
             case 'bb':
+            case 'bbmajor':
+            case 'gminor':
                 return -2;
             case 'f':
+            case 'fmajor':
+            case 'dminor':
                 return -1;
             case 'c':
+            case 'cmajor':
+            case 'aminor':
                 return 0;
             case 'g':
+            case 'gmajor':
+            case 'eminor':
                 return 1;
             case 'd':
+            case 'dmajor':
+            case 'bminor':
                 return 2;
             case 'a':
+            case 'amajor':
+            case 'f#minor':
                 return 3;
             case 'e':
+            case 'emajor':
+            case 'c#minor':
                 return 4;
             case 'b':
+            case 'bmajor':
+            case 'g#minor':
                 return 5;
             case 'f#':
+            case 'f#major':
+            case 'ebminor':
                 return 6;
             case 'c#':
+            case 'c#major':
                 return 7;
             default:
                 return 0;

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -924,11 +924,11 @@ describe('AlphaTexImporterTest', () => {
     });
 
     it('expect-invalid-format-xml', () => {
-        expect(() => parseTex('<xml>')).toThrowError(UnsupportedFormatError);
+        expect<() => Score>(() => parseTex('<xml>')).toThrowError(UnsupportedFormatError);
     });
 
     it('expect-invalid-format-other-text', () => {
-        expect(() => parseTex('This is not an alphaTex file')).toThrowError(UnsupportedFormatError);
+        expect<() => Score>(() => parseTex('This is not an alphaTex file')).toThrowError(UnsupportedFormatError);
     });
 
     it('auto-detect-tuning-from-instrument', () => {
@@ -963,7 +963,7 @@ describe('AlphaTexImporterTest', () => {
     });
 
     it('does-not-hang-on-backslash', () => {
-        expect(() => parseTex('\\title Test . 3.3 \\')).toThrowError(UnsupportedFormatError)
+        expect<() => Score>(() => parseTex('\\title Test . 3.3 \\')).toThrowError(UnsupportedFormatError)
     })
 
     function runSectionNoteSymbolTest(noteSymbol: string) {

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -9,6 +9,7 @@ import { DynamicValue } from '@src/model/DynamicValue';
 import { Fingers } from '@src/model/Fingers';
 import { GraceType } from '@src/model/GraceType';
 import { HarmonicType } from '@src/model/HarmonicType';
+import { KeySignature } from '@src/model';
 import { Score } from '@src/model/Score';
 import { SlideInType } from '@src/model/SlideInType';
 import { SlideOutType } from '@src/model/SlideOutType';
@@ -655,6 +656,29 @@ describe('AlphaTexImporterTest', () => {
         expect(score.masterBars[3].section!.marker).toEqual('S');
     });
 
+    it('key-signature', () => {
+        let tex: string = `:1 3.3 | \\ks C 3.3 | \\ks Cmajor 3.3 | \\ks Aminor 3.3 |
+        \\ks F 3.3 | \\ks bbmajor 3.3 | \\ks CMINOR 3.3 | \\ks aB 3.3 | \\ks db 3.3 | \\ks d#minor 3.3 |
+        \\ks g 3.3 | \\ks Dmajor 3.3 | \\ks f#minor 3.3 | \\ks E 3.3 | \\ks Bmajor 3.3 | \\ks Ebminor 3.3`;
+        let score: Score = parseTex(tex);
+        expect(score.masterBars[0].keySignature).toEqual(KeySignature.C)
+        expect(score.masterBars[1].keySignature).toEqual(KeySignature.C)
+        expect(score.masterBars[2].keySignature).toEqual(KeySignature.C)
+        expect(score.masterBars[3].keySignature).toEqual(KeySignature.C)
+        expect(score.masterBars[4].keySignature).toEqual(KeySignature.F)
+        expect(score.masterBars[5].keySignature).toEqual(KeySignature.Bb)
+        expect(score.masterBars[6].keySignature).toEqual(KeySignature.Eb)
+        expect(score.masterBars[7].keySignature).toEqual(KeySignature.Ab)
+        expect(score.masterBars[8].keySignature).toEqual(KeySignature.Db)
+        expect(score.masterBars[9].keySignature).toEqual(KeySignature.Gb)
+        expect(score.masterBars[10].keySignature).toEqual(KeySignature.G)
+        expect(score.masterBars[11].keySignature).toEqual(KeySignature.D)
+        expect(score.masterBars[12].keySignature).toEqual(KeySignature.A)
+        expect(score.masterBars[13].keySignature).toEqual(KeySignature.E)
+        expect(score.masterBars[14].keySignature).toEqual(KeySignature.B)
+        expect(score.masterBars[15].keySignature).toEqual(KeySignature.FSharp)
+    });
+
     it('pop-slap-tap', () => {
         let tex: string = '3.3{p} 3.3{s} 3.3{tt} r';
         let score: Score = parseTex(tex);
@@ -900,25 +924,11 @@ describe('AlphaTexImporterTest', () => {
     });
 
     it('expect-invalid-format-xml', () => {
-        try {
-            parseTex('<xml>');
-            fail('Expected error');
-        } catch (e) {
-            if (!(e instanceof UnsupportedFormatError)) {
-                fail(`Expected UnsupportedFormatError got ${e}`);
-            }
-        }
+        expect(() => parseTex('<xml>')).toThrowError(UnsupportedFormatError);
     });
 
     it('expect-invalid-format-other-text', () => {
-        try {
-            parseTex('This is not an alphaTex file');
-            fail('Expected error');
-        } catch (e) {
-            if (!(e instanceof UnsupportedFormatError)) {
-                fail(`Expected UnsupportedFormatError got ${e}`);
-            }
-        }
+        expect(() => parseTex('This is not an alphaTex file')).toThrowError(UnsupportedFormatError);
     });
 
     it('auto-detect-tuning-from-instrument', () => {
@@ -953,12 +963,7 @@ describe('AlphaTexImporterTest', () => {
     });
 
     it('does-not-hang-on-backslash', () => {
-        try {
-            parseTex('\\title Test . 3.3 \\')
-            fail('Parsing should fail');
-        } catch (e) {
-            // success
-        }
+        expect(() => parseTex('\\title Test . 3.3 \\')).toThrowError(UnsupportedFormatError)
     })
 
     function runSectionNoteSymbolTest(noteSymbol: string) {
@@ -967,6 +972,7 @@ describe('AlphaTexImporterTest', () => {
         expect(score.masterBars.length).toEqual(3);
         expect(score.tracks[0].staves[0].bars[0].voices[0].beats.length).toEqual(4);
         expect(score.masterBars[1].section!.text).toEqual('Verse');
+        expect(score.masterBars[1].section!.marker).toEqual('');
         expect(score.tracks[0].staves[0].bars[1].voices[0].beats.length).toEqual(1);
     }
 

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -924,11 +924,11 @@ describe('AlphaTexImporterTest', () => {
     });
 
     it('expect-invalid-format-xml', () => {
-        expect<() => Score>(() => parseTex('<xml>')).toThrowError(UnsupportedFormatError);
+        expect(() => parseTex('<xml>')).toThrowError(UnsupportedFormatError);
     });
 
     it('expect-invalid-format-other-text', () => {
-        expect<() => Score>(() => parseTex('This is not an alphaTex file')).toThrowError(UnsupportedFormatError);
+        expect(() => parseTex('This is not an alphaTex file')).toThrowError(UnsupportedFormatError);
     });
 
     it('auto-detect-tuning-from-instrument', () => {
@@ -963,7 +963,7 @@ describe('AlphaTexImporterTest', () => {
     });
 
     it('does-not-hang-on-backslash', () => {
-        expect<() => Score>(() => parseTex('\\title Test . 3.3 \\')).toThrowError(UnsupportedFormatError)
+        expect(() => parseTex('\\title Test . 3.3 \\')).toThrowError(UnsupportedFormatError)
     })
 
     function runSectionNoteSymbolTest(noteSymbol: string) {


### PR DESCRIPTION
### Issues
Fixes #875 

### Proposed changes
Adds the ability to specify minor keys in alphaTab. Major keys can also be explicitly stated.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [x] New tests were added

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website
