### PR TITLE
Fix typos in GpifWriter

### DIFF
--- a/src/exporter/GpifWriter.ts
+++ b/src/exporter/GpifWriter.ts
@@ -1158,7 +1158,7 @@ export class GpifWriter {
         const properties = staffNode.addElement('Properties');
 
         this.writeSimplePropertyNode(properties, 'CapoFret', 'Fret', staff.capo.toString());
-        this.writeSimplePropertyNode(properties, 'FretCount', 'Fret', '24');
+        this.writeSimplePropertyNode(properties, 'FretCount', 'Number', '24');
 
         if (staff.tuning.length > 0) {
             const tuningProperty = properties.addElement('Property');


### PR DESCRIPTION
With 'Pitched' as the name, only MIDI works, RSE doesn't work.

By comparing the file generated by Guitar Pro 7 and the file exported, I believe this is a typo when we generate the file. It should be 'Name', instead of 'Pitched'.

Confirmed by re-export the same file.

(I was testing with https://github.com/CoderLine/alphaTab/blob/develop/test-data/guitarpro7/accentuations.gp with https://gist.github.com/Jeswang/d4173b154c8e3ace3f6c3b0ba3b49736)

Fret in FretCount is also an obvious typo:

<img width="1874" alt="image" src="https://github.com/CoderLine/alphaTab/assets/553783/82b30cd0-076a-4c7a-b58d-6fd763844cbc">

