### PR TITLE
Adjust ui element positioning to support browser scaling

### DIFF
--- a/src/platform/javascript/HtmlElementContainer.ts
+++ b/src/platform/javascript/HtmlElementContainer.ts
@@ -141,27 +141,27 @@ export class HtmlElementContainer implements IContainer {
         this.setBounds(x, NaN, NaN, NaN);
     }
 
-    private _lastBounds: Bounds = new Bounds();
+    protected lastBounds: Bounds = new Bounds();
 
     public setBounds(x: number, y: number, w: number, h: number) {
         if (isNaN(x)) {
-            x = this._lastBounds.x;
+            x = this.lastBounds.x;
         }
         if (isNaN(y)) {
-            y = this._lastBounds.y;
+            y = this.lastBounds.y;
         }
         if (isNaN(w)) {
-            w = this._lastBounds.w;
+            w = this.lastBounds.w;
         }
         if (isNaN(h)) {
-            h = this._lastBounds.h;
+            h = this.lastBounds.h;
         }
         this.element.style.transform = `translate(${x}px, ${y}px) scale(${w}, ${h})`;
         this.element.style.transformOrigin = 'top left';
-        this._lastBounds.x = x;
-        this._lastBounds.y = y;
-        this._lastBounds.w = w;
-        this._lastBounds.h = h;
+        this.lastBounds.x = x;
+        this.lastBounds.y = y;
+        this.lastBounds.w = w;
+        this.lastBounds.h = h;
     }
 
     /**

--- a/src/platform/javascript/ScalableHtmlElementContainer.ts
+++ b/src/platform/javascript/ScalableHtmlElementContainer.ts
@@ -1,0 +1,72 @@
+import { HtmlElementContainer } from './HtmlElementContainer';
+
+/**
+ * An IContainer implementation which can be used for cursors and select ranges
+ * where browser scaling is relevant.
+ *
+ * The problem is that with having 1x1 pixel elements which are sized then to the actual size with a
+ * scale transform this cannot be combined properly with a browser zoom.
+ *
+ * The browser will apply first the browser zoom to the 1x1px element and then apply the scale leaving it always
+ * at full scale instead of a 50% browser zoom.
+ *
+ * This is solved in this container by scaling the element first up to a higher degree (as specified)
+ * so that the browser can do a scaling according to typical zoom levels and then the scaling will work.
+ * @target web
+ */
+export class ScalableHtmlElementContainer extends HtmlElementContainer {
+    private _xscale: number;
+    private _yscale: number;
+
+    public constructor(element: HTMLElement, xscale: number, yscale: number) {
+        super(element);
+        this._xscale = xscale;
+        this._yscale = yscale;
+    }
+
+    public override get width(): number {
+        return this.element.offsetWidth / this._xscale;
+    }
+
+    public override set width(value: number) {
+        this.element.style.width = value * this._xscale + 'px';
+    }
+
+    public override get height(): number {
+        return this.element.offsetHeight / this._yscale;
+    }
+
+    public override set height(value: number) {
+        if (value >= 0) {
+            this.element.style.height = value * this._yscale + 'px';
+        } else {
+            this.element.style.height = '100%';
+        }
+    }
+
+    public override setBounds(x: number, y: number, w: number, h: number) {
+        if (isNaN(x)) {
+            x = this.lastBounds.x;
+        }
+        if (isNaN(y)) {
+            y = this.lastBounds.y;
+        }
+        if (isNaN(w)) {
+            w = this.lastBounds.w;
+        } else {
+            w = w / this._xscale;
+        }
+        if (isNaN(h)) {
+            h = this.lastBounds.h;
+        } else {
+            h = h / this._yscale;
+        }
+
+        this.element.style.transform = `translate(${x}px, ${y}px) scale(${w}, ${h})`;
+        this.element.style.transformOrigin = 'top left';
+        this.lastBounds.x = x;
+        this.lastBounds.y = y;
+        this.lastBounds.w = w;
+        this.lastBounds.h = h;
+    }
+}


### PR DESCRIPTION
### Issues
Fixes wrong cursor placement when using browser zoom (detected as part of 1.2.3 testing)

### Proposed changes
The problem with 1x1px elements being scaled using transforms is the order how the browser applies the browser zoom (not pinch zoom). First the 1x1px element is scaled to the zoom level and then the scale is applied. on a 1x1px element, it will stay a 1x1px element on the browser zoom because on those pixel sized elements no fractions are possible. Then the scale is applied keeping the element always on the 100% zoom level not matching the music sheet. 

As a fix we use now a 100x100px element for cursors and selections which is then scaled correctly. This way the 100x100px element gives us enough zoom options to scale along the browser zoom. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
