### PR TITLE
feat(alphaTex): allow specifying tempo as a float in a string

### DIFF
--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -727,8 +727,16 @@ export class AlphaTexImporter extends ScoreImporter {
                     break;
                 case 'tempo':
                     this._sy = this.newSy();
-                    if (this._sy === AlphaTexSymbols.Number) {
-                        this._score.tempo = this._syData as number;
+                    if (this._sy === AlphaTexSymbols.Number || this._sy === AlphaTexSymbols.String) {
+                        if (this._sy === AlphaTexSymbols.Number) {
+                            this._score.tempo = this._syData as number;
+                        } else if (this._sy === AlphaTexSymbols.String) {
+                            let f: number = parseFloat(this._syData as string);
+                            if (isNaN(f)) {
+                                this.errorMessage('invalid temp string');
+                            }
+                            this._score.tempo = f;
+                        }
                     } else {
                         this.error('tempo', AlphaTexSymbols.Number, true);
                     }
@@ -1879,13 +1887,24 @@ export class AlphaTexImporter extends ScoreImporter {
                 this._sy = this.newSy();
             } else if (syData === 'tempo') {
                 this._sy = this.newSy();
-                if (this._sy !== AlphaTexSymbols.Number) {
+                let value: number = 0;
+                if (this._sy === AlphaTexSymbols.Number || this._sy === AlphaTexSymbols.String) {
+                    if (this._sy === AlphaTexSymbols.Number) {
+                        value = this._syData as number;
+                    } else if (this._sy === AlphaTexSymbols.String) {
+                        let f: number = parseFloat(this._syData as string);
+                        if (isNaN(f)) {
+                            this.errorMessage('invalid temp string');
+                        }
+                        value = f;
+                    }
+                } else {
                     this.error('tempo', AlphaTexSymbols.Number, true);
                 }
                 let tempoAutomation: Automation = new Automation();
                 tempoAutomation.isLinear = false;
                 tempoAutomation.type = AutomationType.Tempo;
-                tempoAutomation.value = this._syData as number;
+                tempoAutomation.value = value;
                 master.tempoAutomation = tempoAutomation;
                 this._sy = this.newSy();
             } else if (syData === 'section') {

--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -136,6 +136,7 @@ export class AlphaTexImporter extends ScoreImporter {
     private _sy: AlphaTexSymbols = AlphaTexSymbols.No;
     private _syData: unknown = "";
     private _allowNegatives: boolean = false;
+    private _allowFloat: boolean = false;
     private _allowTuning: boolean = false;
     private _currentDuration: Duration = Duration.QuadrupleWhole;
     private _currentDynamics: DynamicValue = DynamicValue.PPP;
@@ -548,7 +549,7 @@ export class AlphaTexImporter extends ScoreImporter {
             } else if (this._ch === 0x2d /* - */) {
                 // negative number
                 // is number?
-                if (this._allowNegatives && this.isDigit(this._ch)) {
+                if (this._allowNegatives) {
                     this._sy = AlphaTexSymbols.Number;
                     this._syData = this.readNumber();
                 } else {
@@ -649,7 +650,8 @@ export class AlphaTexImporter extends ScoreImporter {
     private isDigit(ch: number): boolean {
         return (
             (ch >= 0x30 && ch <= 0x39) /* 0-9 */ ||
-            (this._allowNegatives && ch === 0x2d /* - */) // allow minus sign if negatives
+            (this._allowNegatives && ch === 0x2d /* - */) || // allow minus sign if negatives
+            (this._allowFloat && ch === 0x2e /* . */) // allow dot if float
         );
     }
 
@@ -676,7 +678,7 @@ export class AlphaTexImporter extends ScoreImporter {
             str += String.fromCharCode(this._ch);
             this._ch = this.nextChar();
         } while (this.isDigit(this._ch));
-        return parseInt(str);
+        return this._allowFloat ? parseFloat(str) : parseInt(str);
     }
 
     private metaData(): boolean {
@@ -726,17 +728,11 @@ export class AlphaTexImporter extends ScoreImporter {
                     anyMeta = true;
                     break;
                 case 'tempo':
+                    this._allowFloat = true;
                     this._sy = this.newSy();
-                    if (this._sy === AlphaTexSymbols.Number || this._sy === AlphaTexSymbols.String) {
-                        if (this._sy === AlphaTexSymbols.Number) {
-                            this._score.tempo = this._syData as number;
-                        } else if (this._sy === AlphaTexSymbols.String) {
-                            let f: number = parseFloat(this._syData as string);
-                            if (isNaN(f)) {
-                                this.errorMessage('invalid temp string');
-                            }
-                            this._score.tempo = f;
-                        }
+                    this._allowFloat = false;
+                    if (this._sy === AlphaTexSymbols.Number) {
+                        this._score.tempo = this._syData as number;
                     } else {
                         this.error('tempo', AlphaTexSymbols.Number, true);
                     }
@@ -1886,25 +1882,16 @@ export class AlphaTexImporter extends ScoreImporter {
                 }
                 this._sy = this.newSy();
             } else if (syData === 'tempo') {
+                this._allowFloat = true;
                 this._sy = this.newSy();
-                let value: number = 0;
-                if (this._sy === AlphaTexSymbols.Number || this._sy === AlphaTexSymbols.String) {
-                    if (this._sy === AlphaTexSymbols.Number) {
-                        value = this._syData as number;
-                    } else if (this._sy === AlphaTexSymbols.String) {
-                        let f: number = parseFloat(this._syData as string);
-                        if (isNaN(f)) {
-                            this.errorMessage('invalid temp string');
-                        }
-                        value = f;
-                    }
-                } else {
+                this._allowFloat = false;
+                if (this._sy !== AlphaTexSymbols.Number) {
                     this.error('tempo', AlphaTexSymbols.Number, true);
                 }
                 let tempoAutomation: Automation = new Automation();
                 tempoAutomation.isLinear = false;
                 tempoAutomation.type = AutomationType.Tempo;
-                tempoAutomation.value = value;
+                tempoAutomation.value = this._syData as number;
                 master.tempoAutomation = tempoAutomation;
                 this._sy = this.newSy();
             } else if (syData === 'section') {

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -1130,18 +1130,18 @@ describe('AlphaTexImporterTest', () => {
         }
     });
 
-    it('tempo-as-float-string', () => {
-        const score = parseTex('\\tempo "112.5" .');
+    it('tempo-as-float', () => {
+        const score = parseTex('\\tempo 112.5 .');
         expect(score.tempo).to.equal(112.5);
     });
 
-    it('tempo-as-float-string-in-bar', () => {
-        const score = parseTex('\\tempo 112 . 3.3.1 | \\tempo "333.3" 3.3');
+    it('tempo-as-float-in-bar', () => {
+        const score = parseTex('\\tempo 112 . 3.3.1 | \\tempo 333.3 3.3');
         expect(score.tempo).to.equal(112);
         expect(score.tracks[0].staves[0].bars[1].masterBar.tempoAutomation?.value).to.equal(333.3);
     });
 
-    it('tempo-invalid-float-string', () => {
-        expect(() => parseTex('\\tempo "a a 112" .')).to.throw(UnsupportedFormatError);
+    it('tempo-invalid-float', () => {
+        expect(() => parseTex('\\tempo 112.Q .')).to.throw(UnsupportedFormatError);
     });
 });

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -1129,4 +1129,19 @@ describe('AlphaTexImporterTest', () => {
             expect(i.message?.includes('ABC')).to.be.true;
         }
     });
+
+    it('tempo-as-float-string', () => {
+        const score = parseTex('\\tempo "112.5" .');
+        expect(score.tempo).to.equal(112.5);
+    });
+
+    it('tempo-as-float-string-in-bar', () => {
+        const score = parseTex('\\tempo 112 . 3.3.1 | \\tempo "333.3" 3.3');
+        expect(score.tempo).to.equal(112);
+        expect(score.tracks[0].staves[0].bars[1].masterBar.tempoAutomation?.value).to.equal(333.3);
+    });
+
+    it('tempo-invalid-float-string', () => {
+        expect(() => parseTex('\\tempo "a a 112" .')).to.throw(UnsupportedFormatError);
+    });
 });


### PR DESCRIPTION
### Proposed changes
<!-- Describe the proposed changes -->

Stumbled upon a piece that has a BPM of 112.3(!), so I propose this change where the tempo number can also be a float in a string. (using additional dots and number breaks the parser in edge cases)

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [x] New tests were added

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website (or leave it as an easter egg :) )
