### PR TITLE
Handle first MasterBar Tempo changes correctly

### DIFF
--- a/src/importer/MusicXmlImporter.ts
+++ b/src/importer/MusicXmlImporter.ts
@@ -1065,6 +1065,9 @@ export class MusicXmlImporter extends ScoreImporter {
                             tempoAutomation.type = AutomationType.Tempo;
                             tempoAutomation.value = parseInt(tempo);
                             masterBar.tempoAutomation = tempoAutomation;
+                            if(masterBar.index === 0) {
+                                masterBar.score.tempo = tempoAutomation.value;
+                            }
                         }
                         break;
                     case 'direction-type':
@@ -1102,6 +1105,9 @@ export class MusicXmlImporter extends ScoreImporter {
         tempoAutomation.type = AutomationType.Tempo;
         tempoAutomation.value = perMinute * ((unit / 4) | 0);
         masterBar.tempoAutomation = tempoAutomation;
+        if(masterBar.index === 0) {
+            masterBar.score.tempo = tempoAutomation.value;
+        }
     }
 
     private parseAttributes(element: XmlNode, bars: Bar[], masterBar: MasterBar, track: Track): void {

--- a/src/midi/MidiFileGenerator.ts
+++ b/src/midi/MidiFileGenerator.ts
@@ -185,12 +185,12 @@ export class MidiFileGenerator {
         }
 
         // tempo
-        if (!previousMasterBar) {
-            this._handler.addTempo(currentTick, masterBar.score.tempo);
-            this._currentTempo = masterBar.score.tempo;
-        } else if (masterBar.tempoAutomation) {
+        if (masterBar.tempoAutomation) {
             this._handler.addTempo(currentTick, masterBar.tempoAutomation.value);
             this._currentTempo = masterBar.tempoAutomation.value;
+        } else if (!previousMasterBar) {
+            this._handler.addTempo(currentTick, masterBar.score.tempo);
+            this._currentTempo = masterBar.score.tempo;
         }
 
         const masterBarLookup: MasterBarTickLookup = new MasterBarTickLookup();

--- a/test-data/musicxml3/first-bar-tempo.musicxml
+++ b/test-data/musicxml3/first-bar-tempo.musicxml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 1.1 Partwise//EN"
+                                "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="1.1">
+  <identification>
+    <miscellaneous>
+      <miscellaneous-field name="description">Tempo Markings: note=bpm,
+          text (note=bpm), note=note, (note=note), (note=bpm)</miscellaneous-field>
+    </miscellaneous>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name></part-name>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+
+    <!--=======================================================-->
+    <measure number="1">
+      <direction>
+        <direction-type>
+          <metronome>
+            <beat-unit>quarter</beat-unit>
+            <beat-unit-dot/>
+            <beat-unit>half</beat-unit>
+            <beat-unit-dot/>
+          </metronome>
+        </direction-type>
+      </direction>
+      <direction>
+        <direction-type>
+          <metronome parentheses="yes">
+            <beat-unit>quarter</beat-unit>
+            <beat-unit-dot/>
+            <per-minute>60</per-minute>
+          </metronome>
+        </direction-type>
+      </direction>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+    <!--=======================================================-->
+    <measure number="2">
+      <direction>
+        <direction-type>
+          <metronome>
+            <beat-unit>quarter</beat-unit>
+            <beat-unit-dot/>
+            <beat-unit>half</beat-unit>
+            <beat-unit-dot/>
+          </metronome>
+        </direction-type>
+      </direction>
+      <direction>
+        <direction-type>
+          <metronome parentheses="yes">
+            <beat-unit>quarter</beat-unit>
+            <beat-unit-dot/>
+            <per-minute>60</per-minute>
+          </metronome>
+        </direction-type>
+      </direction>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+  <!--=========================================================-->
+</score-partwise>

--- a/test/audio/MidiFileGenerator.test.ts
+++ b/test/audio/MidiFileGenerator.test.ts
@@ -143,9 +143,7 @@ describe('MidiFileGeneratorTest', () => {
             if (i < expectedEvents.length) {
                 expect(expectedEvents[i].equals(handler.midiEvents[i]))
                     .withContext(`i[${i}] expected[${expectedEvents[i]}] !== actual[${handler.midiEvents[i]}]`)
-                    .toEqual(
-                        true,
-                    );
+                    .toEqual(true);
             }
         }
         expect(handler.midiEvents.length).toEqual(expectedEvents.length);
@@ -365,9 +363,7 @@ describe('MidiFileGeneratorTest', () => {
             if (i < expectedEvents.length) {
                 expect(expectedEvents[i].equals(handler.midiEvents[i]))
                     .withContext(`i[${i}] expected[${expectedEvents[i]}] !== actual[${handler.midiEvents[i]}]`)
-                    .toEqual(
-                        true
-                    );
+                    .toEqual(true);
             }
         }
         expect(handler.midiEvents.length).toEqual(expectedEvents.length);
@@ -453,9 +449,7 @@ describe('MidiFileGeneratorTest', () => {
             if (i < expectedEvents.length) {
                 expect(expectedEvents[i].equals(handler.midiEvents[i]))
                     .withContext(`i[${i}] expected[${expectedEvents[i]}] !== actual[${handler.midiEvents[i]}]`)
-                    .toEqual(
-                        true
-                    );
+                    .toEqual(true);
             }
         }
         expect(handler.midiEvents.length).toEqual(expectedEvents.length);
@@ -526,9 +520,7 @@ describe('MidiFileGeneratorTest', () => {
             if (i < expectedEvents.length) {
                 expect(expectedEvents[i].equals(handler.midiEvents[i]))
                     .withContext(`i[${i}] expected[${expectedEvents[i]}] !== actual[${handler.midiEvents[i]}]`)
-                    .toEqual(
-                        true
-                    );
+                    .toEqual(true);
             }
         }
         expect(handler.midiEvents.length).toEqual(expectedEvents.length);
@@ -601,9 +593,7 @@ describe('MidiFileGeneratorTest', () => {
             if (i < expectedEvents.length) {
                 expect(expectedEvents[i].equals(handler.midiEvents[i]))
                     .withContext(`i[${i}] expected[${expectedEvents[i]}] !== actual[${handler.midiEvents[i]}]`)
-                    .toEqual(
-                        true
-                    );
+                    .toEqual(true);
             }
         }
         expect(handler.midiEvents.length).toEqual(expectedEvents.length);
@@ -794,9 +784,7 @@ describe('MidiFileGeneratorTest', () => {
             if (i < expectedEvents.length) {
                 expect(expectedEvents[i].equals(handler.midiEvents[i]))
                     .withContext(`i[${i}] expected[${expectedEvents[i]}] !== actual[${handler.midiEvents[i]}]`)
-                    .toEqual(
-                        true,
-                    );
+                    .toEqual(true);
             }
         }
         expect(handler.midiEvents.length).toEqual(expectedEvents.length);
@@ -811,10 +799,10 @@ describe('MidiFileGeneratorTest', () => {
             0 * MidiUtils.QuarterTime, // note 1
             1 * MidiUtils.QuarterTime, // note 2
             2 * MidiUtils.QuarterTime, // note 3
-            3 * MidiUtils.QuarterTime, // 3/4 rest 
+            3 * MidiUtils.QuarterTime, // 3/4 rest
             6 * MidiUtils.QuarterTime, // note 4
             7 * MidiUtils.QuarterTime, // note 5
-            8 * MidiUtils.QuarterTime, // note 6
+            8 * MidiUtils.QuarterTime // note 6
         ];
         let noteOnTimes: number[] = [];
         let beat: Beat | null = score.tracks[0].staves[0].bars[0].voices[0].beats[0];
@@ -839,7 +827,6 @@ describe('MidiFileGeneratorTest', () => {
         expect(noteOnTimes.join(',')).toEqual(expectedNoteOnTimes.join(','));
     });
 
-
     it('time-signature', () => {
         let tex: string = '\\ts 3 4 3.3.4 3.3.4 3.3.4';
         let score: Score = parseTex(tex);
@@ -850,8 +837,8 @@ describe('MidiFileGeneratorTest', () => {
         generator.generate();
 
         let timeSignature: MidiEvent | null = null;
-        for(const evt of file.events) {
-            if(evt.command === MidiEventType.Meta && evt.data1 === MetaEventType.TimeSignature) {
+        for (const evt of file.events) {
+            if (evt.command === MidiEventType.Meta && evt.data1 === MetaEventType.TimeSignature) {
                 timeSignature = evt;
                 break;
             }
@@ -865,4 +852,26 @@ describe('MidiFileGeneratorTest', () => {
         expect(timeSignatureDenominator).toEqual(4);
     });
 
+    it('first-bar-tempo', () => {
+        let tex: string = '\\tempo 120 . \\tempo 60 3.3*4 | \\tempo 80 3.3*4';
+        let score: Score = parseTex(tex);
+
+        expect(score.tempo).toBe(120);
+        expect(score.masterBars[0].tempoAutomation).toBeTruthy();
+        expect(score.masterBars[0].tempoAutomation!.value).toBe(60);
+
+        const handler: FlatMidiEventGenerator = new FlatMidiEventGenerator();
+        const generator: MidiFileGenerator = new MidiFileGenerator(score, null, handler);
+        generator.generate();
+
+        const tempoChanges: TempoEvent[] = [];
+        for (const evt of handler.midiEvents) {
+            if (evt instanceof TempoEvent) {
+                tempoChanges.push(evt as TempoEvent);
+            }
+        }
+
+        expect(tempoChanges.map(t=>t.tick).join(',')).toBe('0,3840');
+        expect(tempoChanges.map(t=>t.tempo).join(',')).toBe('60,80');
+    });
 });

--- a/test/importer/MusicXmlImporter.test.ts
+++ b/test/importer/MusicXmlImporter.test.ts
@@ -26,7 +26,6 @@ describe('MusicXmlImporterTests', () => {
         expect(score.tracks[4].playbackInfo.balance).toBe(16);
     });
 
-    
     it('full-bar-rest', async () => {
         let score: Score = await MusicXmlImporterTestHelper.testReferenceFile(
             'test-data/musicxml3/full-bar-rest.musicxml'
@@ -35,5 +34,17 @@ describe('MusicXmlImporterTests', () => {
         expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].isFullBarRest).toBeTrue();
         expect(score.tracks[0].staves[0].bars[1].voices[0].beats[0].isFullBarRest).toBeTrue();
         expect(score.tracks[0].staves[0].bars[2].voices[0].beats[0].isFullBarRest).toBeTrue();
+    });
+
+    it('first-bar-tempo', async () => {
+        const score: Score = await MusicXmlImporterTestHelper.testReferenceFile(
+            'test-data/musicxml3/first-bar-tempo.musicxml'
+        );
+
+        expect(score.tempo).toBe(60);
+        expect(score.masterBars[0].tempoAutomation).toBeTruthy();
+        expect(score.masterBars[0].tempoAutomation?.value).toBe(60);
+        expect(score.masterBars[1].tempoAutomation).toBeTruthy();
+        expect(score.masterBars[1].tempoAutomation?.value).toBe(60);
     });
 });


### PR DESCRIPTION
### Issues
Fixes #988 

### Proposed changes

1. Ensure we update the `score.tempo` when we parse the first masterbar in MusicXML
2. Ensure we respect tempo changes from `score.tempo` in the first masterbar.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [x] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
