### PR TITLE
feat(player): Allow pause on intermediate beat position

### DIFF
--- a/src/PlayerSettings.ts
+++ b/src/PlayerSettings.ts
@@ -219,4 +219,15 @@ export class PlayerSettings {
      * Smaller buffers can cause audio crackling due to constant buffering that is happening.
      */
     public bufferTimeInMilliseconds:number = 500;
+
+    /**
+     * Whether alphaTab should seek back to the start of the currently played beat when the playback is paused. 
+     * This will properly play the whole beat again when playback is restarted.
+     * When set to false the player will remain on the exact playback position which can result in slightly strange audio 
+     * due buffering and the way samples are creating physical sound on speakers.
+     * When {@link enableAnimatedBeatCursor} is enabled, it is attempted to place the cursor at the relative position matching
+     * the exact playback position.
+     * @json_read_only
+     */
+    public seekToBeatStartOnPause: boolean = true;
 }

--- a/src/generated/PlayerSettingsJson.ts
+++ b/src/generated/PlayerSettingsJson.ts
@@ -101,4 +101,14 @@ export interface PlayerSettingsJson {
      * Smaller buffers can cause audio crackling due to constant buffering that is happening.
      */
     bufferTimeInMilliseconds?: number;
+    /**
+     * Whether alphaTab should seek back to the start of the currently played beat when the playback is paused.
+     * This will properly play the whole beat again when playback is restarted.
+     * When set to false the player will remain on the exact playback position which can result in slightly strange audio
+     * due buffering and the way samples are creating physical sound on speakers.
+     * When {@link enableAnimatedBeatCursor} is enabled, it is attempted to place the cursor at the relative position matching
+     * the exact playback position.
+     * @json_read_only
+     */
+    seekToBeatStartOnPause?: boolean;
 }

--- a/src/generated/PlayerSettingsSerializer.ts
+++ b/src/generated/PlayerSettingsSerializer.ts
@@ -99,6 +99,9 @@ export class PlayerSettingsSerializer {
             case "buffertimeinmilliseconds":
                 obj.bufferTimeInMilliseconds = v! as number;
                 return true;
+            case "seektobeatstartonpause":
+                obj.seekToBeatStartOnPause = v! as boolean;
+                return true;
         }
         if (["vibrato"].indexOf(property) >= 0) {
             VibratoPlaybackSettingsSerializer.fromJson(obj.vibrato, v as Map<string, unknown>);

--- a/src/platform/javascript/AlphaSynthScriptProcessorOutput.ts
+++ b/src/platform/javascript/AlphaSynthScriptProcessorOutput.ts
@@ -22,10 +22,7 @@ export class AlphaSynthScriptProcessorOutput extends AlphaSynthWebAudioOutputBas
         );
         this._circularBuffer = new CircularSampleBuffer(AlphaSynthWebAudioOutputBase.BufferSize * this._bufferCount);
         this.onReady();
-    }
 
-    public override play(): void {
-        super.play();
         let ctx = this._context!;
         // create a script processor node which will replace the silence with the generated audio
         this._audioNode = ctx.createScriptProcessor(4096, 0, 2);
@@ -35,17 +32,12 @@ export class AlphaSynthScriptProcessorOutput extends AlphaSynthWebAudioOutputBas
         this._source = ctx.createBufferSource();
         this._source.buffer = this._buffer;
         this._source.loop = true;
-        this._source.connect(this._audioNode, 0, 0);
         this._source.start(0);
         this._audioNode.connect(ctx.destination, 0, 0);
     }
 
-    public override pause(): void {
-        super.pause();
-        if (this._audioNode) {
-            this._audioNode.disconnect(0);
-        }
-        this._audioNode = null;
+    protected override reconnectSourceNode(): void {
+        this._source!.connect(this._audioNode!, 0, 0);
     }
 
     public addSamples(f: Float32Array): void {

--- a/src/platform/javascript/AlphaSynthWebAudioOutputBase.ts
+++ b/src/platform/javascript/AlphaSynthWebAudioOutputBase.ts
@@ -99,6 +99,11 @@ export abstract class AlphaSynthWebAudioOutputBase implements ISynthOutput {
         if (ctx.state === 'suspended') {
             this.registerResumeHandler();
         }
+
+        this._buffer = ctx.createBuffer(2, AlphaSynthWebAudioOutputBase.BufferSize, ctx.sampleRate);
+        this._source = ctx.createBufferSource();
+        this._source!.buffer = this._buffer;
+        this._source!.loop = true;
     }
 
     private registerResumeHandler() {
@@ -120,21 +125,16 @@ export abstract class AlphaSynthWebAudioOutputBase implements ISynthOutput {
     }
 
     public play(): void {
-        let ctx = this._context!;
         this.activate();
-        // create an empty buffer source (silence)
-        this._buffer = ctx.createBuffer(2, AlphaSynthWebAudioOutputBase.BufferSize, ctx.sampleRate);
-        this._source = ctx.createBufferSource();
-        this._source.buffer = this._buffer;
-        this._source.loop = true;
+        this.reconnectSourceNode();
     }
+
+    protected abstract reconnectSourceNode(): void;
 
     public pause(): void {
         if (this._source) {
-            this._source.stop(0);
             this._source.disconnect();
         }
-        this._source = null;
     }
 
     public destroy(): void {


### PR DESCRIPTION
### Issues
Relates to #1935

### Proposed changes
Adds a setting to not seek back to the beat start on pause. Additionally it ensures that the beat cursor is placed on intermediate positions between the beats.

While it is a bit of a niche feature, it is also a preparation for allowing external cursor control  (having the synth disabled) which might be the next logical step.


### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website
