### PR TITLE
fix: Ensure we stay within buffer boundaries and stop worklet

### DIFF
--- a/src/platform/javascript/AlphaSynthScriptProcessorOutput.ts
+++ b/src/platform/javascript/AlphaSynthScriptProcessorOutput.ts
@@ -91,10 +91,18 @@ export class AlphaSynthScriptProcessorOutput extends AlphaSynthWebAudioOutputBas
             Math.min(buffer.length, this._circularBuffer.count)
         );
         let s: number = 0;
-        for (let i: number = 0; i < left.length; i++) {
+        const min = Math.min(left.length, samplesFromBuffer);
+        for (let i: number = 0; i < min; i++) {
             left[i] = buffer[s++];
             right[i] = buffer[s++];
         }
+        if(samplesFromBuffer < left.length) {
+            for(let i = samplesFromBuffer; i < left.length; i++) {
+                left[i] = 0;
+                right[i] = 0;
+            }
+        }
+
         this.onSamplesPlayed(samplesFromBuffer / SynthConstants.AudioChannels);
         this.requestBuffers();
     }

--- a/src/platform/javascript/AlphaSynthWorkerSynthOutput.ts
+++ b/src/platform/javascript/AlphaSynthWorkerSynthOutput.ts
@@ -13,6 +13,7 @@ export class AlphaSynthWorkerSynthOutput implements ISynthOutput {
     public static readonly CmdOutputPlay: string = AlphaSynthWorkerSynthOutput.CmdOutputPrefix + 'play';
     public static readonly CmdOutputPause: string = AlphaSynthWorkerSynthOutput.CmdOutputPrefix + 'pause';
     public static readonly CmdOutputResetSamples: string = AlphaSynthWorkerSynthOutput.CmdOutputPrefix + 'resetSamples';
+    public static readonly CmdOutputStop: string = AlphaSynthWorkerSynthOutput.CmdOutputPrefix + 'stop';
     public static readonly CmdOutputSampleRequest: string =
         AlphaSynthWorkerSynthOutput.CmdOutputPrefix + 'sampleRequest';
     public static readonly CmdOutputSamplesPlayed: string =


### PR DESCRIPTION
### Issues
Relates to #1599

### Proposed changes
Improves the handling of audio worklet buffers to not exceed the buffer boundaries and stop the audio worklet after finish. 

Not clear if it fully fixes the problems but if should improve some bits

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
