### PR TITLE
fix(svg): Wrong style quoting with spaced fonts

### DIFF
--- a/src/platform/svg/SvgCanvas.ts
+++ b/src/platform/svg/SvgCanvas.ts
@@ -153,7 +153,7 @@ export abstract class SvgCanvas implements ICanvas {
         }
         let s: string = `<text x="${(x * this.scale) | 0}" y="${
             (y * this.scale) | 0
-        }" style="stroke: none; font:${this.font.toCssString(this.settings.display.scale)}; ${this.getSvgBaseLine()}"`;
+        }" style='stroke: none; font:${this.font.toCssString(this.settings.display.scale)}; ${this.getSvgBaseLine()}'`;
         if (this.color.rgba !== '#000000') {
             s += ` fill="${this.color.rgba}"`;
         }

--- a/test/visualTests/issues/BrokenRenders.test.ts
+++ b/test/visualTests/issues/BrokenRenders.test.ts
@@ -1,7 +1,55 @@
-import { VisualTestHelper } from "../VisualTestHelper";
+import { TestPlatform } from '@test/TestPlatform';
+import { VisualTestHelper } from '../VisualTestHelper';
+import { ScoreLoader } from '@src/importer';
+import { Settings } from '@src/Settings';
+import { RenderFinishedEventArgs, ScoreRenderer } from '@src/rendering';
+import { XmlDocument } from '@src/xml/XmlDocument';
+import { expect } from 'chai';
 
 describe('BrokenRendersTests', () => {
-    it('let-ring-empty-voice', async () =>{
+    it('let-ring-empty-voice', async () => {
         await VisualTestHelper.runVisualTest('issues/let-ring-empty-voice.gp');
-    })
-})
+    });
+
+    it('valid-svg', async () => {
+        const settings = new Settings();
+        settings.core.engine = 'svg';
+        settings.core.enableLazyLoading = false;
+
+        const inputFileData = await TestPlatform.loadFile(`test-data/visual-tests/layout/page-layout.gp`);
+        const score = ScoreLoader.loadScoreFromBytes(inputFileData, settings);
+
+        const api = new ScoreRenderer(settings);
+        const results: RenderFinishedEventArgs[] = [];
+        let error: Error | null = null;
+        api.preRender.on(_ => {});
+        api.partialRenderFinished.on(e => {
+            results.push(e);
+        });
+        api.renderFinished.on(e => {
+            results.push(e);
+        });
+        api.error.on(e => {
+            error = e;
+        });
+
+        api.width = 1300;
+        api.renderScore(score, [0]);
+
+        // https://github.com/microsoft/TypeScript/issues/61313
+        error = error as Error | null;
+        if (error != null) {
+            throw error;
+        }
+
+        for (const r of results) {
+            if (r.renderResult !== null) {
+                const xml = new XmlDocument();
+                xml.parse(r.renderResult as string);
+
+                expect(xml.firstElement).to.be.ok;
+                expect(xml.firstElement!.localName).to.equal('svg');
+            }
+        }
+    });
+});


### PR DESCRIPTION
### Proposed changes
Detected while testing and documenting: If you use font families with quotes, it breaks the SVG attribute quotes. This PR changes the attribute to single quotes. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
