### PR TITLE
fix: Use ParentPath on file copy if available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "MPL-2.0",
             "dependencies": {
                 "@types/express": "^4.17.21",
+                "@types/node": "^20.14.10",
                 "@types/opener": "^1.4.3"
             },
             "devDependencies": {
@@ -1369,9 +1370,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.8.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
-            "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+            "version": "20.14.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+            "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
             "dependencies": {
                 "undici-types": "~5.26.4"
             }

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     ],
     "dependencies": {
         "@types/express": "^4.17.21",
+        "@types/node": "^20.14.10",
         "@types/opener": "^1.4.3"
     }
 }

--- a/src/vite/copyAssetsPlugin.ts
+++ b/src/vite/copyAssetsPlugin.ts
@@ -62,7 +62,9 @@ export function copyAssetsPlugin(options: AlphaTabVitePluginOptions): Plugin {
                     files
                         .filter(f => f.isFile())
                         .map(async file => {
-                            const sourceFilename = path.join(file.path, file.name);
+                            // node v20.12.0 has parentPath pointing to the path (not the file)
+                            // see https://github.com/nodejs/node/pull/50976
+                            const sourceFilename = path.join(file.parentPath ?? file.path, file.name);
                             await fs.promises.copyFile(sourceFilename, path.join(outputPath!, subdir, file.name));
                         })
                 );

--- a/src/webpack/AlphaTabWebPackPlugin.ts
+++ b/src/webpack/AlphaTabWebPackPlugin.ts
@@ -144,7 +144,8 @@ export class AlphaTabWebPackPlugin {
             alphaTab: {} as any
         } satisfies webPackWithAlphaTab;
 
-        if ('alphaTab' in compiler.webpack.util.serialization.register) { // prevent multi registration
+        if ('alphaTab' in compiler.webpack.util.serialization.register) {
+            // prevent multi registration
             webPackWithAlphaTab.alphaTab = compiler.webpack.util.serialization.register.alphaTab;
         } else {
             (compiler.webpack.util.serialization.register as any).alphaTab = webPackWithAlphaTab.alphaTab;
@@ -262,7 +263,9 @@ export class AlphaTabWebPackPlugin {
                         files
                             .filter(f => f.isFile())
                             .map(async file => {
-                                const sourceFilename = path.join(file.path, file.name);
+                                // node v20.12.0 has parentPath pointing to the path (not the file)
+                                // see https://github.com/nodejs/node/pull/50976
+                                const sourceFilename = path.join(file.parentPath ?? file.path, file.name);
                                 await fs.promises.copyFile(sourceFilename, path.join(outputPath!, subdir, file.name));
                                 const assetFileName = subdir + '/' + file.name;
                                 const existingAsset = compilation.getAsset(assetFileName);

--- a/test/bundler/Vite.test.ts
+++ b/test/bundler/Vite.test.ts
@@ -49,7 +49,7 @@ describe('Vite', () => {
 
         for (const file of dir) {
             if (file.isFile()) {
-                const text = await fs.promises.readFile(path.join(file.path, file.name), 'utf8');
+                const text = await fs.promises.readFile(path.join(file.parentPath ?? file.path, file.name), 'utf8');
 
                 if (file.name.startsWith('index-')) {
                     // ensure new worker has worker import

--- a/test/bundler/WebPack.test.ts
+++ b/test/bundler/WebPack.test.ts
@@ -83,7 +83,7 @@ describe('WebPack', () => {
 
         for (const file of dir) {
             if (file.isFile()) {
-                const text = await fs.promises.readFile(path.join(file.path, file.name), 'utf8');
+                const text = await fs.promises.readFile(path.join(file.parentPath ?? file.path, file.name), 'utf8');
 
                 if (file.name.startsWith('app-')) {
                     // ensure new worker has worker import


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Fixes #1577 

### Proposed changes
Seems there are some inconsistencies across node versions when it comes to the paths when traversing directories. With this PR we use the parentPath if available. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
