### PR TITLE
Fix wrong overflow top with bend

### DIFF
--- a/src/rendering/glyphs/TabBendGlyph.ts
+++ b/src/rendering/glyphs/TabBendGlyph.ts
@@ -124,7 +124,8 @@ export class TabBendGlyph extends Glyph {
 
     public override doLayout(): void {
         super.doLayout();
-        let bendHeight: number = this._maxBendValue * TabBendGlyph.BendValueHeight * this.scale;
+        let bendHeight: number = this._maxBendValue * TabBendGlyph.BendValueHeight * this.scale
+            + this.renderer.resources.tablatureFont.size + 2.0 * this.scale;
         this.renderer.registerOverflowTop(bendHeight);
         let value: number = 0;
         for (let note of this._notes) {


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Issue [Top overflowed with bend](https://github.com/CoderLine/alphaTab/issues/910)

### Proposed changes
<!-- Describe the proposed changes -->
Calculating height of bend identify while registering OverflowTop

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] Existing builds tests pass
- [ ] New tests were added