### PR TITLE
fix: Ensure smooth synth ending

### DIFF
--- a/src/synth/MidiFileSequencer.ts
+++ b/src/synth/MidiFileSequencer.ts
@@ -267,7 +267,7 @@ export class MidiFileSequencer {
         while (
             this._currentState.eventIndex < this._currentState.synthData.length &&
             this._currentState.synthData[this._currentState.eventIndex].time < this._currentState.currentTime &&
-            this._currentState.currentTime < endTime
+            this._currentState.currentTime < endTime 
         ) {
             this._synthesizer.dispatchEvent(this._currentState.synthData[this._currentState.eventIndex]);
             this._currentState.eventIndex++;

--- a/src/synth/synthesis/TinySoundFont.ts
+++ b/src/synth/synthesis/TinySoundFont.ts
@@ -514,10 +514,10 @@ export class TinySoundFont {
      */
     public noteOffAll(immediate: boolean): void {
         for (const voice of this._voices) {
-            if (voice.playingPreset !== -1 && voice.ampEnv.segment < VoiceEnvelopeSegment.Release) {
+            if (voice.playingPreset !== -1) {
                 if (immediate) {
                     voice.endQuick(this.outSampleRate);
-                } else {
+                } else if(voice.ampEnv.segment < VoiceEnvelopeSegment.Release) {
                     voice.end(this.outSampleRate);
                 }
             }


### PR DESCRIPTION
### Issues
Fixes #1599 

### Proposed changes
We currently have a hard stop when we reach the end of the song. This leads to a cut-off on the samples and results in weird clicking noises. This PR changes the stop sequence of the synthesizer to:

1. Request a fast stop of all voices being played (not instantly)
2. Waiting for all voices to really stop providing samples before finishing

This way we have a smooth ramp-down of the audio (still fast though). 


### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
