### PR TITLE
Allow dynamic change of transposition pitches. 

### DIFF
--- a/src.csharp/AlphaTab/Platform/CSharp/AlphaSynthWorkerApiBase.cs
+++ b/src.csharp/AlphaTab/Platform/CSharp/AlphaSynthWorkerApiBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using AlphaTab.Collections;
 using AlphaTab.Core.EcmaScript;
 using AlphaTab.Midi;
 using AlphaTab.Synth;
@@ -156,6 +157,11 @@ namespace AlphaTab.Platform.CSharp
         public void LoadMidiFile(MidiFile midi)
         {
             DispatchOnWorkerThread(() => { Player.LoadMidiFile(midi); });
+        }
+
+        public void ApplyTranspositionPitches(IValueTypeMap<double, double> transpositionPitches)
+        {
+            DispatchOnWorkerThread(() => { Player.ApplyTranspositionPitches(transpositionPitches); });
         }
 
         public void SetChannelMute(double channel, bool mute)

--- a/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidThreadAlphaSynthWorkerPlayer.kt
+++ b/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidThreadAlphaSynthWorkerPlayer.kt
@@ -227,6 +227,10 @@ internal class AndroidThreadAlphaSynthWorkerPlayer : IAlphaSynth, Runnable {
         _workerQueue.add { _player?.loadMidiFile(midi) }
     }
 
+    override fun applyTranspositionPitches(transpositionPitches: DoubleDoubleMap) {
+        _workerQueue.add { _player?.applyTranspositionPitches(transpositionPitches) }
+    }
+
     override fun setChannelMute(channel: Double, mute: Boolean) {
         _workerQueue.add { _player?.setChannelMute(channel, mute) }
     }

--- a/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidThreadAlphaSynthWorkerPlayer.kt
+++ b/src.kotlin/alphaTab/alphaTab/src/androidMain/kotlin/alphaTab/platform/android/AndroidThreadAlphaSynthWorkerPlayer.kt
@@ -227,7 +227,7 @@ internal class AndroidThreadAlphaSynthWorkerPlayer : IAlphaSynth, Runnable {
         _workerQueue.add { _player?.loadMidiFile(midi) }
     }
 
