### PR TITLE
Fix: allow the import of gpx files that use displayScale as Float xml node

### DIFF
--- a/src/importer/GpifParser.ts
+++ b/src/importer/GpifParser.ts
@@ -1616,7 +1616,8 @@ export class GpifParser {
                         const id: string = c.getAttribute('id');
                         switch (id) {
                             case '1124139520':
-                                bar.displayScale = parseFloat(c.findChildElement('Double')!.innerText);
+                                const childNode = c.findChildElement('Double') ?? c.findChildElement('Float');
+                                bar.displayScale = parseFloat(childNode!.innerText);
                                 break;
                         }
                         break;


### PR DESCRIPTION
Fix the import of some gpx files that uses Float instead Double node on XProperties

Example of gpx xml part that was throwing error
```xml
<Bar id="29">
  <Clef>G2</Clef>
  <Voices>26 -1 -1 -1</Voices>
  <XProperties>
    <XProperty id="1124139520">
      <Float>1.07818</Float>
    </XProperty>
  </XProperties>
</Bar>
```

### Issues
I was trying to import a gpx file with an error, tracing the error I found that was due to a child node from XProperties that the importer only looks for the Double node, but I found out in gpx that it can also be Float

### Proposed changes
Look for both nodes types (Double and Float) to get the bar scale value 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
