### PR TITLE
Fix beat removeNote function keeping stringLookup reference

### DIFF
--- a/src/model/Beat.ts
+++ b/src/model/Beat.ts
@@ -502,6 +502,9 @@ export class Beat {
         let index: number = this.notes.indexOf(note);
         if (index >= 0) {
             this.notes.splice(index, 1);
+            if (note.isStringed) {
+                this.noteStringLookup.delete(note.string);
+            }
         }
     }
 

--- a/test/model/Beat.test.ts
+++ b/test/model/Beat.test.ts
@@ -1,0 +1,25 @@
+import { Note } from '@src/model';
+import { Beat } from '@src/model/Beat';
+
+describe('BeatTests', () => {
+    it('add-stringed-note', () => {
+        const beat = new Beat();
+        const note = new Note();
+        note.string = 2;
+        beat.addNote(note);
+        expect(beat.notes.length).toBe(1);
+        expect(beat.hasNoteOnString(2)).toBe(true);
+        expect(beat.getNoteOnString(2)).toBe(note);
+    });
+
+    it('remove-stringed-note', () => {
+        const beat = new Beat();
+        const note = new Note();
+        note.string = 1;
+        beat.addNote(note);
+        beat.removeNote(note);
+        expect(beat.notes.length).toBe(0);
+        expect(beat.hasNoteOnString(2)).toBe(false);
+        expect(beat.getNoteOnString(2)).toBe(null);
+    });
+});


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Fixes #932

### Proposed changes
<!-- Describe the proposed changes -->

### Checklist
- [X] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [X] Changes are implemented
- [X] Existing builds tests pass
- [X] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
