### PR TITLE
Reworking AudioContext suspend-resume handling

### DIFF
--- a/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidSynthOutput.kt
+++ b/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidSynthOutput.kt
@@ -27,9 +27,6 @@ internal class AndroidSynthOutput(
     override val sampleRate: Double
         get() = PreferredSampleRate.toDouble()
 
-    override fun activate() {
-    }
-
     override fun open(bufferTimeInMilliseconds: Double) {
         _bufferCount = (bufferTimeInMilliseconds * PreferredSampleRate /
             1000 /

--- a/src/platform/javascript/AlphaSynthWebWorkerApi.ts
+++ b/src/platform/javascript/AlphaSynthWebWorkerApi.ts
@@ -236,7 +236,6 @@ export class AlphaSynthWebWorkerApi implements IAlphaSynth {
     //
     // API communicating with the web worker
     public play(): boolean {
-        this._output.activate();
         this._synth.postMessage({
             cmd: 'alphaSynth.play'
         });
@@ -250,7 +249,6 @@ export class AlphaSynthWebWorkerApi implements IAlphaSynth {
     }
 
     public playPause(): void {
-        this._output.activate();
         this._synth.postMessage({
             cmd: 'alphaSynth.playPause'
         });

--- a/src/platform/javascript/AlphaSynthWorkerSynthOutput.ts
+++ b/src/platform/javascript/AlphaSynthWorkerSynthOutput.ts
@@ -82,8 +82,4 @@ export class AlphaSynthWorkerSynthOutput implements ISynthOutput {
             cmd: 'alphaSynth.output.resetSamples'
         });
     }
-
-    public activate(): void {
-        // nothing to do
-    }
 }

--- a/src/synth/AlphaSynth.ts
+++ b/src/synth/AlphaSynth.ts
@@ -231,7 +231,6 @@ export class AlphaSynth implements IAlphaSynth {
         if (this.state !== PlayerState.Paused || !this._isMidiLoaded) {
             return false;
         }
-        this.output.activate();
 
         this.playInternal();
 

--- a/src/synth/ISynthOutput.ts
+++ b/src/synth/ISynthOutput.ts
@@ -43,11 +43,6 @@ export interface ISynthOutput {
     resetSamples(): void;
 
     /**
-     * Activates the output component.
-     */
-    activate(): void;
-
-    /**
      * Fired when the output has been successfully opened and is ready to play samples.
      */
     readonly ready: IEventEmitter;

--- a/test/audio/TestOutput.ts
+++ b/test/audio/TestOutput.ts
@@ -40,10 +40,6 @@ export class TestOutput implements ISynthOutput {
         // nothing to do
     }
 
-    public activate(): void {
-        // nothing to do
-    }
-
     /**
      * Fired when the output has been successfully opened and is ready to play samples.
      */


### PR DESCRIPTION
### Issues
Fixes #971 

### Proposed changes
Reworks the suspend-resume handling of AudioContexts to avoid the known WebKit bugs on device sleep and reactivation. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [ ] Changes are implemented
- [ ] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
