### PR TITLE
Fix harsh noise by only synthesizing samples while playing

### DIFF
--- a/src/synth/AlphaSynth.ts
+++ b/src/synth/AlphaSynth.ts
@@ -183,7 +183,7 @@ export class AlphaSynth implements IAlphaSynth {
             this.checkReadyForPlayback();
         });
         this.output.sampleRequest.on(() => {
-            if (!this._sequencer.isFinished) {
+            if (this.state == PlayerState.Playing && !this._sequencer.isFinished) {
                 let samples: Float32Array = new Float32Array(
                     SynthConstants.MicroBufferSize * SynthConstants.MicroBufferCount * SynthConstants.AudioChannels
                 );


### PR DESCRIPTION
### Issues
Fixes #1298

### Proposed changes
There was a race condition between the audio workers and the main synthesizer components when the playback finished. The sequence was roughly:

1. The last samples of the song are synthesized and the sequencer finishes. 
2. The audio output still has samples to play so it continues, but we stop synthesizing new samples as we are finished. 
3. The last samples are played the synthesizer marks the playback as finished. 
4. At the same time like 3. the output already has requested again new samples for being played.
5. The output is stopped as part of 3. 
6. As the output already requested samples we start synthesizing the related buffers. 
7. We the midi sequencer is out of sync with the main synth time. 
8. When we now start playing again the midi sequencer finishes too early and we never reach the end time as we send only 0-byte buffers to the output. 
9. We end up hanging on the output side and never complete resulting in weird samples to be played. 

We fix this problem by checking on the synthesizer side whether we are currently playing and do not synthesize any samples. This prevents the sequence above by avoiding step 6. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
