### PR TITLE
fix: Start and end times have to be relative to the masterbar not absolute

### DIFF
--- a/src/midi/MidiTickLookup.ts
+++ b/src/midi/MidiTickLookup.ts
@@ -421,14 +421,15 @@ export class MidiTickLookup {
         if (currentMasterBar) {
             // pre-beat grace notes at the start of the bar we also add the beat to the previous bar
             if (start < 0 && currentMasterBar.previousMasterBar) {
-                const previousStart = currentMasterBar.previousMasterBar!.end + start;
+                const relativeMasterBarEnd = currentMasterBar.previousMasterBar!.end - currentMasterBar.previousMasterBar!.start;
+                const previousStart = relativeMasterBarEnd + start;
                 const previousEnd = previousStart + duration;
 
                 // add to previous bar 
-                currentMasterBar.previousMasterBar!.addBeat(beat, previousStart, previousStart, currentMasterBar.previousMasterBar!.end - previousStart);
+                currentMasterBar.previousMasterBar!.addBeat(beat, previousStart, previousStart, duration);
 
                 // overlap to current bar?
-                if(previousEnd > currentMasterBar.previousMasterBar!.end) {
+                if(previousEnd > relativeMasterBarEnd) {
                     // the start is negative and representing the overlap to the previous bar.
                     const overlapDuration = duration + start;
                     currentMasterBar.addBeat(beat, start, 0, overlapDuration);


### PR DESCRIPTION
### Issues
Fixes #1355

### Proposed changes

1. The start and end times of grace notes stealing from the previous bar were wrongly using absolute times. This caused problems on grace notes which were at any bar higher than 1 that the durations of the notes were treated wrong. 
2. The duration of the grace note was considered wrong in case of multiple grace notes. We wrongly used the remaining time of the bar instead of the actual duration. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [x] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
