### PR TITLE
Update transposition pitches not only on score change

### DIFF
--- a/src/AlphaTabApiBase.ts
+++ b/src/AlphaTabApiBase.ts
@@ -183,6 +183,10 @@ export class AlphaTabApiBase<TSettings> {
      * Applies any changes that were done to the settings object and informs the {@link renderer} about any new values to consider.
      */
     public updateSettings(): void {
+        const score = this.score;
+        if (score) {
+            ModelUtils.applyPitchOffsets(this.settings, score);
+        }
         this.renderer.updateSettings(this.settings);
         // enable/disable player if needed
         if (this.settings.player.enablePlayer) {
@@ -272,8 +276,8 @@ export class AlphaTabApiBase<TSettings> {
     }
 
     private internalRenderTracks(score: Score, tracks: Track[]): void {
+        ModelUtils.applyPitchOffsets(this.settings, score);
         if (score !== this.score) {
-            ModelUtils.applyPitchOffsets(this.settings, score);
             this.score = score;
             this.tracks = tracks;
             this._trackIndexes = [];
@@ -1017,7 +1021,7 @@ export class AlphaTabApiBase<TSettings> {
                         if (
                             nextBeatBoundings &&
                             nextBeatBoundings.barBounds.masterBarBounds.staveGroupBounds ===
-                                barBoundings.staveGroupBounds
+                            barBoundings.staveGroupBounds
                         ) {
                             nextBeatX = nextBeatBoundings.visualBounds.x;
                         }


### PR DESCRIPTION
### Issues
Fixes #896

### Proposed changes
Ensures the transposition pitches are applied to the score not only when the score changes but also when settings are updated and new renderings are initiated. This allows more of an on-the-fly transposition. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
