### PR TITLE
Handle empty bars and pre-beat grace notes on new lookup logic

### DIFF
--- a/src/midi/BeatTickLookup.ts
+++ b/src/midi/BeatTickLookup.ts
@@ -14,19 +14,12 @@ export class BeatTickLookupItem {
      */
     public readonly playbackStart: number;
 
-    /**
-     * Gets the playback start of the beat duration according to the generated audio.
-     */
-    public readonly playbackDuration: number;
-
     public constructor(
         beat: Beat,
-        playbackStart: number,
-        playbackDuration: number
+        playbackStart: number
     ) {
         this.beat = beat;
         this.playbackStart = playbackStart;
-        this.playbackDuration = playbackDuration;
     }
 }
 
@@ -81,13 +74,13 @@ export class BeatTickLookup {
      * Marks the given beat as highlighed as part of this lookup.
      * @param beat The beat to add.
      */
-    public highlightBeat(beat: Beat, playbackStart: number, playbackDuration: number): void {
+    public highlightBeat(beat: Beat, playbackStart: number): void {
         if (beat.isEmpty && !beat.voice.isEmpty) {
             return;
         }
         if (!this._highlightedBeats.has(beat.id)) {
             this._highlightedBeats.set(beat.id, true);
-            this.highlightedBeats.push(new BeatTickLookupItem(beat, playbackStart, playbackDuration));
+            this.highlightedBeats.push(new BeatTickLookupItem(beat, playbackStart));
         }
     }
 

--- a/src/midi/BeatTickLookup.ts
+++ b/src/midi/BeatTickLookup.ts
@@ -82,7 +82,7 @@ export class BeatTickLookup {
      * @param beat The beat to add.
      */
     public highlightBeat(beat: Beat, playbackStart: number, playbackDuration: number): void {
-        if (beat.isEmpty) {
+        if (beat.isEmpty && !beat.voice.isEmpty) {
             return;
         }
         if (!this._highlightedBeats.has(beat.id)) {

--- a/src/midi/MidiTickLookup.ts
+++ b/src/midi/MidiTickLookup.ts
@@ -417,6 +417,25 @@ export class MidiTickLookup {
     }
 
     public addBeat(beat: Beat, start: number, duration: number): void {
-        this._currentMasterBar?.addBeat(beat, start, duration);
+        const currentMasterBar = this._currentMasterBar;
+        if (currentMasterBar) {
+            // pre-beat grace notes at the start of the bar we also add the beat to the previous bar
+            if (start < 0 && currentMasterBar.previousMasterBar) {
+                const previousStart = currentMasterBar.previousMasterBar!.end + start;
+                const previousEnd = previousStart + duration;
+
+                // add to previous bar 
+                currentMasterBar.previousMasterBar!.addBeat(beat, previousStart, previousStart, currentMasterBar.previousMasterBar!.end - previousStart);
+
+                // overlap to current bar?
+                if(previousEnd > currentMasterBar.previousMasterBar!.end) {
+                    // the start is negative and representing the overlap to the previous bar.
+                    const overlapDuration = duration + start;
+                    currentMasterBar.addBeat(beat, start, 0, overlapDuration);
+                }
+            } else {
+                currentMasterBar.addBeat(beat, start, start, duration);
+            }
+        }
     }
 }

--- a/test/audio/MidiTickLookup.test.ts
+++ b/test/audio/MidiTickLookup.test.ts
@@ -520,14 +520,14 @@ describe('MidiTickLookupTest', () => {
 
             Logger.debug("Test", `Checking index ${i} with tick ${ticks[i]}`)
             expect(currentLookup).to.be.ok;
-            actualIncrementalFrets.push(currentLookup!.beat.notes[0].fret);
+            actualIncrementalFrets.push(currentLookup!.beat.notes.length > 0 ? currentLookup!.beat.notes[0].fret : -1);
             actualIncrementalNextFrets.push(currentLookup!.nextBeat?.beat?.notes?.[0]?.fret ?? null)
             actualIncrementalTickDurations.push(currentLookup!.tickDuration)
 
             if (!skipClean) {
                 const cleanLookup = lookup.findBeat(tracks, ticks[i], null);
 
-                actualCleanFrets.push(cleanLookup!.beat.notes[0].fret);
+                actualCleanFrets.push(cleanLookup!.beat.notes.length > 0 ? cleanLookup!.beat.notes[0].fret : -1);
                 actualCleanNextFrets.push(cleanLookup!.nextBeat?.beat?.notes?.[0]?.fret ?? null)
                 actualCleanTickDurations.push(cleanLookup!.tickDuration)
             }
@@ -699,6 +699,36 @@ describe('MidiTickLookupTest', () => {
                 null, null, null, null
             ],
             true
+        )
+    });
+
+    it('empty-bar', () => {
+        lookupTest(
+            `
+            \\ts 2 4
+             | 1.1.1 |
+            `,
+            [
+                // first bar (empty)
+                0, 480, 960, 1440, 
+                // second bar, real playback
+                1920, 2400, 2880, 3360
+            ],
+            [0],
+            [
+                1920, 1920, 1920, 1920,
+                1920, 1920, 1920, 1920
+            ],
+            [
+                // first bar (empty)
+                -1, -1, -1, -1,
+                // second bar, real playback
+                1, 1, 1, 1
+            ],
+            [
+                1, 1, 1, 1, 
+                null, null, null, null
+            ]
         )
     });
 });

--- a/test/audio/MidiTickLookup.test.ts
+++ b/test/audio/MidiTickLookup.test.ts
@@ -636,11 +636,11 @@ describe('MidiTickLookupTest', () => {
         let currentLookup: MidiTickLookupFindBeatResult | null = null;
 
         const actualIncrementalFrets: number[] = [];
-        const actualIncrementalNextFrets: (number | null)[] = [];
+        const actualIncrementalNextFrets: number[] = [];
         const actualIncrementalTickDurations: number[] = [];
 
         const actualCleanFrets: number[] = [];
-        const actualCleanNextFrets: (number | null)[] = [];
+        const actualCleanNextFrets: number[] = [];
         const actualCleanTickDurations: number[] = [];
 
         for (let i = 0; i < ticks.length; i++) {

--- a/test/audio/MidiTickLookup.test.ts
+++ b/test/audio/MidiTickLookup.test.ts
@@ -457,6 +457,10 @@ describe('MidiTickLookupTest', () => {
         return b;
     }
 
+    function fretOfBeat(beat: Beat | null) {
+        return beat && beat.notes.length > 0 ? beat.notes[0].fret : -1;
+    }
+
     function prepareGraceMultiVoice(graceNoteOverlap: number, graceNoteDuration: number): MidiTickLookup {
         const lookup = new MidiTickLookup();
 
@@ -619,7 +623,7 @@ describe('MidiTickLookupTest', () => {
         trackIndexes: number[],
         durations: number[],
         currentBeatFrets: number[],
-        nextBeatFrets: (number | null)[],
+        nextBeatFrets: number[],
         skipClean: boolean = false
     ) {
         const buffer = ByteBuffer.fromString(tex);
@@ -644,15 +648,15 @@ describe('MidiTickLookupTest', () => {
 
             Logger.debug("Test", `Checking index ${i} with tick ${ticks[i]}`)
             expect(currentLookup).to.be.ok;
-            actualIncrementalFrets.push(currentLookup!.beat.notes.length > 0 ? currentLookup!.beat.notes[0].fret : -1);
-            actualIncrementalNextFrets.push(currentLookup!.nextBeat?.beat?.notes?.[0]?.fret ?? null)
+            actualIncrementalFrets.push(fretOfBeat(currentLookup!.beat));
+            actualIncrementalNextFrets.push(fretOfBeat(currentLookup!.nextBeat?.beat ?? null))
             actualIncrementalTickDurations.push(currentLookup!.tickDuration)
 
             if (!skipClean) {
                 const cleanLookup = lookup.findBeat(tracks, ticks[i], null);
 
-                actualCleanFrets.push(cleanLookup!.beat.notes.length > 0 ? cleanLookup!.beat.notes[0].fret : -1);
-                actualCleanNextFrets.push(cleanLookup!.nextBeat?.beat?.notes?.[0]?.fret ?? null)
+                actualCleanFrets.push(fretOfBeat(cleanLookup!.beat));
+                actualCleanNextFrets.push(fretOfBeat(cleanLookup!.nextBeat?.beat ?? null))
                 actualCleanTickDurations.push(cleanLookup!.tickDuration)
             }
         }
@@ -673,7 +677,7 @@ describe('MidiTickLookupTest', () => {
     function nextBeatSearchTest(trackIndexes: number[],
         durations: number[],
         currentBeatFrets: number[],
-        nextBeatFrets: (number | null)[]
+        nextBeatFrets: number[]
     ) {
         lookupTest(
             `
@@ -709,7 +713,7 @@ describe('MidiTickLookupTest', () => {
             ],
             [
                 4, 4, 2, 2, 6, 6, 6, 6,
-                9, 9, 7, 7, null, null, null, null
+                9, 9, 7, 7, -1, -1, -1, -1
             ]
         )
     });
@@ -727,7 +731,7 @@ describe('MidiTickLookupTest', () => {
             ],
             [
                 2, 2, 2, 2, 6, 6, 6, 6,
-                7, 7, 7, 7, null, null, null, null
+                7, 7, 7, 7, -1, -1, -1, -1
             ]
         )
     });
@@ -751,7 +755,7 @@ describe('MidiTickLookupTest', () => {
             ],
             [
                 2, 3, 4, 5,
-                6, 7, 8, null
+                6, 7, 8, -1
             ]
         )
     });
@@ -775,7 +779,7 @@ describe('MidiTickLookupTest', () => {
             ],
             [
                 2, 3, 4, 5,
-                6, 7, 8, null
+                6, 7, 8, -1
             ]
         )
     });
@@ -814,13 +818,13 @@ describe('MidiTickLookupTest', () => {
                 4, 4, 4, 4
             ],
             [
-                2, 2, null, null,
+                2, 2, -1, -1,
 
-                null, null, null, null,
+                -1, -1, -1, -1,
 
-                4, 4, null, null,
+                4, 4, -1, -1,
 
-                null, null, null, null
+                -1, -1, -1, -1
             ],
             true
         )
@@ -830,7 +834,7 @@ describe('MidiTickLookupTest', () => {
         lookupTest(
             `
             \\ts 2 4
-             | 1.1.1 |
+             | 1.1.1
             `,
             [
                 // first bar (empty)
@@ -851,7 +855,7 @@ describe('MidiTickLookupTest', () => {
             ],
             [
                 1, 1, 1, 1,
-                null, null, null, null
+                -1, -1, -1, -1
             ]
         )
     });


### PR DESCRIPTION
### Issues
Fixes #1339

### Proposed changes
Fixes the two scenarios described in the bug report: 

* We need to accept the beat of empty voices in the lookup to have the cursor considered. 
* We need to ensure we add pre-beat grace notes also to the previous bar lookup if possible
* We need to ensure we take the original beat playback start for the visibility check, not the slice start.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [x] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
