### PR TITLE
fix: Scrolling Issue with ScrollMode.OffScreen

### DIFF
--- a/src/platform/javascript/HtmlElementContainer.ts
+++ b/src/platform/javascript/HtmlElementContainer.ts
@@ -40,7 +40,7 @@ export class HtmlElementContainer implements IContainer {
     }
 
     public get scrollTop(): number {
-        return this.element.scrollLeft;
+        return this.element.scrollTop;
     }
 
     public set scrollTop(value: number) {


### PR DESCRIPTION
### Issues
Fixes #1766 

### Proposed changes
Corrected to use correct scroll offset causing vertical scrolling to break.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] Existing builds tests pass
- [ ] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
