### PR TITLE
feat: add live transposition pitch changes

### DIFF
--- a/src.csharp/AlphaTab/Platform/CSharp/AlphaSynthWorkerApiBase.cs
+++ b/src.csharp/AlphaTab/Platform/CSharp/AlphaSynthWorkerApiBase.cs
@@ -184,6 +184,11 @@ namespace AlphaTab.Platform.CSharp
             DispatchOnWorkerThread(() => { Player.SetChannelVolume(channel, volume); });
         }
 
+        public void SetChannelTranspositionPitch(double channel, double semitones)
+        {
+            DispatchOnWorkerThread(() => { Player.SetChannelTranspositionPitch(channel, semitones); });
+        }
+
         public IEventEmitter Ready { get; } = new EventEmitter();
         public IEventEmitter ReadyForPlayback { get; } = new EventEmitter();
         public IEventEmitter Finished { get; } = new EventEmitter();

--- a/src.kotlin/alphaTab/android/src/main/java/alphaTab/platform/android/AndroidThreadAlphaSynthWorkerPlayer.kt
+++ b/src.kotlin/alphaTab/android/src/main/java/alphaTab/platform/android/AndroidThreadAlphaSynthWorkerPlayer.kt
@@ -247,6 +247,10 @@ internal class AndroidThreadAlphaSynthWorkerPlayer : IAlphaSynth, Runnable {
         _workerQueue.add { _player?.setChannelVolume(channel, volume) }
     }
 
+    override fun setChannelTranspositionPitch(channel: Double, semitones: Double) {
+        _workerQueue.add { _player?.setChannelTranspositionPitch(channel, semitones) }
+    }
+
     override val ready: IEventEmitter = EventEmitter()
     override val readyForPlayback: IEventEmitter = EventEmitter()
     override val finished: IEventEmitter = EventEmitter()

--- a/src/AlphaTabApiBase.ts
+++ b/src/AlphaTabApiBase.ts
@@ -673,6 +673,22 @@ export class AlphaTabApiBase<TSettings> {
     }
 
     /**
+     * Changes the pitch transpose applied to the given tracks. These pitches are additional to the ones
+     * applied to the song via the settings and allows a more live-update.
+     * @param tracks The list of tracks to change.
+     * @param semitones The number of semitones to apply as pitch offset.
+     */
+    public changeTrackTranspositionPitch(tracks: Track[], semitones: number): void {
+        if (!this.player) {
+            return;
+        }
+        for (let track of tracks) {
+            this.player.setChannelTranspositionPitch(track.playbackInfo.primaryChannel, semitones);
+            this.player.setChannelTranspositionPitch(track.playbackInfo.secondaryChannel, semitones);
+        }
+    }
+
+    /**
      * Starts the playback of the current song.
      * @returns true if the playback was started, otherwise false. Reasons for not starting can be that the player is not ready or already playing.
      */

--- a/src/platform/javascript/AlphaSynthWebWorker.ts
+++ b/src/platform/javascript/AlphaSynthWebWorker.ts
@@ -115,6 +115,9 @@ export class AlphaSynthWebWorker {
             case 'alphaSynth.setChannelMute':
                 this._player.setChannelMute(data.channel, data.mute);
                 break;
+            case 'alphaSynth.setChannelTranspositionPitch':
+                this._player.setChannelTranspositionPitch(data.channel, data.semitones);
+                break;
             case 'alphaSynth.setChannelSolo':
                 this._player.setChannelSolo(data.channel, data.solo);
                 break;

--- a/src/platform/javascript/AlphaSynthWebWorkerApi.ts
+++ b/src/platform/javascript/AlphaSynthWebWorkerApi.ts
@@ -318,6 +318,14 @@ export class AlphaSynthWebWorkerApi implements IAlphaSynth {
         });
     }
 
+    public setChannelTranspositionPitch(channel: number, semitones: number): void {
+        this._synth.postMessage({
+            cmd: 'alphaSynth.setChannelTranspositionPitch',
+            channel: channel,
+            semitones: semitones
+        });
+    }
+
     public setChannelMute(channel: number, mute: boolean): void {
         this._synth.postMessage({
             cmd: 'alphaSynth.setChannelMute',

--- a/src/synth/AlphaSynth.ts
+++ b/src/synth/AlphaSynth.ts
@@ -390,6 +390,10 @@ export class AlphaSynth implements IAlphaSynth {
         this._synthesizer.applyTranspositionPitches(transpositionPitches);
     }
 
+    public setChannelTranspositionPitch(channel: number, semitones: number): void {
+        this._synthesizer.setChannelTranspositionPitch(channel, semitones);
+    }
+
     public setChannelMute(channel: number, mute: boolean): void {
         this._synthesizer.channelSetMute(channel, mute);
     }

--- a/src/synth/IAlphaSynth.ts
+++ b/src/synth/IAlphaSynth.ts
@@ -136,6 +136,14 @@ export interface IAlphaSynth {
     applyTranspositionPitches(transpositionPitches: Map<number, number>): void;
 
     /**
+     * Sets the transposition pitch a channel. This pitch is additionally applied beside the 
+     * ones applied already via {@link applyTranspositionPitches}.
+     * @param channel The channel number
+     * @param semitones The number of semitones to apply as pitch offset.
+     */
+    setChannelTranspositionPitch(channel: number, semitones: number): void;
+
+    /**
      * Sets the mute state of a channel.
      * @param channel The channel number
      * @param mute true if the channel should be muted, otherwise false.


### PR DESCRIPTION
### Issues
Fixes #1488

### Proposed changes
adds additional APIs for changing the transposition pitches of tracks (and channels) live. These pitches are respected independently from the transpositions already applied on tracks (e.g. via settings). 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website
