### PR TITLE
Ensure we respect repeats on getting beat playback position

### DIFF
--- a/src/AlphaTabApiBase.ts
+++ b/src/AlphaTabApiBase.ts
@@ -805,9 +805,7 @@ export class AlphaTabApiBase<TSettings> {
                     let currentBeat = this._currentBeat;
                     let tickCache = this._tickCache;
                     if (currentBeat && tickCache) {
-                        this.player!.tickPosition =
-                            tickCache.getMasterBarStart(currentBeat.currentBeat.voice.bar.masterBar) +
-                            currentBeat.currentBeat.playbackStart;
+                        this.player!.tickPosition = tickCache.getBeatStart(currentBeat.currentBeat);
                     }
                 }
             });
@@ -1145,8 +1143,8 @@ export class AlphaTabApiBase<TSettings> {
         if (this.settings.player.enableUserInteraction) {
             // for the selection ensure start < end
             if (this._selectionEnd) {
-                let startTick: number = this._selectionStart!.beat.absolutePlaybackStart;
-                let endTick: number = this._selectionEnd!.beat.absolutePlaybackStart;
+                let startTick: number = this._tickCache?.getBeatStart(this._selectionStart!.beat) ?? this._selectionStart!.beat.absolutePlaybackStart;
+                let endTick: number = this._tickCache?.getBeatStart(this._selectionEnd!.beat) ?? this._selectionEnd!.beat.absolutePlaybackStart;
                 if (endTick < startTick) {
                     let t: SelectionInfo = this._selectionStart!;
                     this._selectionStart = this._selectionEnd;
@@ -1162,7 +1160,7 @@ export class AlphaTabApiBase<TSettings> {
                 // move to selection start
                 this._currentBeat = null; // reset current beat so it is updating the cursor
                 if (this._playerState === PlayerState.Paused) {
-                    this.cursorUpdateTick(this._selectionStart.beat.absolutePlaybackStart, false);
+                    this.cursorUpdateTick(this._tickCache.getBeatStart(this._selectionStart.beat), false);
                 }
                 this.tickPosition = realMasterBarStart + this._selectionStart.beat.playbackStart;
                 // set playback range
@@ -1314,8 +1312,8 @@ export class AlphaTabApiBase<TSettings> {
         if (!endBeat.bounds) {
             endBeat.bounds = cache.findBeat(endBeat.beat);
         }
-        let startTick: number = startBeat.beat.absolutePlaybackStart;
-        let endTick: number = endBeat.beat.absolutePlaybackStart;
+        let startTick: number = this._tickCache?.getBeatStart(startBeat.beat) ?? startBeat.beat.absolutePlaybackStart;
+        let endTick: number = this._tickCache?.getBeatStart(endBeat.beat) ?? endBeat.beat.absolutePlaybackStart;
         if (endTick < startTick) {
             let t: SelectionInfo = startBeat;
             startBeat = endBeat;

--- a/src/midi/MidiTickLookup.ts
+++ b/src/midi/MidiTickLookup.ts
@@ -278,6 +278,20 @@ export class MidiTickLookup {
         return this.masterBarLookup.get(bar.index)!.start;
     }
 
+
+    /**
+     * Gets the start time in midi ticks for a given beat at which the masterbar is played the first time.
+     * @param beat The beat to find the time period for.
+     * @returns The time in midi ticks at which the beat is played the first time or 0 if the beat is not contained
+     */
+    public getBeatStart(beat:Beat): number {
+        if (!this.masterBarLookup.has(beat.voice.bar.index)) {
+            return 0;
+        }
+
+        return this.masterBarLookup.get(beat.voice.bar.index)!.start + beat.playbackStart;
+    }
+
     /**
      * Adds a new {@link MasterBarTickLookup} to the lookup table.
      * @param masterBar The item to add.


### PR DESCRIPTION
### Issues
Fixes #1047

### Proposed changes
`absolutePlaybackPosition` does not respect repeats but just goes linearly across bars. This leads to wrong cursor placement (which self-heals right afterwards). This change ensures we use the real playback position respecting repeats where relevant. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
