### PR TITLE
Caching Kotlin things with gradle/actions/setup-gradle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,14 +62,7 @@ jobs:
         with:
           java-version: '19'
           distribution: 'temurin'
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-cache-v5-${{ github.job }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-cache-v5-${{ github.job }}-
+      - uses: gradle/actions/setup-gradle@v4
       - run: npm install
       - run: npm run build-kotlin
       - run: npm run test-kotlin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,8 @@ jobs:
           java-version: '19'
           distribution: 'temurin'
       - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
       - run: npm install
       - run: npm run build-kotlin
       - run: npm run test-kotlin


### PR DESCRIPTION
### Proposed changes
<!-- Describe the proposed changes -->

This is faster than `actions/cache` for Gradle builds.

https://github.com/gradle/actions?tab=readme-ov-file#the-setup-gradle-action

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
