### PR TITLE
feat(alphatex): Remember clefs

### DIFF
--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -1718,6 +1718,10 @@ export class AlphaTexImporter extends ScoreImporter {
         // need new bar
         const newBar: Bar = new Bar();
         staff.addBar(newBar);
+        if(newBar.previousBar) {
+            newBar.clef = newBar.previousBar.clef;
+            newBar.clefOttava = newBar.previousBar.clefOttava;
+        }
         this._barIndex++;
 
         for (let i = 0; i < voiceCount; i++) {

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -1810,4 +1810,14 @@ describe('AlphaTexImporterTest', () => {
         expect(score.stylesheet.perTrackDisplayTuning!.has(1)).to.be.true;
         expect(score.stylesheet.perTrackDisplayTuning!.get(1)).to.be.false;
     });
+
+    it('clefs', () => {
+        let score = parseTex(`
+        \\clef C4 \\ottava 15ma C4 | C4
+        `);
+        expect(score.tracks[0].staves[0].bars[0].clef).to.equal(Clef.C4);
+        expect(score.tracks[0].staves[0].bars[0].clefOttava).to.equal(Ottavia._15ma);
+        expect(score.tracks[0].staves[0].bars[1].clef).to.equal(Clef.C4);
+        expect(score.tracks[0].staves[0].bars[1].clefOttava).to.equal(Ottavia._15ma);
+    });
 });


### PR DESCRIPTION
### Proposed changes
alphaTex did reset the clef on every new bar to the default which makes it cumbersome to write notation correctly. with this change alphaTex keeps the clef from the previous bar. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