-    override fun applyTranspositionPitches(transpositionPitches: DoubleDoubleMap) {
+    override fun applyTranspositionPitches(transpositionPitches: alphaTab.collections.DoubleDoubleMap) {
         _workerQueue.add { _player?.applyTranspositionPitches(transpositionPitches) }
     }
 

--- a/src/AlphaTabApiBase.ts
+++ b/src/AlphaTabApiBase.ts
@@ -191,9 +191,13 @@ export class AlphaTabApiBase<TSettings> {
         // enable/disable player if needed
         if (this.settings.player.enablePlayer) {
             this.setupPlayer();
+            if (score) {
+                this.player?.applyTranspositionPitches(MidiFileGenerator.buildTranspositionPitches(score, this.settings));
+            }
         } else {
             this.destroyPlayer();
         }
+
         this.onSettingsUpdated();
     }
 
@@ -331,8 +335,8 @@ export class AlphaTabApiBase<TSettings> {
                 this._cursorWrapper.width = result.totalWidth;
                 this._cursorWrapper.height = result.totalHeight;
             }
-            
-            if(result.width > 0 || result.height > 0) {
+
+            if (result.width > 0 || result.height > 0) {
                 this.uiFacade.beginAppendRenderResults(result);
             }
         } else {
@@ -607,10 +611,15 @@ export class AlphaTabApiBase<TSettings> {
         let midiFile: MidiFile = new MidiFile();
         let handler: AlphaSynthMidiFileHandler = new AlphaSynthMidiFileHandler(midiFile);
         let generator: MidiFileGenerator = new MidiFileGenerator(this.score, this.settings, handler);
+
+        // we pass the transposition pitches separately to alphaSynth.
+        generator.applyTranspositionPitches = false;
+
         generator.generate();
         this._tickCache = generator.tickLookup;
         this.onMidiLoad(midiFile);
         this.player.loadMidiFile(midiFile);
+        this.player.applyTranspositionPitches(generator.transpositionPitches);
     }
 
     /**

--- a/src/model/Note.ts
+++ b/src/model/Note.ts
@@ -504,28 +504,45 @@ export class Note {
     }
 
     public get realValue(): number {
-        let realValue = this.realValueWithoutHarmonic;
-        if (this.isStringed) {
-            if (this.harmonicType === HarmonicType.Natural) {
-                realValue = this.harmonicPitch + this.stringTuning - this.beat.voice.bar.staff.transpositionPitch;
-            } else {
-                realValue += this.harmonicPitch;
-            }
-        }
-        return realValue;
+        return this.calculateRealValue(true, true);
     }
 
     public get realValueWithoutHarmonic(): number {
-        if (this.isPercussion) {
-            return this.percussionArticulation;
+        return this.calculateRealValue(true, false);
+    }
+
+    /**
+     * Calculates the real note value of this note as midi key respecting the given options.
+     * @param applyTranspositionPitch Whether or not to apply the transposition pitch of the current staff. 
+     * @param applyHarmonic Whether or not to apply harmonic pitches to the note. 
+     * @returns The calculated note value as midi key.
+     */
+    public calculateRealValue(applyTranspositionPitch: boolean, applyHarmonic: boolean): number {
+        const transpositionPitch = applyTranspositionPitch ? this.beat.voice.bar.staff.transpositionPitch : 0;
+
+        if (applyHarmonic) {
+            let realValue = this.calculateRealValue(applyTranspositionPitch, false);
+            if (this.isStringed) {
+                if (this.harmonicType === HarmonicType.Natural) {
+                    realValue = this.harmonicPitch + this.stringTuning - transpositionPitch;
+                } else {
+                    realValue += this.harmonicPitch;
+                }
+            }
+            return realValue;
         }
-        if (this.isStringed) {
-            return this.fret + this.stringTuning - this.beat.voice.bar.staff.transpositionPitch;
+        else {
+            if (this.isPercussion) {
+                return this.percussionArticulation;
+            }
+            if (this.isStringed) {
+                return this.fret + this.stringTuning - transpositionPitch;
+            }
+            if (this.isPiano) {
+                return this.octave * 12 + this.tone - transpositionPitch;
+            }
+            return 0;
         }
-        if (this.isPiano) {
-            return this.octave * 12 + this.tone - this.beat.voice.bar.staff.transpositionPitch;
-        }
-        return 0;
     }
 
     public get harmonicPitch(): number {

--- a/src/platform/javascript/AlphaSynthWebWorker.ts
+++ b/src/platform/javascript/AlphaSynthWebWorker.ts
@@ -18,7 +18,7 @@ export class AlphaSynthWebWorker {
     private _player: AlphaSynth;
     private _main: IWorkerScope;
 
-    public constructor(main: IWorkerScope, bufferTimeInMilliseconds:number) {
+    public constructor(main: IWorkerScope, bufferTimeInMilliseconds: number) {
         this._main = main;
         this._main.addEventListener('message', this.handleMessage.bind(this));
 
@@ -84,7 +84,7 @@ export class AlphaSynthWebWorker {
                 break;
             case 'alphaSynth.setCountInVolume':
                 this._player.countInVolume = data.value;
-                break;           
+                break;
             case 'alphaSynth.setMidiEventsPlayedFilter':
                 this._player.midiEventsPlayedFilter = data.value;
                 break;
@@ -129,6 +129,9 @@ export class AlphaSynthWebWorker {
                 this._main.postMessage({
                     cmd: 'alphaSynth.destroyed'
                 });
+                break;
+            case 'alphaSynth.applyTranspositionPitches':
+                this._player.applyTranspositionPitches(new Map<number, number>(JSON.parse(data.transpositionPitches)));
                 break;
         }
     }

--- a/src/platform/javascript/AlphaSynthWebWorkerApi.ts
+++ b/src/platform/javascript/AlphaSynthWebWorkerApi.ts
@@ -312,6 +312,13 @@ export class AlphaSynthWebWorkerApi implements IAlphaSynth {
         });
     }
 
+    public applyTranspositionPitches(transpositionPitches: Map<number, number>): void {
+        this._synth.postMessage({
+            cmd: 'alphaSynth.applyTranspositionPitches',
+            transpositionPitches: JSON.stringify(Array.from(transpositionPitches.entries()))
+        });
+    }
+
     public setChannelMute(channel: number, mute: boolean): void {
         this._synth.postMessage({
             cmd: 'alphaSynth.setChannelMute',

--- a/src/synth/AlphaSynth.ts
+++ b/src/synth/AlphaSynth.ts
@@ -381,6 +381,10 @@ export class AlphaSynth implements IAlphaSynth {
         }
     }
 
+    public applyTranspositionPitches(transpositionPitches: Map<number, number>): void {
+        this._synthesizer.applyTranspositionPitches(transpositionPitches);
+    }
+
     public setChannelMute(channel: number, mute: boolean): void {
         this._synthesizer.channelSetMute(channel, mute);
     }
@@ -418,7 +422,7 @@ export class AlphaSynth implements IAlphaSynth {
         } else {
             endTick = this._sequencer.currentEndTick;
         }
-     
+
         if (this._tickPosition >= endTick && this._notPlayedSamples <= 0) {
             this._notPlayedSamples = 0;
             if (this._sequencer.isPlayingCountIn) {

--- a/src/synth/IAlphaSynth.ts
+++ b/src/synth/IAlphaSynth.ts
@@ -130,6 +130,12 @@ export interface IAlphaSynth {
     loadMidiFile(midi: MidiFile): void;
 
     /**
+     * Applies the given transposition pitches to be used during playback.
+     * @param transpositionPitches a map defining the transposition pitches for midi channel.
+     */
+    applyTranspositionPitches(transpositionPitches: Map<number, number>): void;
+
+    /**
      * Sets the mute state of a channel.
      * @param channel The channel number
      * @param mute true if the channel should be muted, otherwise false.

--- a/src/synth/synthesis/TinySoundFont.ts
+++ b/src/synth/synthesis/TinySoundFont.ts
@@ -41,6 +41,7 @@ export class TinySoundFont {
     private _mutedChannels: Map<number, boolean> = new Map<number, boolean>();
     private _soloChannels: Map<number, boolean> = new Map<number, boolean>();
     private _isAnySolo: boolean = false;
+    private _transpositionPitches: Map<number, number> = new Map<number, number>();
 
     public currentTempo: number = 0;
     public timeSignatureNumerator: number = 0;
@@ -94,7 +95,32 @@ export class TinySoundFont {
     public resetChannelStates(): void {
         this._mutedChannels = new Map<number, boolean>();
         this._soloChannels = new Map<number, boolean>();
+
+        this.applyTranspositionPitches(new Map<number, number>());
         this._isAnySolo = false;
+    }
+
+    public applyTranspositionPitches(transpositionPitches: Map<number, number>): void {
+        // dynamically adjust actively playing voices to the new pitch they have. 
+        // we are not updating the used preset and regions though. 
+        const previousTransposePitches = this._transpositionPitches;
+        for (const voice of this._voices) {
+            if (voice.playingChannel >= 0 && voice.playingChannel !== 9 /*percussion*/) {
+                let pitchDifference = 0;
+
+                if(previousTransposePitches.has(voice.playingChannel)) {
+                    pitchDifference -= previousTransposePitches.get(voice.playingChannel)!;
+                }
+                
+                if(transpositionPitches.has(voice.playingChannel)) {
+                    pitchDifference += transpositionPitches.get(voice.playingChannel)!;
+                }
+
+                voice.playingKey += pitchDifference;
+            }
+        }
+
+        this._transpositionPitches = transpositionPitches;
     }
 
     public dispatchEvent(synthEvent: SynthEvent): void {
@@ -581,6 +607,10 @@ export class TinySoundFont {
             return;
         }
 
+        if (this._transpositionPitches.has(channel)) {
+            key += this._transpositionPitches.get(channel)!;
+        }
+
         this._channels.activeChannel = channel;
         this.noteOn(this._channels.channelList[channel].presetIndex, key, vel);
     }
@@ -591,6 +621,10 @@ export class TinySoundFont {
      * @param key note value between 0 and 127 (60 being middle C)
      */
     public channelNoteOff(channel: number, key: number): void {
+        if (this._transpositionPitches.has(channel)) {
+            key += this._transpositionPitches.get(channel)!;
+        }
+
         const matches: Voice[] = [];
         let matchFirst: Voice | null = null;
         let matchLast: Voice | null = null;
@@ -804,6 +838,10 @@ export class TinySoundFont {
      * @param pitchWheel pitch wheel position 0 to 16383 (default 8192 unpitched)
      */
     public channelSetPerNotePitchWheel(channel: number, key: number, pitchWheel: number): void {
+        if (this._transpositionPitches.has(channel)) {
+            key += this._transpositionPitches.get(channel)!;
+        }
+
         const c: Channel = this.channelInit(channel);
         if (c.perNotePitchWheel.has(key) && c.perNotePitchWheel.get(key) === pitchWheel) {
             return;

--- a/src/synth/synthesis/TinySoundFont.ts
+++ b/src/synth/synthesis/TinySoundFont.ts
@@ -117,6 +117,10 @@ export class TinySoundFont {
                 }
 
                 voice.playingKey += pitchDifference;
+
+                if(this._channels) {
+                    voice.updatePitchRatio(this._channels!.channelList[voice.playingChannel], this.outSampleRate);
+                }
             }
         }
 


### PR DESCRIPTION
### Issues
Fixes #896

### Proposed changes
Instead of applying the transposition pitches directly to the midi, we generate now the midi without transposal and pass the transposition pitches separately to the synth. 

A new synth API allows then modifying the pitches on-the fly and we use this API in applySettings. 


### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
