### PR TITLE
Fix dynamics generation exceeding value range

### DIFF
--- a/src/midi/AlphaSynthMidiFileHandler.ts
+++ b/src/midi/AlphaSynthMidiFileHandler.ts
@@ -6,8 +6,6 @@ import { SystemCommonType } from '@src/midi/SystemCommonEvent';
 import { AlphaTabSystemExclusiveEvents, SystemExclusiveEvent } from '@src/midi/SystemExclusiveEvent';
 import { IMidiFileHandler } from '@src/midi/IMidiFileHandler';
 import { MidiFile } from '@src/midi/MidiFile';
-import { MidiUtils } from '@src/midi/MidiUtils';
-import { DynamicValue } from '@src/model/DynamicValue';
 import { SynthConstants } from '@src/synth/SynthConstants';
 import { Midi20PerNotePitchBendEvent } from '@src/midi/Midi20PerNotePitchBendEvent';
 
@@ -62,10 +60,9 @@ export class AlphaSynthMidiFileHandler implements IMidiFileHandler {
         start: number,
         length: number,
         key: number,
-        dynamicValue: DynamicValue,
+        velocity: number,
         channel: number
     ): void {
-        const velocity: number = MidiUtils.dynamicToVelocity(dynamicValue);
         const noteOn: MidiEvent = new MidiEvent(
             track,
             start,

--- a/src/midi/IMidiFileHandler.ts
+++ b/src/midi/IMidiFileHandler.ts
@@ -1,5 +1,3 @@
-import { DynamicValue } from '@src/model/DynamicValue';
-
 /**
  * A handler is responsible for writing midi events to a custom structure
  */
@@ -26,7 +24,7 @@ export interface IMidiFileHandler {
      * @param start The midi ticks when the note should start playing.
      * @param length The duration the note in midi ticks.
      * @param key The key of the note to play
-     * @param dynamicValue The dynamic which should be applied to the note.
+     * @param velocity The velocity which should be applied to the note (derived from the note dynamics).
      * @param channel The midi channel on which the note should be played.
      */
     addNote(
@@ -34,7 +32,7 @@ export interface IMidiFileHandler {
         start: number,
         length: number,
         key: number,
-        dynamicValue: DynamicValue,
+        velocity: number,
         channel: number
     ): void;
 

--- a/src/midi/MidiUtils.ts
+++ b/src/midi/MidiUtils.ts
@@ -1,5 +1,4 @@
 import { Duration } from '@src/model/Duration';
-import { DynamicValue } from '@src/model/DynamicValue';
 
 export class MidiUtils {
     public static readonly QuarterTime: number = 960;
@@ -60,7 +59,7 @@ export class MidiUtils {
         return ((ticks * numerator) / denominator) | 0;
     }
 
-    public static dynamicToVelocity(dyn: DynamicValue): number {
-        return MidiUtils.MinVelocity + dyn * MidiUtils.VelocityIncrement;
+    public static dynamicToVelocity(dynamicsSteps: number): number {
+        return MidiUtils.MinVelocity + dynamicsSteps * MidiUtils.VelocityIncrement;
     }
 }

--- a/test/audio/FlatMidiEventGenerator.ts
+++ b/test/audio/FlatMidiEventGenerator.ts
@@ -1,6 +1,5 @@
 import { ControllerType } from '@src/midi/ControllerType';
 import { IMidiFileHandler } from '@src/midi/IMidiFileHandler';
-import { DynamicValue } from '@src/model/DynamicValue';
 
 export class FlatMidiEventGenerator implements IMidiFileHandler {
     public midiEvents: FlatMidiEvent[];
@@ -24,10 +23,10 @@ export class FlatMidiEventGenerator implements IMidiFileHandler {
         start: number,
         length: number,
         key: number,
-        dynamicValue: DynamicValue,
+        velocity: number,
         channel: number
     ): void {
-        let e = new NoteEvent(start, track, channel, length, key, dynamicValue);
+        let e = new NoteEvent(start, track, channel, length, key, velocity);
         this.midiEvents.push(e);
     }
 
@@ -281,7 +280,7 @@ export class ProgramChangeEvent extends ChannelMidiEvent {
 export class NoteEvent extends ChannelMidiEvent {
     public length: number = 0;
     public key: number = 0;
-    public dynamicValue: DynamicValue;
+    public velocity: number;
 
     public constructor(
         tick: number,
@@ -289,16 +288,16 @@ export class NoteEvent extends ChannelMidiEvent {
         channel: number,
         length: number,
         key: number,
-        dynamicValue: DynamicValue
+        velocity: number
     ) {
         super(tick, track, channel);
         this.length = length;
         this.key = key;
-        this.dynamicValue = dynamicValue;
+        this.velocity = velocity;
     }
 
     public override toString(): string {
-        return `Note: ${super.toString()} Length[${this.length}] Key[${this.key}] Dynamic[${this.dynamicValue}]`;
+        return `Note: ${super.toString()} Length[${this.length}] Key[${this.key}] Velocity[${this.velocity}]`;
     }
 
     public override equals(obj: unknown): boolean {
@@ -307,7 +306,7 @@ export class NoteEvent extends ChannelMidiEvent {
         }
 
         if (obj instanceof NoteEvent) {
-            return this.length === obj.length && this.key === obj.key && this.dynamicValue === obj.dynamicValue;
+            return this.length === obj.length && this.key === obj.key && this.velocity === obj.velocity;
         }
 
         return false;

--- a/test/audio/MidiFileGenerator.test.ts
+++ b/test/audio/MidiFileGenerator.test.ts
@@ -134,7 +134,7 @@ describe('MidiFileGeneratorTest', () => {
                 info.secondaryChannel,
                 MidiUtils.toTicks(note.beat.duration),
                 note.realValue,
-                note.dynamics
+                MidiUtils.dynamicToVelocity(note.dynamics as number)
             ),
 
             // reset bend
@@ -145,7 +145,7 @@ describe('MidiFileGeneratorTest', () => {
                 info.primaryChannel,
                 MidiUtils.toTicks(note.beat.duration),
                 note.realValue,
-                note.dynamics
+                MidiUtils.dynamicToVelocity(note.dynamics as number)
             ),
 
             // end of track
@@ -203,6 +203,7 @@ describe('MidiFileGeneratorTest', () => {
         ticks.push(tick);
         tick += score.tracks[0].staves[0].bars[4].voices[0].beats[1].playbackDuration;
         let info: PlaybackInformation = score.tracks[0].playbackInfo;
+        const mfVelocity = MidiUtils.dynamicToVelocity(DynamicValue.MF as number);
         let expectedEvents: FlatMidiEvent[] = [
             // channel init
             new ControlChangeEvent(0, 0, info.primaryChannel, ControllerType.VolumeCoarse, 96),
@@ -228,23 +229,23 @@ describe('MidiFileGeneratorTest', () => {
 
             // on beat
             new NoteBendEvent(ticks[0], 0, info.primaryChannel, 67, 8192),
-            new NoteEvent(ticks[0], 0, info.primaryChannel, 3840, 67, DynamicValue.MF),
+            new NoteEvent(ticks[0], 0, info.primaryChannel, 3840, 67, mfVelocity),
 
             new NoteBendEvent(ticks[1], 0, info.primaryChannel, 67, 8192),
-            new NoteEvent(ticks[1], 0, info.primaryChannel, 120, 67, DynamicValue.MF),
+            new NoteEvent(ticks[1], 0, info.primaryChannel, 120, 67, mfVelocity),
 
             new NoteBendEvent(ticks[2], 0, info.primaryChannel, 67, 8192),
-            new NoteEvent(ticks[2], 0, info.primaryChannel, 3720, 67, DynamicValue.MF),
+            new NoteEvent(ticks[2], 0, info.primaryChannel, 3720, 67, mfVelocity),
 
             // before beat
             new NoteBendEvent(ticks[3], 0, info.primaryChannel, 67, 8192),
-            new NoteEvent(ticks[3], 0, info.primaryChannel, 3720, 67, DynamicValue.MF),
+            new NoteEvent(ticks[3], 0, info.primaryChannel, 3720, 67, mfVelocity),
 
             new NoteBendEvent(ticks[4], 0, info.primaryChannel, 67, 8192),
-            new NoteEvent(ticks[4], 0, info.primaryChannel, 120, 67, DynamicValue.MF),
+            new NoteEvent(ticks[4], 0, info.primaryChannel, 120, 67, mfVelocity),
 
             new NoteBendEvent(ticks[5], 0, info.primaryChannel, 67, 8192),
-            new NoteEvent(ticks[5], 0, info.primaryChannel, 3840, 67, DynamicValue.MF),
+            new NoteEvent(ticks[5], 0, info.primaryChannel, 3840, 67, mfVelocity),
 
             // bend beat
             new NoteBendEvent(ticks[6], 0, info.secondaryChannel, 67, 8192),
@@ -260,7 +261,7 @@ describe('MidiFileGeneratorTest', () => {
             new NoteBendEvent(ticks[6] + 12 * 9, 0, info.secondaryChannel, 67, 8960),
             new NoteBendEvent(ticks[6] + 12 * 10, 0, info.secondaryChannel, 67, 9045),
             new NoteBendEvent(ticks[6] + 12 * 11, 0, info.secondaryChannel, 67, 9131),
-            new NoteEvent(ticks[6], 0, info.secondaryChannel, 3840, 67, DynamicValue.MF),
+            new NoteEvent(ticks[6], 0, info.secondaryChannel, 3840, 67, mfVelocity),
 
             // end of track
             new TrackEndEvent(19200, 0) // 3840 = end of bar
@@ -341,7 +342,7 @@ describe('MidiFileGeneratorTest', () => {
                 info.secondaryChannel,
                 MidiUtils.toTicks(note.beat.duration),
                 note.realValue,
-                note.dynamics
+                MidiUtils.dynamicToVelocity(note.dynamics as number)
             ),
 
             // reset bend
@@ -352,7 +353,7 @@ describe('MidiFileGeneratorTest', () => {
                 info.primaryChannel,
                 MidiUtils.toTicks(note.beat.duration),
                 note.realValue,
-                note.dynamics
+                MidiUtils.dynamicToVelocity(note.dynamics as number)
             ), // end of track
             new TrackEndEvent(3840, 0) // 3840 = end of bar
         ];
@@ -414,7 +415,7 @@ describe('MidiFileGeneratorTest', () => {
                 info.secondaryChannel,
                 MidiUtils.toTicks(note.beat.duration) * 2,
                 note.realValue,
-                note.dynamics
+                MidiUtils.dynamicToVelocity(note.dynamics as number)
             ),
 
             // release on tied note
@@ -494,7 +495,7 @@ describe('MidiFileGeneratorTest', () => {
                 info.secondaryChannel,
                 MidiUtils.toTicks(note.beat.duration) * 2,
                 note.realValue,
-                note.dynamics
+                MidiUtils.dynamicToVelocity(note.dynamics as number)
             ),
 
             new TrackEndEvent(3840, 0) // 3840 = end of bar
@@ -560,7 +561,7 @@ describe('MidiFileGeneratorTest', () => {
                 info.secondaryChannel,
                 MidiUtils.toTicks(note.beat.duration) * 2,
                 note.realValue,
-                note.dynamics
+                MidiUtils.dynamicToVelocity(note.dynamics as number)
             ),
 
             new TrackEndEvent(3840, 0) // 3840 = end of bar
@@ -695,7 +696,7 @@ describe('MidiFileGeneratorTest', () => {
                 info.secondaryChannel,
                 MidiUtils.toTicks(note1.beat.duration),
                 note1.realValue,
-                note1.dynamics
+                MidiUtils.dynamicToVelocity(note1.dynamics as number)
             ),
 
             // bend effect (note 2)
@@ -732,7 +733,7 @@ describe('MidiFileGeneratorTest', () => {
                 info.secondaryChannel,
                 MidiUtils.toTicks(note2.beat.duration),
                 note2.realValue,
-                note2.dynamics
+                MidiUtils.dynamicToVelocity(note2.dynamics as number)
             ),
 
             // reset bend
@@ -743,7 +744,7 @@ describe('MidiFileGeneratorTest', () => {
                 info.primaryChannel,
                 MidiUtils.toTicks(note1.beat.duration),
                 note1.realValue,
-                note1.dynamics
+                MidiUtils.dynamicToVelocity(note1.dynamics as number)
             ),
 
             // end of track
@@ -805,7 +806,7 @@ describe('MidiFileGeneratorTest', () => {
                 info.primaryChannel,
                 1920,
                 note1.realValue,
-                note1.dynamics
+                MidiUtils.dynamicToVelocity(note1.dynamics as number)
             ),
 
             new NoteBendEvent(1440, 0, info.primaryChannel, note1.realValue, 8192),
@@ -954,7 +955,7 @@ describe('MidiFileGeneratorTest', () => {
                 info.primaryChannel,
                 1920,
                 note1.realValue,
-                8 as DynamicValue
+                MidiUtils.dynamicToVelocity((note1.dynamics as number) + 1)
             ),
 
             new NoteBendEvent(1920, 0, info.primaryChannel, note2.realValue, 8192),
@@ -964,7 +965,7 @@ describe('MidiFileGeneratorTest', () => {
                 info.primaryChannel,
                 1920,
                 note2.realValue,
-                0 as DynamicValue
+                MidiUtils.dynamicToVelocity((note2.dynamics as number) - 1)
             ),
 
             // end of track

--- a/test/audio/MidiFileGenerator.test.ts
+++ b/test/audio/MidiFileGenerator.test.ts
@@ -31,13 +31,25 @@ import { TestPlatform } from '@test/TestPlatform';
 import { AlphaSynthMidiFileHandler } from '@src/midi/AlphaSynthMidiFileHandler';
 import { MetaEventType } from '@src/midi/MetaEvent';
 import { MetaDataEvent } from '@src/midi/MetaDataEvent';
-import { VibratoType } from '@src/model';
+import { AccentuationType, VibratoType } from '@src/model';
 
 describe('MidiFileGeneratorTest', () => {
     const parseTex: (tex: string) => Score = (tex: string): Score => {
         let importer: AlphaTexImporter = new AlphaTexImporter();
         importer.initFromString(tex, new Settings());
         return importer.readScore();
+    };
+
+    const assertEvents: (actualEvents:FlatMidiEvent[], expectedEvents:FlatMidiEvent[]) => void = (actualEvents:FlatMidiEvent[], expectedEvents:FlatMidiEvent[]) => {
+        for (let i: number = 0; i < actualEvents.length; i++) {
+            Logger.info('Test', `i[${i}] ${actualEvents[i]}`);
+            if (i < expectedEvents.length) {
+                expect(expectedEvents[i].equals(actualEvents[i]))
+                    .withContext(`i[${i}] expected[${expectedEvents[i]}] !== actual[${actualEvents[i]}]`)
+                    .toEqual(true);
+            }
+        }
+        expect(actualEvents.length).toEqual(expectedEvents.length);
     };
 
     it('full-song', async () => {
@@ -139,12 +151,8 @@ describe('MidiFileGeneratorTest', () => {
             // end of track
             new TrackEndEvent(3840, 0) // 3840 = end of bar
         ];
-        expect(handler.midiEvents.length).toEqual(expectedEvents.length);
-        for (let i: number = 0; i < expectedEvents.length; i++) {
-            expect(expectedEvents[i].equals(handler.midiEvents[i]))
-                .withContext(`i[${i}] expected[${expectedEvents[i]}] !== actual[${handler.midiEvents[i]}]`)
-                .toEqual(true);
-        }
+
+        assertEvents(handler.midiEvents, expectedEvents);
     });
 
     it('grace-beats', async () => {
@@ -258,15 +266,7 @@ describe('MidiFileGeneratorTest', () => {
             new TrackEndEvent(19200, 0) // 3840 = end of bar
         ];
 
-        for (let i: number = 0; i < handler.midiEvents.length; i++) {
-            Logger.info('Test', `i[${i}] ${handler.midiEvents[i]}`);
-            if (i < expectedEvents.length) {
-                expect(handler.midiEvents[i].equals(expectedEvents[i]))
-                    .withContext(`i[${i}] expected[${expectedEvents[i]}] !== actual[${handler.midiEvents[i]}]`)
-                    .toEqual(true);
-            }
-        }
-        expect(handler.midiEvents.length).toEqual(expectedEvents.length);
+        assertEvents(handler.midiEvents, expectedEvents);
     });
 
     it('bend-multi-point', () => {
@@ -356,15 +356,8 @@ describe('MidiFileGeneratorTest', () => {
             ), // end of track
             new TrackEndEvent(3840, 0) // 3840 = end of bar
         ];
-        for (let i: number = 0; i < handler.midiEvents.length; i++) {
-            Logger.info('Test', `i[${i}] ${handler.midiEvents[i]}`);
-            if (i < expectedEvents.length) {
-                expect(expectedEvents[i].equals(handler.midiEvents[i]))
-                    .withContext(`i[${i}] expected[${expectedEvents[i]}] !== actual[${handler.midiEvents[i]}]`)
-                    .toEqual(true);
-            }
-        }
-        expect(handler.midiEvents.length).toEqual(expectedEvents.length);
+
+        assertEvents(handler.midiEvents, expectedEvents);
     });
 
     it('bend-continued', () => {
@@ -442,15 +435,8 @@ describe('MidiFileGeneratorTest', () => {
 
             new TrackEndEvent(3840, 0) // 3840 = end of bar
         ];
-        for (let i: number = 0; i < handler.midiEvents.length; i++) {
-            Logger.info('Test', `i[${i}] ${handler.midiEvents[i]}`);
-            if (i < expectedEvents.length) {
-                expect(expectedEvents[i].equals(handler.midiEvents[i]))
-                    .withContext(`i[${i}] expected[${expectedEvents[i]}] !== actual[${handler.midiEvents[i]}]`)
-                    .toEqual(true);
-            }
-        }
-        expect(handler.midiEvents.length).toEqual(expectedEvents.length);
+
+        assertEvents(handler.midiEvents, expectedEvents);
     });
 
     it('pre-bend-release-continued', () => {
@@ -513,15 +499,8 @@ describe('MidiFileGeneratorTest', () => {
 
             new TrackEndEvent(3840, 0) // 3840 = end of bar
         ];
-        for (let i: number = 0; i < handler.midiEvents.length; i++) {
-            Logger.info('Test', `i[${i}] ${handler.midiEvents[i]}`);
-            if (i < expectedEvents.length) {
-                expect(expectedEvents[i].equals(handler.midiEvents[i]))
-                    .withContext(`i[${i}] expected[${expectedEvents[i]}] !== actual[${handler.midiEvents[i]}]`)
-                    .toEqual(true);
-            }
-        }
-        expect(handler.midiEvents.length).toEqual(expectedEvents.length);
+
+        assertEvents(handler.midiEvents, expectedEvents);
     });
 
     it('pre-bend-release-continued-songbook', () => {
@@ -586,15 +565,8 @@ describe('MidiFileGeneratorTest', () => {
 
             new TrackEndEvent(3840, 0) // 3840 = end of bar
         ];
-        for (let i: number = 0; i < handler.midiEvents.length; i++) {
-            Logger.info('Test', `i[${i}] ${handler.midiEvents[i]}`);
-            if (i < expectedEvents.length) {
-                expect(expectedEvents[i].equals(handler.midiEvents[i]))
-                    .withContext(`i[${i}] expected[${expectedEvents[i]}] !== actual[${handler.midiEvents[i]}]`)
-                    .toEqual(true);
-            }
-        }
-        expect(handler.midiEvents.length).toEqual(expectedEvents.length);
+
+        assertEvents(handler.midiEvents, expectedEvents);
     });
 
     it('triplet-feel', () => {
@@ -777,15 +749,8 @@ describe('MidiFileGeneratorTest', () => {
             // end of track
             new TrackEndEvent(3840, 0) // 3840 = end of bar
         ];
-        for (let i: number = 0; i < handler.midiEvents.length; i++) {
-            Logger.info('Test', `i[${i}] ${handler.midiEvents[i]}`);
-            if (i < expectedEvents.length) {
-                expect(expectedEvents[i].equals(handler.midiEvents[i]))
-                    .withContext(`i[${i}] expected[${expectedEvents[i]}] !== actual[${handler.midiEvents[i]}]`)
-                    .toEqual(true);
-            }
-        }
-        expect(handler.midiEvents.length).toEqual(expectedEvents.length);
+
+        assertEvents(handler.midiEvents, expectedEvents);
     });
 
     it('tied-vibrato', () => {
@@ -855,15 +820,8 @@ describe('MidiFileGeneratorTest', () => {
             // end of track
             new TrackEndEvent(3840, 0) // 3840 = end of bar
         ];
-        for (let i: number = 0; i < handler.midiEvents.length; i++) {
-            Logger.info('Test', `i[${i}] ${handler.midiEvents[i]}`);
-            if (i < expectedEvents.length) {
-                expect(expectedEvents[i].equals(handler.midiEvents[i]))
-                    .withContext(`i[${i}] expected[${expectedEvents[i]}] !== actual[${handler.midiEvents[i]}]`)
-                    .toEqual(true);
-            }
-        }
-        expect(handler.midiEvents.length).toEqual(expectedEvents.length);
+
+        assertEvents(handler.midiEvents, expectedEvents);
     });
 
     it('full-bar-rest', () => {
@@ -950,4 +908,72 @@ describe('MidiFileGeneratorTest', () => {
         expect(tempoChanges.map(t=>t.tick).join(',')).toBe('0,3840');
         expect(tempoChanges.map(t=>t.tempo).join(',')).toBe('60,80');
     });
+
+    it('has-valid-dynamics', () => {
+        let tex: string = ':2 1.1{dy fff ac} 1.1{dy ppp g}';
+        let score: Score = parseTex(tex);
+
+        let info: PlaybackInformation = score.tracks[0].playbackInfo;
+        let note1: Note = score.tracks[0].staves[0].bars[0].voices[0].beats[0].notes[0];
+        let note2: Note = score.tracks[0].staves[0].bars[0].voices[0].beats[1].notes[0];
+        // First note has already highest dynamics which is increased due to accentuation
+        expect(note1.dynamics).toBe(DynamicValue.FFF);
+        expect(note1.accentuated).toBe(AccentuationType.Normal);
+
+        // Second note has lowest dynamics which is decreased due to ghost note
+        expect(note2.dynamics).toBe(DynamicValue.PPP);
+        expect(note2.isGhost).toBeTrue();
+
+        let expectedEvents: FlatMidiEvent[] = [
+            // channel init
+            new ControlChangeEvent(0, 0, info.primaryChannel, ControllerType.VolumeCoarse, 120),
+            new ControlChangeEvent(0, 0, info.primaryChannel, ControllerType.PanCoarse, 64),
+            new ControlChangeEvent(0, 0, info.primaryChannel, ControllerType.ExpressionControllerCoarse, 127),
+            new ControlChangeEvent(0, 0, info.primaryChannel, ControllerType.RegisteredParameterFine, 0),
+            new ControlChangeEvent(0, 0, info.primaryChannel, ControllerType.RegisteredParameterCourse, 0),
+            new ControlChangeEvent(0, 0, info.primaryChannel, ControllerType.DataEntryFine, 0),
+            new ControlChangeEvent(0, 0, info.primaryChannel, ControllerType.DataEntryCoarse, 16),
+            new ProgramChangeEvent(0, 0, info.primaryChannel, info.program),
+
+            new ControlChangeEvent(0, 0, info.secondaryChannel, ControllerType.VolumeCoarse, 120),
+            new ControlChangeEvent(0, 0, info.secondaryChannel, ControllerType.PanCoarse, 64),
+            new ControlChangeEvent(0, 0, info.secondaryChannel, ControllerType.ExpressionControllerCoarse, 127),
+            new ControlChangeEvent(0, 0, info.secondaryChannel, ControllerType.RegisteredParameterFine, 0),
+            new ControlChangeEvent(0, 0, info.secondaryChannel, ControllerType.RegisteredParameterCourse, 0),
+            new ControlChangeEvent(0, 0, info.secondaryChannel, ControllerType.DataEntryFine, 0),
+            new ControlChangeEvent(0, 0, info.secondaryChannel, ControllerType.DataEntryCoarse, 16),
+            new ProgramChangeEvent(0, 0, info.secondaryChannel, info.program),
+
+            new TimeSignatureEvent(0, 4, 4),
+            new TempoEvent(0, 120),
+
+            new NoteBendEvent(0, 0, info.primaryChannel, note1.realValue, 8192),
+            new NoteEvent(
+                0,
+                0,
+                info.primaryChannel,
+                1920,
+                note1.realValue,
+                8 as DynamicValue
+            ),
+
+            new NoteBendEvent(1920, 0, info.primaryChannel, note2.realValue, 8192),
+            new NoteEvent(
+                1920,
+                0,
+                info.primaryChannel,
+                1920,
+                note2.realValue,
+                0 as DynamicValue
+            ),
+
+            // end of track
+            new TrackEndEvent(3840, 0) // 3840 = end of bar
+        ];
+
+        const handler: FlatMidiEventGenerator = new FlatMidiEventGenerator();
+        const generator: MidiFileGenerator = new MidiFileGenerator(score, null, handler);
+        generator.generate();
+        assertEvents(handler.midiEvents, expectedEvents);
+    })
 });


### PR DESCRIPTION
### Issues
Fixes #1150 

### Proposed changes
We do a 2 stage velocity calculation for notes, first we adjust the dynamics and then later convert it to the midi note velocity. But this can exceed the valid value range of dynamics. 

This can lead to problems on platforms like Kotlin exceeding the valid enum values as they are strictly checked. 

This PR changes the generation to a simple direct velocity computation to fix it. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
