### PR TITLE
Ensure correct BoundsLookup state

### DIFF
--- a/src/platform/javascript/AlphaTabWorkerScoreRenderer.ts
+++ b/src/platform/javascript/AlphaTabWorkerScoreRenderer.ts
@@ -105,6 +105,7 @@ export class AlphaTabWorkerScoreRenderer<T> implements IScoreRenderer {
                 break;
             case 'alphaTab.postRenderFinished':
                 this.boundsLookup = BoundsLookup.fromJson(data.boundsLookup, this._api.score!);
+                this.boundsLookup.finish();
                 (this.postRenderFinished as EventEmitter).trigger();
                 break;
             case 'alphaTab.error':

--- a/src/rendering/ScoreRenderer.ts
+++ b/src/rendering/ScoreRenderer.ts
@@ -198,6 +198,7 @@ export class ScoreRenderer implements IScoreRenderer {
     public readonly error: IEventEmitterOfT<Error> = new EventEmitterOfT<Error>();
 
     private onRenderFinished() {
+        this.boundsLookup?.finish();
         const e = new RenderFinishedEventArgs();
         e.totalHeight = this.layout!.height;
         e.totalWidth = this.layout!.width;

--- a/src/rendering/utils/BarBounds.ts
+++ b/src/rendering/utils/BarBounds.ts
@@ -58,4 +58,11 @@ export class BarBounds {
         }
         return beat;
     }
+
+    /**
+     * Finishes the lookup object and optimizes itself for fast access.
+     */
+    public finish(): void {
+        this.beats.sort((a, b) => a.realBounds.x - b.realBounds.x);
+    }
 }

--- a/src/rendering/utils/MasterBarBounds.ts
+++ b/src/rendering/utils/MasterBarBounds.ts
@@ -60,10 +60,14 @@ export class MasterBarBounds {
      */
     public findBeatAtPos(x: number, y: number): Beat | null {
         let beat: BeatBounds | null = null;
+        let distance = 10000000;
         for (let bar of this.bars) {
             let b = bar.findBeatAtPos(x);
             if (b && (!beat || beat.realBounds.x < b.realBounds.x)) {
-                beat = b;
+                const newDistance = Math.abs(b.realBounds.x - x);
+                if (!beat || newDistance < distance) {
+                    beat = b;
+                }
             }
         }
         return !beat ? null : beat.beat;
@@ -88,6 +92,9 @@ export class MasterBarBounds {
             }
             return 0;
         });
+        for (const bar of this.bars) {
+            bar.finish();
+        }
     }
 
     /**


### PR DESCRIPTION
### Issues
Fixes #959

### Proposed changes
Beats were not sorted by the x-axis like expected and the finish operation was not called. Seems some stuff got lost over time. 
Mainly affects multi-voice/-staff/-track display. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
