### PR TITLE
Fix broken count-in on playback ranges

### DIFF
--- a/src/synth/AlphaSynth.ts
+++ b/src/synth/AlphaSynth.ts
@@ -411,13 +411,14 @@ export class AlphaSynth implements IAlphaSynth {
     private checkForFinish() {
         let startTick = 0;
         let endTick = 0;
-        if (this.playbackRange) {
+
+        if (this.playbackRange && this._sequencer.isPlayingMain) {
             startTick = this.playbackRange.startTick;
             endTick = this.playbackRange.endTick;
         } else {
             endTick = this._sequencer.currentEndTick;
         }
-
+     
         if (this._tickPosition >= endTick && this._notPlayedSamples <= 0) {
             this._notPlayedSamples = 0;
             if (this._sequencer.isPlayingCountIn) {


### PR DESCRIPTION
### Issues
Fixes #1140

### Proposed changes
The check whether the count-in is done was wrong in case of playback ranges. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
