### PR TITLE
fix: Create blob worker for ESM to allow easier CDN usage.

### DIFF
--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -743,6 +743,13 @@ export class Environment {
     /**
      * @target web
      */
+    public static get alphaTabUrl(): any {
+        return this.globalThis.URL;
+    }
+
+    /**
+     * @target web
+     */
     public static initializeWorker() {
         if (!Environment.isRunningInWorker) {
             throw new AlphaTabError(

--- a/src/alphaTab.main.ts
+++ b/src/alphaTab.main.ts
@@ -16,10 +16,65 @@ if (alphaTab.Environment.isRunningInWorker) {
                 );
             }
 
-	        if (alphaTab.Environment.webPlatform == alphaTab.WebPlatform.BrowserModule || alphaTab.Environment.isWebPackBundled || alphaTab.Environment.isViteBundled) {
-	            alphaTab.Logger.debug("AlphaTab", "Creating webworker");
-	            return new alphaTab.Environment.alphaTabWorker(new URL('./alphaTab.worker', import.meta.url), { type: 'module' });
-	        }
+            if (
+                alphaTab.Environment.webPlatform == alphaTab.WebPlatform.BrowserModule ||
+                alphaTab.Environment.isWebPackBundled ||
+                alphaTab.Environment.isViteBundled
+            ) {
+                alphaTab.Logger.debug('AlphaTab', 'Creating webworker');
+                try {
+                    return new alphaTab.Environment.alphaTabWorker(new URL('./alphaTab.worker', import.meta.url), {
+                        type: 'module'
+                    });
+                } catch (e) {
+                    alphaTab.Logger.debug('AlphaTab', `ESM webworker construction with direct URL failed`, e);
+                    // continue with fallbacks
+                }
+
+                // fallback to blob worker with ESM URL
+                let workerUrl: URL | string = '';
+                try {
+                    // Note: prevent bundlers to copy worker as asset via alphaTabUrl
+                    workerUrl = new alphaTab.Environment.alphaTabUrl('./alphaTab.worker', import.meta.url);
+                    const script: string = `import ${JSON.stringify(workerUrl)}`;
+                    const blob: Blob = new Blob([script], {
+                        type: 'application/javascript'
+                    });
+                    return new Worker(URL.createObjectURL(blob), {
+                        type: 'module'
+                    });
+                } catch (e) {
+                    alphaTab.Logger.debug(
+                        'AlphaTab',
+                        `ESM webworker construction with blob import failed`,
+                        workerUrl,
+                        e
+                    );
+                }
+
+                // fallback to worker with configurable fallback URL
+                try {
+                    // Note: prevent bundlers to copy worker as asset
+                    if (!settings.core.scriptFile) {
+                        throw new Error('Could not detect alphaTab script file');
+                    }
+                    workerUrl = settings.core.scriptFile;
+                    const script: string = `import ${JSON.stringify(settings.core.scriptFile)}`;
+                    const blob: Blob = new Blob([script], {
+                        type: 'application/javascript'
+                    });
+                    return new Worker(URL.createObjectURL(blob), {
+                        type: 'module'
+                    });
+                } catch (e) {
+                    alphaTab.Logger.debug(
+                        'AlphaTab',
+                        `ESM webworker construction with blob import failed`,
+                        settings.core.scriptFile,
+                        e
+                    );
+                }
+            }
 
             // classical browser entry point
             if (!settings.core.scriptFile) {
@@ -32,7 +87,9 @@ if (alphaTab.Environment.isRunningInWorker) {
             try {
                 alphaTab.Logger.debug('AlphaTab', 'Creating Blob worker');
                 const script: string = `importScripts('${settings.core.scriptFile}')`;
-                const blob: Blob = new Blob([script]);
+                const blob: Blob = new Blob([script], {
+                    type: 'application/javascript'
+                });
                 return new Worker(URL.createObjectURL(blob));
             } catch (e) {
                 alphaTab.Logger.warning('Rendering', 'Could not create inline worker, fallback to normal worker');
@@ -48,11 +105,15 @@ if (alphaTab.Environment.isRunningInWorker) {
                 );
             }
 
-	        if (alphaTab.Environment.webPlatform == alphaTab.WebPlatform.BrowserModule || alphaTab.Environment.isWebPackBundled || alphaTab.Environment.isViteBundled) {
-	            alphaTab.Logger.debug("AlphaTab", "Creating Module worklet");
-	            const alphaTabWorklet = context.audioWorklet; // this name triggers the WebPack Plugin
-	            return alphaTabWorklet.addModule(new URL('./alphaTab.worklet', import.meta.url));
-	        }
+            if (
+                alphaTab.Environment.webPlatform == alphaTab.WebPlatform.BrowserModule ||
+                alphaTab.Environment.isWebPackBundled ||
+                alphaTab.Environment.isViteBundled
+            ) {
+                alphaTab.Logger.debug('AlphaTab', 'Creating Module worklet');
+                const alphaTabWorklet = context.audioWorklet; // this name triggers the WebPack Plugin
+                return alphaTabWorklet.addModule(new URL('./alphaTab.worklet', import.meta.url));
+            }
 
             alphaTab.Logger.debug('AlphaTab', 'Creating Script worklet');
             return context.audioWorklet.addModule(settings.core.scriptFile!);


### PR DESCRIPTION
### Issues
Fixes #1917

### Proposed changes
Attempt creating blob workers on ESM as fallback to prevent CORS problems when importing alphaTab from CDNs. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
