### PR TITLE
Fix wrong repeats on alternate endings

### DIFF
--- a/src/midi/MidiPlaybackController.ts
+++ b/src/midi/MidiPlaybackController.ts
@@ -55,6 +55,7 @@ export class MidiPlaybackController {
                 this._repeatStack.push(repeat);
                 this._groupsOnStack.add(masterBar.repeatGroup);
                 this._previousAlternateEndings = 0;
+                masterBarAlternateEndings = masterBar.alternateEndings;
             }
         }
 

--- a/test/audio/MidiPlaybackController.test.ts
+++ b/test/audio/MidiPlaybackController.test.ts
@@ -139,4 +139,19 @@ describe('MidiPlaybackControllerTest', () => {
         ];
         testAlphaTexRepeat(tex, expectedBars, 50);
     });
+
+    it('alternate-endings-1046', () => {
+        let tex: string = `
+        \\tempo 175
+        .
+        \\ro :1 r | \\ae 1 r | \\ae 2 \\rc 2 r | \\ro r | \\ae 1 r | \\ae (2 3 4) \\rc 4 r |       
+        `;
+        let expectedBars: number[] = [
+            0, 1, 0, 2,
+            3, 4,
+            3, 5, 3, 5, 3, 5,
+            6
+        ];
+        testAlphaTexRepeat(tex, expectedBars, 50);
+    });
 });


### PR DESCRIPTION
### Issues
Fixes #1046 

### Proposed changes
When starting a fresh new group, we have to clear any potential alternate endings from previous bars. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [x] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
