### PR TITLE
fix: Source Maps should not be shipped in NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,9 @@
         "webpack-cli": "^5.1.4"
     },
     "files": [
-        "/dist/alphaTab*",
+        "/dist/alphaTab*.js",
+        "/dist/alphaTab*.mjs",
+        "/dist/alphaTab*.ts",
         "/dist/font/Bravura.*",
         "/dist/font/Bravura*.txt",
         "/dist/font/*.txt",


### PR DESCRIPTION
### Issues
Fixes #1503 

### Proposed changes
Do not pack source maps to NPM package, they reference the TS files not shipped in the package.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
