### PR TITLE
fix: Wrong transpositions

### DIFF
--- a/src.kotlin/alphaTab/android/src/test/java/alphaTab/core/TestGlobals.kt
+++ b/src.kotlin/alphaTab/android/src/test/java/alphaTab/core/TestGlobals.kt
@@ -43,7 +43,7 @@ class Expector<T>(private val actual: T) {
     val to
         get() = this
     val not
-        get() = NotExpector<T>(actual)
+        get() = NotExpector(actual)
 
     val be
         get() = this
@@ -51,17 +51,27 @@ class Expector<T>(private val actual: T) {
         get() = this
 
     fun equal(expected: Any?, message: String? = null) {
+        var actualToCheck = actual
         var expectedTyped: Any? = expected
 
-        if (expected is Int && actual is Double) {
+        if (expected is Int && actualToCheck is Double) {
             expectedTyped = expected.toDouble();
         }
 
-        if (expected is Double && actual is Int) {
+        if (expected is Double && actualToCheck is Int) {
             expectedTyped = expected.toInt();
         }
 
-        Assert.assertEquals(message, expectedTyped, actual as Any?)
+        if(expected is Double && expected == 0.0 &&
+            actualToCheck is Double) {
+            val d = actualToCheck as Double;
+            if (d == -0.0) {
+                @Suppress("UNCHECKED_CAST")
+                actualToCheck = 0.0 as T
+            }
+        }
+
+        Assert.assertEquals(message, expectedTyped, actualToCheck as Any?)
     }
 
     fun greaterThan(expected: Double) {

--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -1216,7 +1216,7 @@ export class AlphaTexImporter extends ScoreImporter {
                 this._allowNegatives = true;
                 this._sy = this.newSy();
                 if (this._sy === AlphaTexSymbols.Number) {
-                    this._currentStaff.displayTranspositionPitch = this._syData as number;
+                    this._currentStaff.displayTranspositionPitch = (this._syData as number) * -1;
                     this._staffHasExplicitDisplayTransposition = true;
                 } else {
                     this.error('displaytranspose', AlphaTexSymbols.Number, true);
@@ -1228,7 +1228,7 @@ export class AlphaTexImporter extends ScoreImporter {
                 this._allowNegatives = true;
                 this._sy = this.newSy();
                 if (this._sy === AlphaTexSymbols.Number) {
-                    this._currentStaff.transpositionPitch = this._syData as number;
+                    this._currentStaff.transpositionPitch = (this._syData as number) * -1;
                 } else {
                     this.error('transpose', AlphaTexSymbols.Number, true);
                 }

--- a/src/midi/MidiFileGenerator.ts
+++ b/src/midi/MidiFileGenerator.ts
@@ -179,7 +179,7 @@ export class MidiFileGenerator {
             const transpositionPitch =
                 track.index < settings.notation.transpositionPitches.length
                     ? settings.notation.transpositionPitches[track.index]
-                    : 0;
+                    : -track.staves[0].transpositionPitch;
             transpositionPitches.set(track.playbackInfo.primaryChannel, transpositionPitch);
             transpositionPitches.set(track.playbackInfo.secondaryChannel, transpositionPitch);
         }
@@ -190,7 +190,7 @@ export class MidiFileGenerator {
         const transpositionPitch =
             track.index < this._settings.notation.transpositionPitches.length
                 ? this._settings.notation.transpositionPitches[track.index]
-                : 0;
+                : -track.staves[0].transpositionPitch;
         this.transpositionPitches.set(channel, transpositionPitch);
 
         let volume: number = MidiFileGenerator.toChannelShort(playbackInfo.volume);

--- a/test/audio/MidiFileGenerator.test.ts
+++ b/test/audio/MidiFileGenerator.test.ts
@@ -1763,4 +1763,47 @@ describe('MidiFileGeneratorTest', () => {
 
         expect(actualTimers.join(',')).to.equal(expectedTimers.join(','));
     });
+
+    it('transpose', ()=>{
+        const score = parseTex(`
+            \\track \\staff \\instrument piano 
+                    C4.4| r.1
+            \\track \\staff \\instrument piano 
+                \\displayTranspose 12
+                    r.1 | C4.4 | r.1
+            \\track \\staff \\instrument piano
+                \\transpose 12
+                    r.1 | r.1 | C4.4
+        `);
+        expect(score.tracks[0].staves[0].displayTranspositionPitch).to.equal(0);
+        expect(score.tracks[0].staves[0].transpositionPitch).to.equal(0);
+
+        expect(score.tracks[1].staves[0].displayTranspositionPitch).to.equal(-12);
+        expect(score.tracks[1].staves[0].transpositionPitch).to.equal(0);
+
+        expect(score.tracks[2].staves[0].displayTranspositionPitch).to.equal(0);
+        expect(score.tracks[2].staves[0].transpositionPitch).to.equal(-12);
+
+        const handler: FlatMidiEventGenerator = new FlatMidiEventGenerator();
+        const generator: MidiFileGenerator = new MidiFileGenerator(score, null, handler);
+        generator.generate();
+
+        expect(generator.transpositionPitches.has(0)).to.be.true;
+        expect(generator.transpositionPitches.get(0)!).to.equal(0);
+
+        expect(generator.transpositionPitches.has(1)).to.be.true;
+        expect(generator.transpositionPitches.get(1)!).to.equal(0);
+
+        expect(generator.transpositionPitches.has(2)).to.be.true;
+        expect(generator.transpositionPitches.get(2)!).to.equal(0);
+
+        expect(generator.transpositionPitches.has(3)).to.be.true;
+        expect(generator.transpositionPitches.get(3)!).to.equal(0);
+
+        expect(generator.transpositionPitches.has(4)).to.be.true;
+        expect(generator.transpositionPitches.get(4)!).to.equal(12);
+
+        expect(generator.transpositionPitches.has(5)).to.be.true;
+        expect(generator.transpositionPitches.get(5)!).to.equal(12);
+    })
 });

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -1503,8 +1503,8 @@ describe('AlphaTexImporterTest', () => {
     it('transpose', () => {
         let score = parseTex(`
             \\staff 
-            \\displaytranspose -12
-            \\transpose -6
+            \\displaytranspose 12
+            \\transpose 6
             .
         `);
         expect(score.tracks[0].staves[0].displayTranspositionPitch).to.equal(-12);


### PR DESCRIPTION
### Proposed changes
Fixes a problem detected during release testing and documenting. The live-transposition pitches change broke something on pre-applied transpositions. This PR fixes these problems. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
