### PR TITLE
Prevent duplicate render requests of partials

### DIFF
--- a/src/platform/javascript/BrowserUiFacade.ts
+++ b/src/platform/javascript/BrowserUiFacade.ts
@@ -138,7 +138,13 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
                     // missing result or result not matching layout -> request render
                     if (placeholder.renderedResultId !== placeholder.layoutResultId) {
                         if (this._resultIdToElementLookup.has(placeholder.layoutResultId!)) {
-                            this._api.renderer.renderResult(placeholder.layoutResultId!);
+                            if(placeholder.resultState !== ResultState.RenderRequested) {
+                                Logger.warning('Rendering', 'Outside Request render of lazy partial ' + placeholder.layoutResultId!);
+                                placeholder.resultState = ResultState.RenderRequested;
+                                this._api.renderer.renderResult(placeholder.layoutResultId!);
+                            } else {
+                                // Already requested render of this partial, wait for result
+                            }
                         } else {
                             htmlElement.replaceChildren();
                         }


### PR DESCRIPTION
### Issues
Fixes #1147

### Proposed changes
Prevents requesting the rendering of the same partial multiple times. If the same partial is requested to be rendered multiple times this messes with the positioning of ties. 

iOS can sometimes signal the visibility change of the same element multiple times. If this happens things break. By preventing multiple render requests we not only improve performance but also fix the problem with the ties. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
