### PR TITLE
Handle WebWorkers ourselves for Angular

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -126,7 +126,7 @@ export default [
         },
         plugins: [...bundlePlugins, commonjs()]
     },
-    !isWatch && {
+    (!isWatch || !!process.env.ALPHATAB_WEBPACK) && {
         input: 'src/alphaTab.webpack.ts',
         output: [
             {
@@ -138,7 +138,7 @@ export default [
         ],
         external: ['webpack', 'webpack/lib/ModuleTypeConstants', 'webpack/lib/util/makeSerializable', 'fs', 'path'],
         watch: {
-            include: ['src/alphaTab.webpack.ts'],
+            include: ['src/alphaTab.webpack.ts', "src/webpack/**"],
             exclude: 'node_modules/**'
         },
         plugins: [...bundlePlugins]

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -662,6 +662,11 @@ export class Environment {
     /**
      * @target web
      */
+    public static get alphaTabWorker(): any { return this.globalThis.Worker };
+
+    /**
+     * @target web
+     */
     public static initializeWorker() {
         if (!Environment.isRunningInWorker) {
             throw new AlphaTabError(AlphaTabErrorType.General, "Not running in worker, cannot run worker initialization");

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -662,7 +662,7 @@ export class Environment {
     /**
      * @target web
      */
-    public static get alphaTabWorker(): any { return this.globalThis.Worker };
+    public static get alphaTabWorker(): any { return this.globalThis.Worker }
 
     /**
      * @target web

--- a/src/alphaTab.main.ts
+++ b/src/alphaTab.main.ts
@@ -16,20 +16,10 @@ if (alphaTab.Environment.isRunningInWorker) {
                 );
             }
 
-            if (alphaTab.Environment.isWebPackBundled) {
-                alphaTab.Logger.debug('AlphaTab', 'Creating WebPack compatible worker');
-                // WebPack currently requires this exact syntax: new Worker(new URL(..., import.meta.url)))
-                // The module `@coderline/alphatab` will be resolved by WebPack to alphaTab consumed as library
-                // this will not work with CDNs because worker start scripts need to have the same origin like
-                // the current browser.
-
-                // https://github.com/webpack/webpack/discussions/14066
-
-                return new Worker(new URL('./alphaTab.worker', import.meta.url));
-            } else if (alphaTab.Environment.webPlatform == alphaTab.WebPlatform.BrowserModule) {
-                alphaTab.Logger.debug('AlphaTab', 'Creating Module worker');
-                return new Worker(new URL('./alphaTab.worker', import.meta.url), { type: 'module' });
-            }
+	        if (alphaTab.Environment.webPlatform == alphaTab.WebPlatform.BrowserModule || alphaTab.Environment.isWebPackBundled) {
+	            alphaTab.Logger.debug("AlphaTab", "Creating webworker");
+	            return new alphaTab.Environment.alphaTabWorker(new URL('./alphaTab.worker', import.meta.url), { type: 'module' });
+	        }
 
             // classical browser entry point
             if (!settings.core.scriptFile) {
@@ -58,14 +48,11 @@ if (alphaTab.Environment.isRunningInWorker) {
                 );
             }
 
-            if (
-                alphaTab.Environment.isWebPackBundled ||
-                alphaTab.Environment.webPlatform == alphaTab.WebPlatform.BrowserModule
-            ) {
-                alphaTab.Logger.debug('AlphaTab', 'Creating Module worklet');
-                const alphaTabWorklet = context.audioWorklet; // this name triggers the WebPack Plugin
-                return alphaTabWorklet.addModule(new URL('./alphaTab.worklet', import.meta.url));
-            }
+	        if (alphaTab.Environment.webPlatform == alphaTab.WebPlatform.BrowserModule || alphaTab.Environment.isWebPackBundled) {
+	            alphaTab.Logger.debug("AlphaTab", "Creating Module worklet");
+	            const alphaTabWorklet = context.audioWorklet; // this name triggers the WebPack Plugin
+	            return alphaTabWorklet.addModule(new URL('./alphaTab.worklet', import.meta.url));
+	        }
 
             alphaTab.Logger.debug('AlphaTab', 'Creating Script worklet');
             return context.audioWorklet.addModule(settings.core.scriptFile!);

--- a/src/webpack/AlphaTabAudioWorklet.ts
+++ b/src/webpack/AlphaTabAudioWorklet.ts
@@ -1,0 +1,101 @@
+/**@target web */
+import webpack from 'webpack'
+
+import { type VariableDeclarator, type Identifier, type Expression, type CallExpression } from 'estree'
+import { AlphaTabWebPackPluginOptions } from './AlphaTabWebPackPluginOptions';
+import { AlphaTabWorkletDependency } from './AlphaTabWorkletDependency';
+import { getWorkerRuntime, parseModuleUrl, tapJavaScript } from './Utils';
+
+const AlphaTabWorkletSpecifierTag = Symbol("alphatab worklet specifier tag");
+const workletIndexMap = new WeakMap<webpack.ParserState, number>();
+
+/**
+ * Configures the Audio Worklet aspects within webpack.
+ * The counterpart which this plugin detects sits in alphaTab.main.ts
+ * @param pluginName 
+ * @param options 
+ * @param compiler 
+ * @param compilation 
+ * @param normalModuleFactory 
+ * @param cachedContextify 
+ * @returns 
+ */
+export function configureAudioWorklet(pluginName: string,
+    options: AlphaTabWebPackPluginOptions,
+    compiler: webpack.Compiler, compilation: webpack.Compilation, normalModuleFactory: any, cachedContextify: (s: string) => string) {
+    if (options.audioWorklets === false) {
+        return;
+    }
+
+    compilation.dependencyFactories.set(
+        AlphaTabWorkletDependency,
+        normalModuleFactory
+    );
+    compilation.dependencyTemplates.set(
+        AlphaTabWorkletDependency,
+        new AlphaTabWorkletDependency.Template()
+    );
+
+    const handleAlphaTabWorklet = (parser: any, expr: CallExpression) => {
+        const [arg1] = expr.arguments;
+        const parsedUrl = parseModuleUrl(parser, arg1 as Expression);
+        if (!parsedUrl) {
+            return;
+        }
+
+        const [url] = parsedUrl;
+        if (!url.isString()) {
+            return;
+        }
+
+        const runtime = getWorkerRuntime(parser, compilation, cachedContextify, workletIndexMap);
+        const block = new webpack.AsyncDependenciesBlock({
+            entryOptions: {
+                chunkLoading: false,
+                wasmLoading: false,
+                runtime: runtime
+            }
+        });
+
+        block.loc = expr.loc;
+
+        const workletBootstrap = new AlphaTabWorkletDependency(
+            url.string,
+            [expr.range![0], expr.range![1]],
+            compiler.options.output.workerPublicPath,
+        );
+        workletBootstrap.loc = expr.loc!;
+        block.addDependency(workletBootstrap);
+        parser.state.module.addBlock(block);
+
+        return true;
+    };
+
+    const parserPlugin = (parser: any) => {
+        const pattern = "alphaTabWorklet";
+        const itemMembers = "addModule";
+
+        parser.hooks.preDeclarator.tap(pluginName, (decl: VariableDeclarator) => {
+            if (decl.id.type === "Identifier" && decl.id.name === pattern) {
+                parser.tagVariable(decl.id.name, AlphaTabWorkletSpecifierTag);
+                return true;
+            }
+            return;
+        });
+        parser.hooks.pattern.for(pattern).tap(pluginName, (pattern: Identifier) => {
+            parser.tagVariable(pattern.name, AlphaTabWorkletSpecifierTag);
+            return true;
+        });
+
+        parser.hooks.callMemberChain
+            .for(AlphaTabWorkletSpecifierTag)
+            .tap(pluginName, (expression: CallExpression, members: string[]) => {
+                if (itemMembers !== members.join(".")) {
+                    return;
+                }
+                return handleAlphaTabWorklet(parser, expression);
+            });
+    };
+
+    tapJavaScript(normalModuleFactory, pluginName, parserPlugin);
+}

--- a/src/webpack/AlphaTabWebPackPluginOptions.ts
+++ b/src/webpack/AlphaTabWebPackPluginOptions.ts
@@ -1,0 +1,38 @@
+/**@target web */
+export interface AlphaTabWebPackPluginChunkOptions {
+    name?: string;
+    minSize?: number;
+    priority?: number;
+}
+
+/**@target web */
+export interface AlphaTabWebPackPluginOptions {
+    /**
+     * The location where alphaTab can be found.
+     * (default: node_modules/@coderline/alphatab/dist)
+     */
+    alphaTabSourceDir?: string;
+
+    /**
+     * The location where assets of alphaTab should be placed. 
+     * Set it to false to disable the copying of assets like fonts.
+     * (default: compiler.options.output.path)
+     */
+    assetOutputDir?: string | false;
+
+    /**
+     * Whether alphaTab should configure the audio worklet support in WebPack.
+     * This might break support for audio playback unless audio worklet support is added
+     * through other means to WebPack. 
+     * (default: true)
+     */
+    audioWorklets?: boolean;
+
+    /**
+     * Whether alphaTab should configure the web worklet support in WebPack.
+     * This might break support for audio playback and background unless audio worklet support is added
+     * through other means to WebPack. 
+     * (default: true)
+     */
+    webWorkers?: boolean;
+}

--- a/src/webpack/AlphaTabWebWorker.ts
+++ b/src/webpack/AlphaTabWebWorker.ts
@@ -1,0 +1,94 @@
+/**@target web */
+import webpack from 'webpack'
+
+
+import { type Expression, type CallExpression } from 'estree'
+import { AlphaTabWebPackPluginOptions } from './AlphaTabWebPackPluginOptions';
+import { getWorkerRuntime, parseModuleUrl, tapJavaScript } from './Utils';
+// @ts-expect-error
+import EnableChunkLoadingPlugin from "webpack/lib/javascript/EnableChunkLoadingPlugin";
+// @ts-expect-error
+import WorkerDependency from "webpack/lib/dependencies/WorkerDependency";
+
+const workerIndexMap = new WeakMap<webpack.ParserState, number>();
+
+/**
+ * Configures the WebWorker aspects within webpack.
+ * The counterpart which this plugin detects sits in alphaTab.main.ts
+ * @param pluginName 
+ * @param options 
+ * @param compiler 
+ * @param compilation 
+ * @param normalModuleFactory 
+ * @param cachedContextify 
+ * @returns 
+ */
+export function configureWebWorker(pluginName: string,
+    options: AlphaTabWebPackPluginOptions,
+    compiler: webpack.Compiler, compilation: webpack.Compilation, normalModuleFactory: any, cachedContextify: (s: string) => string) {
+    if (options.audioWorklets === false) {
+        return;
+    }
+
+    compilation.dependencyFactories.set(
+        WorkerDependency,
+        normalModuleFactory
+    );
+    compilation.dependencyTemplates.set(
+        WorkerDependency,
+        new WorkerDependency.Template()
+    );
+
+    new EnableChunkLoadingPlugin('import-scripts').apply(compiler);
+
+    const handleAlphaTabWorker = (parser: any, expr: CallExpression) => {
+        const [arg1, arg2] = expr.arguments;
+        const parsedUrl = parseModuleUrl(parser, arg1 as Expression);
+        if (!parsedUrl) {
+            return;
+        }
+
+        const [url, range] = parsedUrl;
+        if (!url.isString()) {
+            return;
+        }
+
+        const runtime = getWorkerRuntime(parser, compilation, cachedContextify, workerIndexMap);
+
+        const block = new webpack.AsyncDependenciesBlock({
+            entryOptions: {
+                chunkLoading: 'import-scripts',
+                wasmLoading: false,
+                runtime: runtime
+            }
+        });
+
+        block.loc = expr.loc;
+
+        const workletBootstrap = new WorkerDependency(
+            url.string,
+            range,
+            compiler.options.output.workerPublicPath,
+        );
+        workletBootstrap.loc = expr.loc!;
+        block.addDependency(workletBootstrap);
+        parser.state.module.addBlock(block);
+
+        const dep1 = new webpack.dependencies.ConstDependency(
+            `{ type: ${compilation.options.output.module ? '"module"' : "undefined"} }`,
+            arg2.range!
+        );
+        dep1.loc = expr.loc!;
+        parser.state.module.addPresentationalDependency(dep1);
+
+        parser.walkExpression(expr.callee);
+
+        return true;
+    };
+
+    const parserPlugin = (parser: any) => {
+        parser.hooks.new.for("alphaTab.Environment.alphaTabWorker").tap(pluginName, (expr:CallExpression) => handleAlphaTabWorker(parser, expr));
+    };
+
+    tapJavaScript(normalModuleFactory, pluginName, parserPlugin);
+}

--- a/src/webpack/AlphaTabWorkerDependency.ts
+++ b/src/webpack/AlphaTabWorkerDependency.ts
@@ -7,8 +7,9 @@ import { Hash, ObjectDeserializerContext, ObjectSerializerContext, makeDependenc
 
 
 /**
- * This module dependency injects the relevant code into a worklet bootstrap script
- * to install chunks which have been added to the worklet via addModule before the bootstrap script starts.
+ * This module dependency injects the relevant code into a worker bootstrap script
+ * load chunks via importScript.
+ * 
  */
 export class AlphaTabWorkletDependency extends webpack.dependencies.ModuleDependency {
     publicPath: string | undefined;

--- a/src/webpack/AlphaTabWorkerRuntimeModule.ts
+++ b/src/webpack/AlphaTabWorkerRuntimeModule.ts
@@ -1,11 +1,11 @@
 /**@target web */
 import webpack from 'webpack'
 
-export class AlphaTabWorkletRuntimeModule extends webpack.RuntimeModule {
-    public static Key: string = "AlphaTabWorkletRuntime";
+export class AlphaTabWorkerRuntimeModule extends webpack.RuntimeModule {
+    public static Key: string = "AlphaTabWorkerRuntime";
 
     constructor() {
-        super("alphaTab audio worklet chunk loading", webpack.RuntimeModule.STAGE_BASIC);
+        super("alphaTab audio worker chunk loading", webpack.RuntimeModule.STAGE_BASIC);
     }
 
     override generate(): string | null {

--- a/src/webpack/AlphaTabWorkletStartRuntimeModule.ts
+++ b/src/webpack/AlphaTabWorkletStartRuntimeModule.ts
@@ -1,6 +1,6 @@
 /**@target web */
 import webpack from 'webpack'
-import { AlphaTabWorkletRuntimeModule } from './AlphaTabWorkletRuntimeModule';
+import { AlphaTabWorkerRuntimeModule } from './AlphaTabWorkerRuntimeModule';
 
 export class AlphaTabWorkletStartRuntimeModule extends webpack.RuntimeModule {
     static readonly RuntimeGlobalWorkletGetStartupChunks = "__webpack_require__.wsc";
@@ -18,7 +18,7 @@ export class AlphaTabWorkletStartRuntimeModule extends webpack.RuntimeModule {
         for (const chunk of allChunks) {
             const isWorkletEntry = chunkGraph
                 .getTreeRuntimeRequirements(chunk)
-                .has(AlphaTabWorkletRuntimeModule.Key);
+                .has(AlphaTabWorkerRuntimeModule.Key);
 
             if (isWorkletEntry) {
 

--- a/src/webpack/Utils.ts
+++ b/src/webpack/Utils.ts
@@ -1,0 +1,88 @@
+/**@target web */
+
+import {
+    JAVASCRIPT_MODULE_TYPE_AUTO,
+    JAVASCRIPT_MODULE_TYPE_ESM
+}
+    // @ts-expect-error
+    from "webpack/lib/ModuleTypeConstants";
+
+import webpack from 'webpack'
+
+// @ts-expect-error
+import makeSerializable from 'webpack/lib/util/makeSerializable'
+
+export type NormalModuleFactory = webpack.Compilation['params']['normalModuleFactory'];
+export type Parser = any;
+import type { Expression, NewExpression } from 'estree'
+
+export interface Hash {
+    update(data: string | Buffer, inputEncoding?: string): Hash;
+}
+
+export interface ObjectSerializerContext {
+    write: (arg0?: any) => void;
+}
+
+export interface ObjectDeserializerContext {
+    read: () => any;
+}
+
+export function makeDependencySerializable(dependency: any, key: string) {
+    makeSerializable(dependency, key);
+}
+
+export function tapJavaScript(normalModuleFactory: NormalModuleFactory, pluginName: string, parserPlugin: (parser: any) => void) {
+    normalModuleFactory.hooks.parser
+        .for(JAVASCRIPT_MODULE_TYPE_AUTO)
+        .tap(pluginName, parserPlugin);
+    normalModuleFactory.hooks.parser
+        .for(JAVASCRIPT_MODULE_TYPE_ESM)
+        .tap(pluginName, parserPlugin);
+}
+
+export function parseModuleUrl(parser: any, expr: Expression) {
+    if (expr.type !== "NewExpression" || (expr as NewExpression).arguments.length !== 2) {
+        return;
+    }
+
+    const newExpr = expr as NewExpression;
+    const [arg1, arg2] = newExpr.arguments;
+    const callee = parser.evaluateExpression(newExpr.callee);
+
+    if (!callee.isIdentifier() || callee.identifier !== "URL") {
+        return;
+    }
+
+    const arg1Value = parser.evaluateExpression(arg1);
+    return [
+        arg1Value,
+        [
+            (arg1.range!)[0],
+            (arg2.range!)[1]
+        ]
+    ];
+}
+
+export function getWorkerRuntime(
+    parser: any,
+    compilation: webpack.Compilation,
+    cachedContextify: (s: string) => string,
+    workerIndexMap: WeakMap<webpack.ParserState, number>): string {
+
+    let i = workerIndexMap.get(parser.state) || 0;
+    workerIndexMap.set(parser.state, i + 1);
+    let name = `${cachedContextify(
+        parser.state.module.identifier()
+    )}|${i}`;
+    const hash = webpack.util.createHash(compilation.outputOptions.hashFunction);
+    hash.update(name);
+    const digest = hash.digest(compilation.outputOptions.hashDigest) as string;
+    const runtime = digest.slice(
+        0,
+        compilation.outputOptions.hashDigestLength
+    );
+
+
+    return runtime;
+};

--- a/test/bundler/WebPack.test.ts
+++ b/test/bundler/WebPack.test.ts
@@ -33,6 +33,14 @@ describe('WebPack', () => {
                             },
                         },
                     },
+                    module: {
+                        parser: {
+                            javascript: {
+                                // angular sets this to false, our plugin needs to work like this
+                                worker: false
+                            }
+                        }
+                      },
                 }, (err, stats) => {
                     process.chdir(cwd);
                     if (err) {

--- a/types/webpack/Identifier.d.ts
+++ b/types/webpack/Identifier.d.ts
@@ -1,5 +1,0 @@
-declare module 'webpack/lib/util/identifier' {
-    export const contextify:  {
-        bindContextCache(context: string, associatedObjectForCache: any): (s: string) => string;
-    }
-}

--- a/types/webpack/MakeSerializable.d.ts
+++ b/types/webpack/MakeSerializable.d.ts
@@ -1,4 +1,0 @@
-declare module 'webpack/lib/util/makeSerializable' {
-    export default function (Constructor: any, request: string): void;
-    export default function (Constructor: any, request: string, name: string | null): void;
-}

--- a/types/webpack/ModuleTypeConstants.d.ts
+++ b/types/webpack/ModuleTypeConstants.d.ts
@@ -1,4 +1,0 @@
-declare module 'webpack/lib/ModuleTypeConstants' {
-    export const JAVASCRIPT_MODULE_TYPE_AUTO: string;
-    export const JAVASCRIPT_MODULE_TYPE_ESM: string;
-}

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1,3 +1,0 @@
-import './ModuleTypeConstants'
-import './MakeSerializable'
-import './Identifier'


### PR DESCRIPTION
### Issues
Fixes #1396 

### Proposed changes
Adjusts the WebPack plugin further to be compatible with Angular out of the box.

1. We remove the feature for custom chunking and leave this up to the user or frameworks to handle. 
2. We handle WebWorkers ourselves (reusing some parts of the official worker plugin) to bypass the Angular config. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website
