### PR TITLE
Ensure we do not signal the UI facade for empty partials

### DIFF
--- a/src/AlphaTabApiBase.ts
+++ b/src/AlphaTabApiBase.ts
@@ -331,8 +331,13 @@ export class AlphaTabApiBase<TSettings> {
                 this._cursorWrapper.width = result.totalWidth;
                 this._cursorWrapper.height = result.totalHeight;
             }
+            
+            if(result.width > 0 || result.height > 0) {
+                this.uiFacade.beginAppendRenderResults(result);
+            }
+        } else {
+            this.uiFacade.beginAppendRenderResults(result);
         }
-        this.uiFacade.beginAppendRenderResults(result);
     }
 
     private updateRenderResult(result: RenderFinishedEventArgs | null): void {

--- a/src/rendering/ScoreRenderer.ts
+++ b/src/rendering/ScoreRenderer.ts
@@ -170,7 +170,7 @@ export class ScoreRenderer implements IScoreRenderer {
             this.onRenderFinished();
             (this.postRenderFinished as EventEmitter).trigger();
         } else {
-            Logger.warning('Rendering', 'Current layout does not support dynamic resizing, nothing was done', null);
+            Logger.debug('Rendering', 'Current layout does not support dynamic resizing, nothing was done', null);
         }
         Logger.debug('Rendering', 'Resize finished');
     }


### PR DESCRIPTION
### Issues
Fixes #1090

### Proposed changes
ICanvas used to provide some results when render finished but not it doesn't. Due to that the onRenderFinished signals an empty render result to the UI facade to be displayed. The problem is that the new placeholder system does not clear placeholders to get a smoother UI: It is better to keep an old render result before the new one becomes available. 

The problem is if the placeholder content has a 0 width and height. We would need to clean the placeholder from its old content because it will never become visible. To avoid implementing this code in every UI facade we simply not signal empty results to the UI facade anymore which will ensure placeholders are only filled with proper content or are removed. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
