### PR TITLE
refactor: Add childElements iterator for XML parsing

### DIFF
--- a/src.compiler/AstPrinterBase.ts
+++ b/src.compiler/AstPrinterBase.ts
@@ -181,6 +181,7 @@ export default abstract class AstPrinterBase {
     protected abstract writeNewExpression(expr: cs.NewExpression);
     protected abstract writeCastExpression(expr: cs.CastExpression);
     protected abstract writeNonNullExpression(expr: cs.NonNullExpression);
+    protected abstract writeYieldExpression(expr: cs.YieldExpression);
 
     protected writeToDoExpression(expr: cs.ToDoExpression) {
         this.write('/* TODO */');
@@ -383,6 +384,9 @@ export default abstract class AstPrinterBase {
                 break;
             case cs.SyntaxKind.TypeOfExpression:
                 this.writeTypeOfExpression(expr as cs.TypeOfExpression);
+                break;
+            case cs.SyntaxKind.YieldExpression:
+                this.writeYieldExpression(expr as cs.YieldExpression);
                 break;
             case cs.SyntaxKind.TypeReference:
                 this.writeType(expr as cs.TypeReference);

--- a/src.compiler/csharp/CSharpAst.ts
+++ b/src.compiler/csharp/CSharpAst.ts
@@ -80,7 +80,8 @@ export enum SyntaxKind {
     Attribute,
 
     SpreadExpression,
-    LocalFunction
+    LocalFunction,
+    YieldExpression
 }
 
 export interface Node {
@@ -92,16 +93,19 @@ export interface Node {
 }
 
 export interface SourceFile extends Node {
+    nodeType: SyntaxKind.SourceFile;
     fileName: string;
     usings: UsingDeclaration[];
     namespace: NamespaceDeclaration;
 }
 
 export interface UsingDeclaration extends Node {
+    nodeType: SyntaxKind.UsingDeclaration;
     namespaceOrTypeName: string;
 }
 
 export interface NamespaceDeclaration extends Node {
+    nodeType: SyntaxKind.NamespaceDeclaration;
     namespace: string;
     declarations: NamespaceMember[];
 }
@@ -135,6 +139,7 @@ export interface NamedElement {
 // Declarations
 
 export interface TypeParameterDeclaration extends NamedElement, Node {
+    nodeType: SyntaxKind.TypeParameterDeclaration;
     constraint?: TypeNode;
 }
 
@@ -146,6 +151,7 @@ export interface NamedTypeDeclaration extends NamedElement, DocumentedElement, N
 }
 
 export interface ClassDeclaration extends NamedTypeDeclaration {
+    nodeType: SyntaxKind.ClassDeclaration;
     baseClass?: TypeNode;
     interfaces?: TypeNode[];
     isAbstract: boolean;
@@ -160,14 +166,17 @@ export type ClassMember =
     | NamedTypeDeclaration;
 
 export interface EnumDeclaration extends NamedTypeDeclaration {
+    nodeType: SyntaxKind.EnumDeclaration;
     members: EnumMember[];
 }
 
 export interface EnumMember extends Node, NamedElement, DocumentedElement {
+    nodeType: SyntaxKind.EnumMember;
     initializer?: Expression;
 }
 
 export interface InterfaceDeclaration extends NamedTypeDeclaration {
+    nodeType: SyntaxKind.InterfaceDeclaration;
     interfaces?: TypeNode[];
     members: InterfaceMember[];
 }
@@ -186,10 +195,12 @@ export interface MethodDeclarationBase extends MemberDeclaration {
 }
 
 export interface MethodDeclaration extends MethodDeclarationBase, AttributedElement {
+    nodeType: SyntaxKind.MethodDeclaration;
     isVirtual: boolean;
     isOverride: boolean;
     isAbstract: boolean;
     isTestMethod: boolean;
+    isGeneratorFunction: boolean;
     partial: boolean;
     returnType: TypeNode;
     parameters: ParameterDeclaration[];
@@ -198,16 +209,19 @@ export interface MethodDeclaration extends MethodDeclarationBase, AttributedElem
 }
 
 export interface ConstructorDeclaration extends MethodDeclarationBase {
+    nodeType: SyntaxKind.ConstructorDeclaration;
     baseConstructorArguments?: Expression[];
 }
 
 export interface FieldDeclaration extends MemberDeclaration {
+    nodeType: SyntaxKind.FieldDeclaration;
     isReadonly: boolean;
     type: TypeNode;
     initializer?: Expression;
 }
 
 export interface PropertyDeclaration extends MemberDeclaration {
+    nodeType: SyntaxKind.PropertyDeclaration;
     isVirtual: boolean;
     isOverride: boolean;
     isAbstract: boolean;
@@ -219,11 +233,13 @@ export interface PropertyDeclaration extends MemberDeclaration {
 }
 
 export interface PropertyAccessorDeclaration extends Node {
+    nodeType: SyntaxKind.PropertyAccessorDeclaration;
     keyword: string;
     body?: Block | Expression;
 }
 
 export interface ParameterDeclaration extends NamedElement, Node, DocumentedElement {
+    nodeType: SyntaxKind.ParameterDeclaration;
     type?: TypeNode;
     initializer?: Expression;
     params: boolean;
@@ -237,6 +253,7 @@ export interface TypeNode extends Node {
 }
 
 export interface UnresolvedTypeNode extends TypeNode {
+    nodeType: SyntaxKind.UnresolvedTypeNode;
     tsType?: ts.Type;
     tsSymbol?: ts.Symbol;
     typeArguments?: UnresolvedTypeNode[];
@@ -244,16 +261,19 @@ export interface UnresolvedTypeNode extends TypeNode {
 
 export type TypeReferenceType = NamedTypeDeclaration | TypeParameterDeclaration | TypeNode | string;
 export interface TypeReference extends TypeNode {
+    nodeType: SyntaxKind.TypeReference;
     reference: TypeReferenceType;
     isAsync: boolean;
     typeArguments?: TypeNode[];
 }
 
 export interface ArrayTypeNode extends TypeNode {
+    nodeType: SyntaxKind.ArrayTypeNode;
     elementType: TypeNode;
 }
 
 export interface MapTypeNode extends TypeNode {
+    nodeType: SyntaxKind.MapTypeNode;
     keyType: TypeNode;
     keyIsValueType: boolean;
     valueType: TypeNode;
@@ -261,6 +281,7 @@ export interface MapTypeNode extends TypeNode {
 }
 
 export interface FunctionTypeNode extends TypeNode {
+    nodeType: SyntaxKind.FunctionTypeNode;
     parameterTypes: TypeNode[];
     returnType: TypeNode;
 }
@@ -278,6 +299,7 @@ export enum PrimitiveType {
 }
 
 export interface PrimitiveTypeNode extends TypeNode {
+    nodeType: SyntaxKind.PrimitiveTypeNode;
     type: PrimitiveType;
 }
 
@@ -286,50 +308,64 @@ export interface PrimitiveTypeNode extends TypeNode {
 export interface Expression extends Node {}
 
 export interface PrefixUnaryExpression extends Node {
+    nodeType: SyntaxKind.PrefixUnaryExpression;
     operand: Expression;
     operator: string;
 }
 
 export interface PostfixUnaryExpression extends Node {
+    nodeType: SyntaxKind.PostfixUnaryExpression;
     operand: Expression;
     operator: string;
 }
 
-export interface NullLiteral extends Node {}
+export interface NullLiteral extends Node {
+    nodeType: SyntaxKind.NullLiteral;
+}
 
-export interface BooleanLiteral extends Node {}
+export interface BooleanLiteral extends Node {
+    nodeType: SyntaxKind.TrueLiteral | SyntaxKind.FalseLiteral;
+}
 
-export interface ThisLiteral extends Node {}
+export interface ThisLiteral extends Node {
+    nodeType: SyntaxKind.ThisLiteral;
+}
 
 export interface BaseLiteralExpression extends Node {}
 
 export interface StringLiteral extends Node {
+    nodeType: SyntaxKind.StringLiteral;
     text: string;
 }
 
 export interface AwaitExpression extends Node {
+    nodeType: SyntaxKind.AwaitExpression;
     expression: Expression;
 }
 
 export interface BinaryExpression extends Node {
+    nodeType: SyntaxKind.BinaryExpression;
     left: Expression;
     operator: string;
     right: Expression;
 }
 
 export interface ConditionalExpression extends Node {
+    nodeType: SyntaxKind.ConditionalExpression;
     condition: Expression;
     whenTrue: Expression;
     whenFalse: Expression;
 }
 
 export interface LambdaExpression extends Node {
+    nodeType: SyntaxKind.LambdaExpression;
     parameters: ParameterDeclaration[];
     body: Block | Expression;
     returnType: TypeNode;
 }
 
 export interface LocalFunctionDeclaration extends Node {
+    nodeType: SyntaxKind.LocalFunction;
     name: string;
     parameters: ParameterDeclaration[];
     body: Block;
@@ -337,95 +373,122 @@ export interface LocalFunctionDeclaration extends Node {
 }
 
 export interface NumericLiteral extends Node {
+    nodeType: SyntaxKind.NumericLiteral;
     value: string;
 }
 export interface StringTemplateExpression extends Node {
+    nodeType: SyntaxKind.StringTemplateExpression;
     chunks: (StringLiteral | Expression)[];
 }
 
 export interface IsExpression extends Node {
+    nodeType: SyntaxKind.IsExpression;
     expression: Expression;
     type: TypeNode;
     newName?: string;
 }
 export interface ParenthesizedExpression extends Node {
+    nodeType: SyntaxKind.ParenthesizedExpression;
     expression: Expression;
 }
 export interface SpreadExpression extends Node {
+    nodeType: SyntaxKind.SpreadExpression;
     expression: Expression;
 }
 export interface DefaultExpression extends Node {
+    nodeType: SyntaxKind.DefaultExpression;
     type?: TypeNode;
 }
 export interface ArrayCreationExpression extends Node {
+    nodeType: SyntaxKind.ArrayCreationExpression;
     type?: TypeNode;
     values?: Expression[];
     sizeExpression?: Expression;
 }
 export interface MemberAccessExpression extends Node {
+    nodeType: SyntaxKind.MemberAccessExpression;
     expression: Expression;
     member: string;
     nullSafe?: boolean;
 }
 
 export interface AnonymousObjectCreationExpression extends Node {
+    nodeType: SyntaxKind.AnonymousObjectCreationExpression;
     properties: AnonymousObjectProperty[];
 }
 
 export interface AnonymousObjectProperty extends Node {
+    nodeType: SyntaxKind.AnonymousObjectProperty;
     name: string;
     value: Expression;
 }
 
 export interface ElementAccessExpression extends Node {
+    nodeType: SyntaxKind.ElementAccessExpression;
     expression: Expression;
     argumentExpression: Expression;
     nullSafe: boolean;
 }
 
 export interface InvocationExpression extends Node {
+    nodeType: SyntaxKind.InvocationExpression;
     expression: Expression;
     arguments: Expression[];
     typeArguments?: TypeNode[];
 }
 
 export interface NewExpression extends Node {
+    nodeType: SyntaxKind.NewExpression;
     type: TypeNode;
     arguments: Expression[];
 }
 
 export interface CastExpression extends Node {
+    nodeType: SyntaxKind.CastExpression;
     type: TypeNode;
     expression: Expression;
 }
 
 export interface NonNullExpression extends Node {
+    nodeType: SyntaxKind.NonNullExpression;
     expression: Expression;
 }
 
 export interface TypeOfExpression extends Node {
+    nodeType: SyntaxKind.TypeOfExpression;
     expression: Expression;
 }
 
 export interface NullSafeExpression extends Node {
+    nodeType: SyntaxKind.NullSafeExpression;
     expression: Expression;
 }
 
 export interface Identifier extends Expression {
+    nodeType: SyntaxKind.Identifier;
     text: string;
 }
 
-export interface ToDoExpression extends Node {}
+export interface ToDoExpression extends Node {
+    nodeType: SyntaxKind.ToDoExpression;
+}
+export interface YieldExpression extends Node {
+    nodeType: SyntaxKind.YieldExpression;
+    expression: Expression | null;
+}
 
 // Statements
 
 export interface Statement extends Node {}
 
 export interface Block extends Statement {
+    nodeType: SyntaxKind.Block;
     statements: Statement[];
 }
 
-export interface EmptyStatement extends Statement {}
+export interface EmptyStatement extends Statement {
+    nodeType: SyntaxKind.EmptyStatement;
+}
 
 export enum VariableStatementKind {
     Normal,
@@ -435,36 +498,43 @@ export enum VariableStatementKind {
 }
 
 export interface VariableStatement extends Statement {
+    nodeType: SyntaxKind.VariableStatement;
     declarationList: VariableDeclarationList;
     variableStatementKind: VariableStatementKind;
 }
 
 export interface ExpressionStatement extends Statement {
+    nodeType: SyntaxKind.ExpressionStatement;
     expression: Expression;
 }
 
 export interface IfStatement extends Statement {
+    nodeType: SyntaxKind.IfStatement;
     expression: Expression;
     thenStatement: Statement;
     elseStatement?: Statement;
 }
 
 export interface DoStatement extends Statement {
+    nodeType: SyntaxKind.DoStatement;
     expression: Expression;
     statement: Statement;
 }
 
 export interface WhileStatement extends Statement {
+    nodeType: SyntaxKind.WhileStatement;
     expression: Expression;
     statement: Statement;
 }
 
 export interface VariableDeclarationList extends Node {
+    nodeType: SyntaxKind.VariableDeclarationList;
     declarations: VariableDeclaration[];
     isConst: boolean;
 }
 
 export interface VariableDeclaration extends Node {
+    nodeType: SyntaxKind.VariableDeclaration;
     type: TypeNode;
     name: string;
     deconstructNames?: string[];
@@ -472,10 +542,12 @@ export interface VariableDeclaration extends Node {
 }
 
 export interface DeconstructDeclaration extends Node {
+    nodeType: SyntaxKind.DeconstructDeclaration;
     names: string[];
 }
 
 export interface ForStatement extends Statement {
+    nodeType: SyntaxKind.ForStatement;
     initializer?: VariableDeclarationList | Expression;
     condition?: Expression;
     incrementor?: Expression;
@@ -483,44 +555,56 @@ export interface ForStatement extends Statement {
 }
 
 export interface ForEachStatement extends Statement {
+    nodeType: SyntaxKind.ForEachStatement;
     initializer: VariableDeclarationList | Expression;
     expression: Expression;
     statement: Statement;
 }
 
-export interface BreakStatement extends Statement {}
+export interface BreakStatement extends Statement {
+    nodeType: SyntaxKind.BreakStatement;
+}
 
-export interface ContinueStatement extends Statement {}
+export interface ContinueStatement extends Statement {
+    nodeType: SyntaxKind.ContinueStatement;
+}
 
 export interface ReturnStatement extends Statement {
+    nodeType: SyntaxKind.ReturnStatement;
     expression?: Expression;
 }
 
 export interface SwitchStatement extends Statement {
+    nodeType: SyntaxKind.SwitchStatement;
     expression: Expression;
     caseClauses: (CaseClause | DefaultClause)[];
 }
 
 export interface CaseClause extends Node {
+    nodeType: SyntaxKind.CaseClause;
     expression: Expression;
     statements: Statement[];
 }
 
 export interface DefaultClause extends Node {
+    nodeType: SyntaxKind.DefaultClause;
     statements: Statement[];
 }
 
 export interface ThrowStatement extends Statement {
+    nodeType: SyntaxKind.ThrowStatement;
     expression?: Expression;
 }
 
 export interface TryStatement extends Statement {
+    nodeType: SyntaxKind.TryStatement;
     tryBlock: Block;
     catchClauses?: CatchClause[];
     finallyBlock?: Block;
 }
 
 export interface CatchClause extends Node {
+    nodeType: SyntaxKind.CatchClause;
     variableDeclaration: VariableDeclaration;
     block: Block;
 }
@@ -753,4 +837,7 @@ export function isSpreadExpression(node: Node): node is SpreadExpression {
 }
 export function isLocalFunction(node: Node): node is LocalFunctionDeclaration {
     return node.nodeType === SyntaxKind.LocalFunction;
+}
+export function isYieldExpression(node: Node): node is YieldExpression {
+    return node.nodeType === SyntaxKind.YieldExpression;
 }

--- a/src.compiler/csharp/CSharpAstPrinter.ts
+++ b/src.compiler/csharp/CSharpAstPrinter.ts
@@ -974,4 +974,14 @@ export default class CSharpAstPrinter extends AstPrinterBase {
         this.writeParameters(expr.parameters);
         this.writeBlock(expr.body);
     }
+
+    protected writeYieldExpression(expr: cs.YieldExpression) {
+        this.write('yield ');
+        if (expr.expression) {
+            this.write('return ');
+            this.writeExpression(expr.expression);
+        } else {
+            this.write('break');
+        }
+    }
 }

--- a/src.compiler/kotlin/KotlinEmitterContext.ts
+++ b/src.compiler/kotlin/KotlinEmitterContext.ts
@@ -105,10 +105,18 @@ export default class KotlinEmitterContext extends CSharpEmitterContext {
         const parent = 'parent' in symbol ? (symbol.parent as ts.Symbol) : undefined;
 
         if (symbol.name === 'dispose' && (!parent || parent.name === 'SymbolConstructor')) {
-            return "close";
+            return 'close';
         }
 
         return '';
     }
+
+    public override makeIterableType(): string {
+        return this.makeTypeName('kotlin.collections.Iterable');
+    }
+
     
+    public override makeGeneratorType(): string {
+        return this.makeTypeName('kotlin.collections.Iterator');
+    }
 }

--- a/src.csharp/AlphaTab/Collections/List.cs
+++ b/src.csharp/AlphaTab/Collections/List.cs
@@ -2,7 +2,7 @@
 
 namespace AlphaTab.Collections;
 
-internal class List<T> : System.Collections.Generic.List<T>, Iterable<T>
+internal class List<T> : System.Collections.Generic.List<T>
 {
     public List(double size)
         : this(new T[(int)size])

--- a/src.csharp/AlphaTab/Core/EcmaScript/Iterable.cs
+++ b/src.csharp/AlphaTab/Core/EcmaScript/Iterable.cs
@@ -1,9 +1,0 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace AlphaTab.Core.EcmaScript;
-
-internal interface Iterable<T> : IEnumerable<T>
-{
-}

--- a/src.kotlin/alphaTab/android/src/main/java/alphaTab/core/ecmaScript/Iterable.kt
+++ b/src.kotlin/alphaTab/android/src/main/java/alphaTab/core/ecmaScript/Iterable.kt
@@ -1,3 +1,0 @@
-package alphaTab.core.ecmaScript
-
-internal typealias Iterable<T> = kotlin.collections.Iterable<T>

--- a/src/importer/CapellaParser.ts
+++ b/src/importer/CapellaParser.ts
@@ -17,7 +17,7 @@ import { Voice } from '@src/model/Voice';
 import { Settings } from '@src/Settings';
 import { XmlDocument } from '@src/xml/XmlDocument';
 
-import { XmlNode, XmlNodeType } from '@src/xml/XmlNode';
+import { XmlNode } from '@src/xml/XmlNode';
 import { BeamDirection } from '@src/rendering/utils/BeamDirection';
 import { TextAlign } from '@src/platform/ICanvas';
 import { ModelUtils } from '@src/model/ModelUtils';
@@ -53,9 +53,9 @@ class GuitarDrawObject extends DrawObject {
     public chord: Chord = new Chord();
 }
 
-class SlurDrawObject extends DrawObject { }
+class SlurDrawObject extends DrawObject {}
 
-class WavyLineDrawObject extends DrawObject { }
+class WavyLineDrawObject extends DrawObject {}
 
 class TupletBracketDrawObject extends DrawObject {
     public number: number = 0;
@@ -75,7 +75,7 @@ class OctaveClefDrawObject extends DrawObject {
     public octave: number = 1;
 }
 
-class TrillDrawObject extends DrawObject { }
+class TrillDrawObject extends DrawObject {}
 
 class StaffLayout {
     public defaultClef: Clef = Clef.G2;
@@ -176,7 +176,7 @@ export class CapellaParser {
         effects: Map<Beat, T>,
         applyEffect: (effect: T, beat: Beat) => void
     ) {
-        for(const [startBeat, effect] of effects) {
+        for (const [startBeat, effect] of effects) {
             const noteRange = effect.noteRange;
             let endBeat = startBeat;
             for (let i = 0; i < noteRange; i++) {
@@ -203,26 +203,24 @@ export class CapellaParser {
             this.score = new Score();
             this.score.tempo = 120;
             // parse all children
-            for (let n of root.childNodes) {
-                if (n.nodeType === XmlNodeType.Element) {
-                    switch (n.localName) {
-                        case 'info':
-                            this.parseInfo(n);
-                            break;
-                        case 'layout':
-                            this.parseLayout(n);
-                            break;
-                        case 'gallery':
-                            this.parseGallery(n);
-                            break;
-                        case 'pageObjects':
-                            this.parsePageObjects(n);
-                            break;
-                        // barCount ignored
-                        case 'systems':
-                            this.parseSystems(n);
-                            break;
-                    }
+            for (let n of root.childElements()) {
+                switch (n.localName) {
+                    case 'info':
+                        this.parseInfo(n);
+                        break;
+                    case 'layout':
+                        this.parseLayout(n);
+                        break;
+                    case 'gallery':
+                        this.parseGallery(n);
+                        break;
+                    case 'pageObjects':
+                        this.parsePageObjects(n);
+                        break;
+                    // barCount ignored
+                    case 'systems':
+                        this.parseSystems(n);
+                        break;
                 }
             }
         } else {
@@ -232,16 +230,14 @@ export class CapellaParser {
 
     private _staffLookup: Map<number, Staff> = new Map();
     private parseLayout(element: XmlNode) {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'staves':
-                        this.parseLayoutStaves(c);
-                        break;
-                    case 'brackets':
-                        this.parseBrackets(c);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'staves':
+                    this.parseLayoutStaves(c);
+                    break;
+                case 'brackets':
+                    this.parseBrackets(c);
+                    break;
             }
         }
 
@@ -298,13 +294,11 @@ export class CapellaParser {
 
     private _brackets: Bracket[] = [];
     private parseBrackets(element: XmlNode) {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'bracket':
-                        this.parseBracket(c);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'bracket':
+                    this.parseBracket(c);
+                    break;
             }
         }
     }
@@ -320,13 +314,11 @@ export class CapellaParser {
     }
 
     private parseLayoutStaves(element: XmlNode) {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'staffLayout':
-                        this.parseStaffLayout(c);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'staffLayout':
+                    this.parseStaffLayout(c);
+                    break;
             }
         }
     }
@@ -338,30 +330,28 @@ export class CapellaParser {
         const layout = new StaffLayout();
         layout.description = element.getAttribute('description');
 
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'notation':
-                        if (c.attributes.has('defaultClef')) {
-                            layout.defaultClef = this.parseClef(c.attributes.get('defaultClef')!);
-                        }
-                        break;
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'notation':
+                    if (c.attributes.has('defaultClef')) {
+                        layout.defaultClef = this.parseClef(c.attributes.get('defaultClef')!);
+                    }
+                    break;
 
-                    case 'sound':
-                        if (c.attributes.has('percussion')) {
-                            layout.percussion = c.attributes.get('percussion') === 'true';
-                        }
-                        if (c.attributes.has('instr')) {
-                            layout.instrument = parseInt(c.attributes.get('instr')!);
-                        }
-                        if (c.attributes.has('volume')) {
-                            layout.volume = parseInt(c.attributes.get('volume')!);
-                        }
-                        if (c.attributes.has('transpose')) {
-                            layout.transpose = parseInt(c.attributes.get('transpose')!);
-                        }
-                        break;
-                }
+                case 'sound':
+                    if (c.attributes.has('percussion')) {
+                        layout.percussion = c.attributes.get('percussion') === 'true';
+                    }
+                    if (c.attributes.has('instr')) {
+                        layout.instrument = parseInt(c.attributes.get('instr')!);
+                    }
+                    if (c.attributes.has('volume')) {
+                        layout.volume = parseInt(c.attributes.get('volume')!);
+                    }
+                    if (c.attributes.has('transpose')) {
+                        layout.transpose = parseInt(c.attributes.get('transpose')!);
+                    }
+                    break;
             }
         }
 
@@ -395,13 +385,11 @@ export class CapellaParser {
     }
 
     private parseSystems(element: XmlNode) {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'system':
-                        this.parseSystem(c);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'system':
+                    this.parseSystem(c);
+                    break;
             }
         }
     }
@@ -417,13 +405,11 @@ export class CapellaParser {
             this._beamingMode = BeatBeamingMode.ForceSplitToNext;
         }
 
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'staves':
-                        this.parseStaves(element, c);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'staves':
+                    this.parseStaves(element, c);
+                    break;
             }
         }
 
@@ -432,13 +418,11 @@ export class CapellaParser {
 
     private parseStaves(systemElement: XmlNode, element: XmlNode) {
         let firstBarIndex = this.score.masterBars.length;
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'staff':
-                        this.parseStaff(systemElement, firstBarIndex, c);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'staff':
+                    this.parseStaff(systemElement, firstBarIndex, c);
+                    break;
             }
         }
     }
@@ -463,13 +447,11 @@ export class CapellaParser {
             this.addNewBar(staff);
         }
 
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'voices':
-                        this.parseVoices(staffId, staff, systemElement, firstBarIndex, c);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'voices':
+                    this.parseVoices(staffId, staff, systemElement, firstBarIndex, c);
+                    break;
             }
         }
     }
@@ -504,14 +486,12 @@ export class CapellaParser {
         element: XmlNode
     ) {
         let voiceIndex = 0;
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'voice':
-                        this.parseVoice(staffId, staff, systemElement, voiceIndex, firstBarIndex, c);
-                        voiceIndex++;
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'voice':
+                    this.parseVoice(staffId, staff, systemElement, voiceIndex, firstBarIndex, c);
+                    voiceIndex++;
+                    break;
             }
         }
     }
@@ -609,135 +589,126 @@ export class CapellaParser {
         const noteObjects = element.findChildElement('noteObjects');
 
         if (systemElement.attributes.has('tempo')) {
-            const automation = new Automation()
+            const automation = new Automation();
             automation.isLinear = true;
             automation.type = AutomationType.Tempo;
             automation.value = parseInt(systemElement.attributes.get('tempo')!);
-            automation.ratioPosition = this._currentVoiceState.currentPosition / this._currentVoiceState.currentBarDuration;
-            this._currentBar.masterBar.tempoAutomations.push(automation); 
+            automation.ratioPosition =
+                this._currentVoiceState.currentPosition / this._currentVoiceState.currentBarDuration;
+            this._currentBar.masterBar.tempoAutomations.push(automation);
         }
 
         if (noteObjects) {
-            for (let c of noteObjects.childNodes) {
-                if (c.nodeType === XmlNodeType.Element) {
-                    if (this._currentVoiceState.currentBarComplete && c.localName !== 'barline') {
-                        this.newBar(staff, voiceIndex);
-                    }
+            for (let c of noteObjects.childElements()) {
+                if (this._currentVoiceState.currentBarComplete && c.localName !== 'barline') {
+                    this.newBar(staff, voiceIndex);
+                }
 
-                    switch (c.localName) {
-                        case 'clefSign':
-                            this._currentBar.clef = this.parseClef(c.getAttribute('clef'));
-                            this._currentBar.clefOttava = this.parseClefOttava(c.getAttribute('clef'));
-                            break;
-                        case 'keySign':
-                            this._currentBar.masterBar.keySignature = parseInt(
-                                c.getAttribute('fifths')
-                            ) as KeySignature;
-                            break;
-                        case 'timeSign':
-                            this.parseTime(c.getAttribute('time'));
-                            this._currentBar.masterBar.timeSignatureDenominator = this._timeSignature.timeSignatureDenominator;
-                            this._currentBar.masterBar.timeSignatureNumerator = this._timeSignature.timeSignatureNumerator;
-                            this._currentBar.masterBar.timeSignatureCommon = this._timeSignature.timeSignatureCommon;
-                            // NOTE: capella resets the current bar position to 0 whenever a timeSign is placed
-                            this._currentVoiceState.currentPosition = 0;
-                            this._currentVoiceState.currentBarDuration = this._currentBar.masterBar.calculateDuration(
-                                false
-                            );
-                            break;
-                        case 'barline':
-                            switch (c.getAttribute('type')) {
-                                case 'double':
-                                    this._currentBar.masterBar.isDoubleBar = true;
-                                    if (!this._currentVoiceState.currentBarComplete) {
-                                        this._currentBar.masterBar.isAnacrusis = true;
-                                    }
-                                    this._currentVoiceState.currentBarComplete = true;
-                                    break;
-                                case 'end':
-                                    if (!this._currentVoiceState.currentBarComplete) {
-                                        this._currentBar.masterBar.isAnacrusis = true;
-                                    }
-                                    break;
-                                case 'repEnd':
-                                    this._currentVoiceState.repeatEnd = this._currentBar.masterBar;
-                                    if (this._currentBar.masterBar.repeatCount < this._currentVoiceState.repeatCount) {
-                                        this._currentBar.masterBar.repeatCount = this._currentVoiceState.repeatCount;
-                                    }
-                                    this.parseBarDrawObject(c);
-                                    if (!this._currentVoiceState.currentBarComplete) {
-                                        this._currentBar.masterBar.isAnacrusis = true;
-                                    }
-                                    this._currentVoiceState.currentBarComplete = true;
-                                    break;
-                                case 'repBegin':
-                                    this.newBar(staff, voiceIndex); // repeat-start requires instant new bar
-                                    this._currentBar.masterBar.isRepeatStart = true;
-                                    this._currentVoiceState.repeatEnd = null;
-                                    this._currentVoiceState.repeatCount = 0;
-                                    break;
-                                case 'repEndBegin':
-                                    this._currentVoiceState.repeatEnd = this._currentBar.masterBar;
-                                    if (this._currentBar.masterBar.repeatCount < this._currentVoiceState.repeatCount) {
-                                        this._currentBar.masterBar.repeatCount = this._currentVoiceState.repeatCount;
-                                    }
-                                    this.parseBarDrawObject(c);
-                                    this.newBar(staff, voiceIndex); // end-begin requires instant new bar
-                                    this._currentBar.masterBar.isRepeatStart = true;
-                                    break;
-                                case 'dashed':
-                                    if (!this._currentVoiceState.currentBarComplete) {
-                                        this._currentBar.masterBar.isAnacrusis = true;
-                                    }
-                                    this._currentVoiceState.currentBarComplete = true;
-                                    break;
-                                // case 'single':
-                                default:
-                                    if (!this._currentVoiceState.currentBarComplete) {
-                                        this._currentBar.masterBar.isAnacrusis = true;
-                                    }
-                                    this._currentVoiceState.currentBarComplete = true;
-                                    break;
-                            }
-                            break;
-                        case 'chord':
-                            let chordBeat = new Beat();
-                            this.initFromPreviousBeat(chordBeat, this._currentVoice);
-                            chordBeat.beamingMode = this._beamingMode;
-                            if (this._currentVoiceState.voiceStemDir) {
-                                chordBeat.preferredBeamDirection = this._currentVoiceState.voiceStemDir;
-                            }
-                            this.parseDuration(this._currentBar, chordBeat, c.findChildElement('duration')!);
-                            chordBeat.updateDurations();
-                            this._currentVoiceState.currentPosition += chordBeat.playbackDuration;
-                            this._currentVoice.addBeat(chordBeat);
+                switch (c.localName) {
+                    case 'clefSign':
+                        this._currentBar.clef = this.parseClef(c.getAttribute('clef'));
+                        this._currentBar.clefOttava = this.parseClefOttava(c.getAttribute('clef'));
+                        break;
+                    case 'keySign':
+                        this._currentBar.masterBar.keySignature = parseInt(c.getAttribute('fifths')) as KeySignature;
+                        break;
+                    case 'timeSign':
+                        this.parseTime(c.getAttribute('time'));
+                        this._currentBar.masterBar.timeSignatureDenominator =
+                            this._timeSignature.timeSignatureDenominator;
+                        this._currentBar.masterBar.timeSignatureNumerator = this._timeSignature.timeSignatureNumerator;
+                        this._currentBar.masterBar.timeSignatureCommon = this._timeSignature.timeSignatureCommon;
+                        // NOTE: capella resets the current bar position to 0 whenever a timeSign is placed
+                        this._currentVoiceState.currentPosition = 0;
+                        this._currentVoiceState.currentBarDuration =
+                            this._currentBar.masterBar.calculateDuration(false);
+                        break;
+                    case 'barline':
+                        switch (c.getAttribute('type')) {
+                            case 'double':
+                                this._currentBar.masterBar.isDoubleBar = true;
+                                if (!this._currentVoiceState.currentBarComplete) {
+                                    this._currentBar.masterBar.isAnacrusis = true;
+                                }
+                                this._currentVoiceState.currentBarComplete = true;
+                                break;
+                            case 'end':
+                                if (!this._currentVoiceState.currentBarComplete) {
+                                    this._currentBar.masterBar.isAnacrusis = true;
+                                }
+                                break;
+                            case 'repEnd':
+                                this._currentVoiceState.repeatEnd = this._currentBar.masterBar;
+                                if (this._currentBar.masterBar.repeatCount < this._currentVoiceState.repeatCount) {
+                                    this._currentBar.masterBar.repeatCount = this._currentVoiceState.repeatCount;
+                                }
+                                this.parseBarDrawObject(c);
+                                if (!this._currentVoiceState.currentBarComplete) {
+                                    this._currentBar.masterBar.isAnacrusis = true;
+                                }
+                                this._currentVoiceState.currentBarComplete = true;
+                                break;
+                            case 'repBegin':
+                                this.newBar(staff, voiceIndex); // repeat-start requires instant new bar
+                                this._currentBar.masterBar.isRepeatStart = true;
+                                this._currentVoiceState.repeatEnd = null;
+                                this._currentVoiceState.repeatCount = 0;
+                                break;
+                            case 'repEndBegin':
+                                this._currentVoiceState.repeatEnd = this._currentBar.masterBar;
+                                if (this._currentBar.masterBar.repeatCount < this._currentVoiceState.repeatCount) {
+                                    this._currentBar.masterBar.repeatCount = this._currentVoiceState.repeatCount;
+                                }
+                                this.parseBarDrawObject(c);
+                                this.newBar(staff, voiceIndex); // end-begin requires instant new bar
+                                this._currentBar.masterBar.isRepeatStart = true;
+                                break;
+                            case 'dashed':
+                                if (!this._currentVoiceState.currentBarComplete) {
+                                    this._currentBar.masterBar.isAnacrusis = true;
+                                }
+                                this._currentVoiceState.currentBarComplete = true;
+                                break;
+                            // case 'single':
+                            default:
+                                if (!this._currentVoiceState.currentBarComplete) {
+                                    this._currentBar.masterBar.isAnacrusis = true;
+                                }
+                                this._currentVoiceState.currentBarComplete = true;
+                                break;
+                        }
+                        break;
+                    case 'chord':
+                        let chordBeat = new Beat();
+                        this.initFromPreviousBeat(chordBeat, this._currentVoice);
+                        chordBeat.beamingMode = this._beamingMode;
+                        if (this._currentVoiceState.voiceStemDir) {
+                            chordBeat.preferredBeamDirection = this._currentVoiceState.voiceStemDir;
+                        }
+                        this.parseDuration(this._currentBar, chordBeat, c.findChildElement('duration')!);
+                        chordBeat.updateDurations();
+                        this._currentVoiceState.currentPosition += chordBeat.playbackDuration;
+                        this._currentVoice.addBeat(chordBeat);
 
-                            this.parseChord(chordBeat, c);
+                        this.parseChord(chordBeat, c);
+
+                        if (this._currentVoiceState.currentPosition >= this._currentVoiceState.currentBarDuration) {
+                            this._currentVoiceState.currentBarComplete = true;
+                        }
+                        break;
+                    case 'rest':
+                        const restBeat = this.parseRestDurations(this._currentBar, c.findChildElement('duration')!);
+                        if (restBeat) {
+                            this.initFromPreviousBeat(restBeat, this._currentVoice);
+                            restBeat.updateDurations();
+                            this._currentVoiceState.currentPosition += restBeat.playbackDuration;
+                            this._currentVoice.addBeat(restBeat);
 
                             if (this._currentVoiceState.currentPosition >= this._currentVoiceState.currentBarDuration) {
                                 this._currentVoiceState.currentBarComplete = true;
                             }
-                            break;
-                        case 'rest':
-                            const restBeat = this.parseRestDurations(
-                                this._currentBar,
-                                c.findChildElement('duration')!
-                            );
-                            if (restBeat) {
-                                this.initFromPreviousBeat(restBeat, this._currentVoice);
-                                restBeat.updateDurations();
-                                this._currentVoiceState.currentPosition += restBeat.playbackDuration;
-                                this._currentVoice.addBeat(restBeat);
-
-                                if (
-                                    this._currentVoiceState.currentPosition >=
-                                    this._currentVoiceState.currentBarDuration
-                                ) {
-                                    this._currentVoiceState.currentBarComplete = true;
-                                }
-                            }
-                            break;
-                    }
+                        }
+                        break;
                 }
             }
         }
@@ -780,65 +751,61 @@ export class CapellaParser {
 
     private parseChord(beat: Beat, element: XmlNode) {
         const articulation: Note = new Note();
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'stem':
-                        switch (c.getAttribute('dir')) {
-                            case 'up':
-                                beat.preferredBeamDirection = BeamDirection.Up;
-                                break;
-                            case 'down':
-                                beat.preferredBeamDirection = BeamDirection.Down;
-                                break;
-                        }
-                        break;
-                    case 'articulation':
-                        switch (c.getAttribute('type')) {
-                            case 'staccato':
-                                articulation.isStaccato = true;
-                                break;
-                            case 'normalAccent':
-                                articulation.accentuated = AccentuationType.Normal;
-                                break;
-                            case 'strongAccent':
-                                articulation.accentuated = AccentuationType.Heavy;
-                                break;
-                        }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'stem':
+                    switch (c.getAttribute('dir')) {
+                        case 'up':
+                            beat.preferredBeamDirection = BeamDirection.Up;
+                            break;
+                        case 'down':
+                            beat.preferredBeamDirection = BeamDirection.Down;
+                            break;
+                    }
+                    break;
+                case 'articulation':
+                    switch (c.getAttribute('type')) {
+                        case 'staccato':
+                            articulation.isStaccato = true;
+                            break;
+                        case 'normalAccent':
+                            articulation.accentuated = AccentuationType.Normal;
+                            break;
+                        case 'strongAccent':
+                            articulation.accentuated = AccentuationType.Heavy;
+                            break;
+                    }
 
-                        break;
-                    case 'lyric':
-                        this.parseLyric(beat, c);
-                        break;
-                    case 'drawObjects':
-                        this.parseBeatDrawObject(beat, c);
-                        break;
-                    case 'heads':
-                        this.parseHeads(beat, articulation, c);
-                        break;
-                    case 'beam':
-                        switch (c.getAttribute('group')) {
-                            case 'force':
-                                beat.beamingMode = BeatBeamingMode.ForceMergeWithNext;
-                                break;
-                            case 'divide':
-                                beat.beamingMode = BeatBeamingMode.ForceSplitToNext;
-                                break;
-                        }
-                        break;
-                }
+                    break;
+                case 'lyric':
+                    this.parseLyric(beat, c);
+                    break;
+                case 'drawObjects':
+                    this.parseBeatDrawObject(beat, c);
+                    break;
+                case 'heads':
+                    this.parseHeads(beat, articulation, c);
+                    break;
+                case 'beam':
+                    switch (c.getAttribute('group')) {
+                        case 'force':
+                            beat.beamingMode = BeatBeamingMode.ForceMergeWithNext;
+                            break;
+                        case 'divide':
+                            beat.beamingMode = BeatBeamingMode.ForceSplitToNext;
+                            break;
+                    }
+                    break;
             }
         }
     }
 
     private parseHeads(beat: Beat, articulation: Note, element: XmlNode) {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'head':
-                        this.parseHead(beat, articulation, c);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'head':
+                    this.parseHead(beat, articulation, c);
+                    break;
             }
         }
     }
@@ -860,110 +827,104 @@ export class CapellaParser {
         // TODO: based on the shape attribute apply effects or
         // right percussion value
 
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'alter':
-                        if (c.attributes.has('step')) {
-                            note.tone += parseInt(c.attributes.get('step')!);
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'alter':
+                    if (c.attributes.has('step')) {
+                        note.tone += parseInt(c.attributes.get('step')!);
+                    }
+                    break;
+                case 'tie':
+                    if (c.attributes.has('begin')) {
+                        if (!this._tieStartIds.has(note.id)) {
+                            this._tieStartIds.set(note.id, true);
+                            this._tieStarts.push(note);
                         }
-                        break;
-                    case 'tie':
-                        if (c.attributes.has('begin')) {
-                            if (!this._tieStartIds.has(note.id)) {
-                                this._tieStartIds.set(note.id, true);
-                                this._tieStarts.push(note);
-                            }
-                        } else if (c.attributes.has('end') && this._tieStarts.length > 0 && !note.isTieDestination) {
-                            note.isTieDestination = true;
-                            note.tieOrigin = this._tieStarts[0];
-                            this._tieStarts.splice(0, 1);
-                            this._tieStartIds.delete(note.id);
-                        }
-                        break;
-                }
+                    } else if (c.attributes.has('end') && this._tieStarts.length > 0 && !note.isTieDestination) {
+                        note.isTieDestination = true;
+                        note.tieOrigin = this._tieStarts[0];
+                        this._tieStarts.splice(0, 1);
+                        this._tieStartIds.delete(note.id);
+                    }
+                    break;
             }
         }
     }
 
     private parseBeatDrawObject(beat: Beat, element: XmlNode) {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'drawObj':
-                        const obj = this.parseDrawObj(c);
-                        if (obj) {
-                            if (obj instanceof TextDrawObject) {
-                                if (obj.fontFace.startsWith('capella')) {
-                                    if (obj.text === 'u') {
-                                        beat.fermata = new Fermata();
-                                        beat.fermata.type = FermataType.Medium;
-                                    } else if (obj.text === 'f') {
-                                        beat.dynamics = DynamicValue.F;
-                                    } else if (obj.text === 'j') {
-                                        beat.dynamics = DynamicValue.MF;
-                                    }
-                                } else if (
-                                    this._isFirstSystem &&
-                                    this.score.title === '' &&
-                                    obj.align === TextAlign.Center &&
-                                    obj.height > 16 &&
-                                    obj.weight > 400
-                                ) {
-                                    // bold large centered text is very likely the title
-                                    this.score.title = obj.text;
-                                } else if (
-                                    this._isFirstSystem &&
-                                    this.score.artist === '' &&
-                                    obj.align === TextAlign.Center &&
-                                    obj.y < 0
-                                ) {
-                                    this.score.artist = obj.text;
-                                } else if (
-                                    this._isFirstSystem &&
-                                    this.score.music === '' &&
-                                    obj.align === TextAlign.Right &&
-                                    obj.y < 0
-                                ) {
-                                    this.score.music = obj.text;
-                                } else if (!obj.text.startsWith('by capella')) {
-                                    beat.text = obj.text;
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'drawObj':
+                    const obj = this.parseDrawObj(c);
+                    if (obj) {
+                        if (obj instanceof TextDrawObject) {
+                            if (obj.fontFace.startsWith('capella')) {
+                                if (obj.text === 'u') {
+                                    beat.fermata = new Fermata();
+                                    beat.fermata.type = FermataType.Medium;
+                                } else if (obj.text === 'f') {
+                                    beat.dynamics = DynamicValue.F;
+                                } else if (obj.text === 'j') {
+                                    beat.dynamics = DynamicValue.MF;
                                 }
-                            } else if (obj instanceof GuitarDrawObject) {
-                                // TODO: Chord
-                            } else if (obj instanceof WavyLineDrawObject) {
-                                beat.vibrato = VibratoType.Slight;
-                            } else if (obj instanceof WedgeDrawObject) {
-                                beat.crescendo = obj.decrescendo ? CrescendoType.Decrescendo : CrescendoType.Crescendo;
-                                obj.noteRange++;
-                                this._crescendo.set(beat, obj);
-                            } else if (obj instanceof SlurDrawObject) {
-                                // NOTE: casting needed for C#
-                                const slur = obj as any as SlurDrawObject;
-                                this._slurs.set(beat, slur);
-                            } else if (obj instanceof VoltaDrawObject) {
-                                this.applyVolta(obj);
+                            } else if (
+                                this._isFirstSystem &&
+                                this.score.title === '' &&
+                                obj.align === TextAlign.Center &&
+                                obj.height > 16 &&
+                                obj.weight > 400
+                            ) {
+                                // bold large centered text is very likely the title
+                                this.score.title = obj.text;
+                            } else if (
+                                this._isFirstSystem &&
+                                this.score.artist === '' &&
+                                obj.align === TextAlign.Center &&
+                                obj.y < 0
+                            ) {
+                                this.score.artist = obj.text;
+                            } else if (
+                                this._isFirstSystem &&
+                                this.score.music === '' &&
+                                obj.align === TextAlign.Right &&
+                                obj.y < 0
+                            ) {
+                                this.score.music = obj.text;
+                            } else if (!obj.text.startsWith('by capella')) {
+                                beat.text = obj.text;
                             }
+                        } else if (obj instanceof GuitarDrawObject) {
+                            // TODO: Chord
+                        } else if (obj instanceof WavyLineDrawObject) {
+                            beat.vibrato = VibratoType.Slight;
+                        } else if (obj instanceof WedgeDrawObject) {
+                            beat.crescendo = obj.decrescendo ? CrescendoType.Decrescendo : CrescendoType.Crescendo;
+                            obj.noteRange++;
+                            this._crescendo.set(beat, obj);
+                        } else if (obj instanceof SlurDrawObject) {
+                            // NOTE: casting needed for C#
+                            const slur = obj as any as SlurDrawObject;
+                            this._slurs.set(beat, slur);
+                        } else if (obj instanceof VoltaDrawObject) {
+                            this.applyVolta(obj);
                         }
-                        break;
-                }
+                    }
+                    break;
             }
         }
     }
 
     private parseBarDrawObject(element: XmlNode) {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'drawObj':
-                        const obj = this.parseDrawObj(c);
-                        if (obj) {
-                            if (obj instanceof VoltaDrawObject) {
-                                this.applyVolta(obj);
-                            }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'drawObj':
+                    const obj = this.parseDrawObj(c);
+                    if (obj) {
+                        if (obj instanceof VoltaDrawObject) {
+                            this.applyVolta(obj);
                         }
-                        break;
-                }
+                    }
+                    break;
             }
         }
     }
@@ -971,14 +932,18 @@ export class CapellaParser {
     private applyVolta(obj: VoltaDrawObject) {
         if (obj.lastNumber > 0) {
             this._currentVoiceState.repeatCount = obj.lastNumber;
-            if (this._currentVoiceState.repeatEnd &&
-                this._currentVoiceState.repeatEnd.repeatCount < this._currentVoiceState.repeatCount) {
+            if (
+                this._currentVoiceState.repeatEnd &&
+                this._currentVoiceState.repeatEnd.repeatCount < this._currentVoiceState.repeatCount
+            ) {
                 this._currentVoiceState.repeatEnd.repeatCount = this._currentVoiceState.repeatCount;
             }
         } else if (obj.firstNumber > 0) {
             this._currentVoiceState.repeatCount = obj.firstNumber;
-            if (this._currentVoiceState.repeatEnd &&
-                this._currentVoiceState.repeatEnd.repeatCount < this._currentVoiceState.repeatCount) {
+            if (
+                this._currentVoiceState.repeatEnd &&
+                this._currentVoiceState.repeatEnd.repeatCount < this._currentVoiceState.repeatCount
+            ) {
                 this._currentVoiceState.repeatEnd.repeatCount = this._currentVoiceState.repeatCount;
             }
         }
@@ -986,7 +951,7 @@ export class CapellaParser {
         if (obj.lastNumber > 0 && obj.firstNumber > 0) {
             let alternateEndings = 0;
             for (let i = obj.firstNumber; i <= obj.lastNumber; i++) {
-                alternateEndings = alternateEndings |  (0x01 << (i - 1));
+                alternateEndings = alternateEndings | (0x01 << (i - 1));
             }
             this._currentBar.masterBar.alternateEndings = alternateEndings;
         } else if (obj.lastNumber > 0) {
@@ -997,20 +962,18 @@ export class CapellaParser {
     }
 
     private parseLyric(beat: Beat, element: XmlNode) {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'verse':
-                        if (!beat.lyrics) {
-                            beat.lyrics = [];
-                        }
-                        let text = c.innerText;
-                        if (c.getAttribute('hyphen') === 'true') {
-                            text += '-';
-                        }
-                        beat.lyrics.push(text);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'verse':
+                    if (!beat.lyrics) {
+                        beat.lyrics = [];
+                    }
+                    let text = c.innerText;
+                    if (c.getAttribute('hyphen') === 'true') {
+                        text += '-';
+                    }
+                    beat.lyrics.push(text);
+                    break;
             }
         }
     }
@@ -1087,47 +1050,43 @@ export class CapellaParser {
     }
 
     private parsePageObjects(element: XmlNode) {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'drawObj':
-                        const obj = this.parseDrawObj(c);
-                        if (obj) {
-                            if (obj instanceof TextDrawObject) {
-                                switch (obj.align) {
-                                    case TextAlign.Center:
-                                        if (!this.score.title) {
-                                            this.score.title = c.innerText;
-                                        } else if (!this.score.subTitle) {
-                                            this.score.subTitle = c.innerText;
-                                        }
-                                        break;
-                                    case TextAlign.Right:
-                                        if (!this.score.artist) {
-                                            this.score.artist = c.innerText;
-                                        }
-                                        break;
-                                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'drawObj':
+                    const obj = this.parseDrawObj(c);
+                    if (obj) {
+                        if (obj instanceof TextDrawObject) {
+                            switch (obj.align) {
+                                case TextAlign.Center:
+                                    if (!this.score.title) {
+                                        this.score.title = c.innerText;
+                                    } else if (!this.score.subTitle) {
+                                        this.score.subTitle = c.innerText;
+                                    }
+                                    break;
+                                case TextAlign.Right:
+                                    if (!this.score.artist) {
+                                        this.score.artist = c.innerText;
+                                    }
+                                    break;
                             }
                         }
+                    }
 
-                        break;
-                }
+                    break;
             }
         }
     }
 
     private parseGallery(element: XmlNode) {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'drawObj':
-                        const obj = this.parseDrawObj(c);
-                        if (obj) {
-                            this._galleryObjects.set(c.getAttribute('name'), obj);
-                        }
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'drawObj':
+                    const obj = this.parseDrawObj(c);
+                    if (obj) {
+                        this._galleryObjects.set(c.getAttribute('name'), obj);
+                    }
+                    break;
             }
         }
     }
@@ -1137,42 +1096,40 @@ export class CapellaParser {
 
         let noteRange = 1;
 
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'text':
-                        obj = this.parseText(c);
-                        break;
-                    case 'guitar':
-                        obj = this.parseGuitar(c);
-                        break;
-                    case 'slur':
-                        obj = this.parseSlur(c);
-                        break;
-                    case 'wavyLine':
-                        obj = this.parseWavyLine(c);
-                        break;
-                    case 'bracket':
-                        obj = this.parseTupletBracket(c);
-                        break;
-                    case 'wedge':
-                        obj = this.parseWedge(c);
-                        break;
-                    case 'volta':
-                        obj = this.parseVolta(c);
-                        break;
-                    case 'octaveClef':
-                        obj = this.parseOctaveClef(c);
-                        break;
-                    case 'trill':
-                        obj = this.parseTrill(c);
-                        break;
-                    case 'basic':
-                        if (c.attributes.has('noteRange')) {
-                            noteRange = parseInt(c.attributes.get('noteRange')!);
-                        }
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'text':
+                    obj = this.parseText(c);
+                    break;
+                case 'guitar':
+                    obj = this.parseGuitar(c);
+                    break;
+                case 'slur':
+                    obj = this.parseSlur(c);
+                    break;
+                case 'wavyLine':
+                    obj = this.parseWavyLine(c);
+                    break;
+                case 'bracket':
+                    obj = this.parseTupletBracket(c);
+                    break;
+                case 'wedge':
+                    obj = this.parseWedge(c);
+                    break;
+                case 'volta':
+                    obj = this.parseVolta(c);
+                    break;
+                case 'octaveClef':
+                    obj = this.parseOctaveClef(c);
+                    break;
+                case 'trill':
+                    obj = this.parseTrill(c);
+                    break;
+                case 'basic':
+                    if (c.attributes.has('noteRange')) {
+                        noteRange = parseInt(c.attributes.get('noteRange')!);
+                    }
+                    break;
             }
         }
 
@@ -1294,25 +1251,23 @@ export class CapellaParser {
         }
 
         if (element.firstElement) {
-            for (let c of element.childNodes) {
-                if (c.nodeType === XmlNodeType.Element) {
-                    switch (c.localName) {
-                        case 'font':
-                            obj.fontFace = c.getAttribute('face');
+            for (let c of element.childElements()) {
+                switch (c.localName) {
+                    case 'font':
+                        obj.fontFace = c.getAttribute('face');
 
-                            if (c.attributes.has('weight')) {
-                                obj.weight = parseInt(c.attributes.get('weight')!);
-                            }
+                        if (c.attributes.has('weight')) {
+                            obj.weight = parseInt(c.attributes.get('weight')!);
+                        }
 
-                            if (c.attributes.has('height')) {
-                                obj.height = parseInt(c.attributes.get('height')!);
-                            }
+                        if (c.attributes.has('height')) {
+                            obj.height = parseInt(c.attributes.get('height')!);
+                        }
 
-                            break;
-                        case 'content':
-                            obj.text = c.innerText;
-                            break;
-                    }
+                        break;
+                    case 'content':
+                        obj.text = c.innerText;
+                        break;
                 }
             }
         } else {
@@ -1323,18 +1278,16 @@ export class CapellaParser {
     }
 
     private parseInfo(element: XmlNode): void {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    // encodingSoftware ignored
-                    case 'author':
-                        this.score.tab = c.firstChild!.innerText;
-                        break;
-                    // keywords ignored
-                    case 'comment':
-                        this.score.notices = c.firstChild!.innerText;
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                // encodingSoftware ignored
+                case 'author':
+                    this.score.tab = c.firstChild!.innerText;
+                    break;
+                // keywords ignored
+                case 'comment':
+                    this.score.notices = c.firstChild!.innerText;
+                    break;
             }
         }
     }

--- a/src/importer/GpifParser.ts
+++ b/src/importer/GpifParser.ts
@@ -171,37 +171,35 @@ export class GpifParser {
         if (root.localName === 'GPIF') {
             this.score = new Score();
             // parse all children
-            for (let n of root.childNodes) {
-                if (n.nodeType === XmlNodeType.Element) {
-                    switch (n.localName) {
-                        case 'Score':
-                            this.parseScoreNode(n);
-                            break;
-                        case 'MasterTrack':
-                            this.parseMasterTrackNode(n);
-                            break;
-                        case 'Tracks':
-                            this.parseTracksNode(n);
-                            break;
-                        case 'MasterBars':
-                            this.parseMasterBarsNode(n);
-                            break;
-                        case 'Bars':
-                            this.parseBars(n);
-                            break;
-                        case 'Voices':
-                            this.parseVoices(n);
-                            break;
-                        case 'Beats':
-                            this.parseBeats(n);
-                            break;
-                        case 'Notes':
-                            this.parseNotes(n);
-                            break;
-                        case 'Rhythms':
-                            this.parseRhythms(n);
-                            break;
-                    }
+            for (let n of root.childElements()) {
+                switch (n.localName) {
+                    case 'Score':
+                        this.parseScoreNode(n);
+                        break;
+                    case 'MasterTrack':
+                        this.parseMasterTrackNode(n);
+                        break;
+                    case 'Tracks':
+                        this.parseTracksNode(n);
+                        break;
+                    case 'MasterBars':
+                        this.parseMasterBarsNode(n);
+                        break;
+                    case 'Bars':
+                        this.parseBars(n);
+                        break;
+                    case 'Voices':
+                        this.parseVoices(n);
+                        break;
+                    case 'Beats':
+                        this.parseBeats(n);
+                        break;
+                    case 'Notes':
+                        this.parseNotes(n);
+                        break;
+                    case 'Rhythms':
+                        this.parseRhythms(n);
+                        break;
                 }
             }
         } else {
@@ -213,57 +211,55 @@ export class GpifParser {
     // <Score>...</Score>
     //
     private parseScoreNode(element: XmlNode): void {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Title':
-                        this.score.title = c.firstChild!.innerText;
-                        break;
-                    case 'SubTitle':
-                        this.score.subTitle = c.firstChild!.innerText;
-                        break;
-                    case 'Artist':
-                        this.score.artist = c.firstChild!.innerText;
-                        break;
-                    case 'Album':
-                        this.score.album = c.firstChild!.innerText;
-                        break;
-                    case 'Words':
-                        this.score.words = c.firstChild!.innerText;
-                        break;
-                    case 'Music':
-                        this.score.music = c.firstChild!.innerText;
-                        break;
-                    case 'WordsAndMusic':
-                        if (c.firstChild && c.firstChild.innerText !== '') {
-                            let wordsAndMusic: string = c.firstChild.innerText;
-                            if (wordsAndMusic && !this.score.words) {
-                                this.score.words = wordsAndMusic;
-                            }
-                            if (wordsAndMusic && !this.score.music) {
-                                this.score.music = wordsAndMusic;
-                            }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'Title':
+                    this.score.title = c.firstChild!.innerText;
+                    break;
+                case 'SubTitle':
+                    this.score.subTitle = c.firstChild!.innerText;
+                    break;
+                case 'Artist':
+                    this.score.artist = c.firstChild!.innerText;
+                    break;
+                case 'Album':
+                    this.score.album = c.firstChild!.innerText;
+                    break;
+                case 'Words':
+                    this.score.words = c.firstChild!.innerText;
+                    break;
+                case 'Music':
+                    this.score.music = c.firstChild!.innerText;
+                    break;
+                case 'WordsAndMusic':
+                    if (c.firstChild && c.firstChild.innerText !== '') {
+                        let wordsAndMusic: string = c.firstChild.innerText;
+                        if (wordsAndMusic && !this.score.words) {
+                            this.score.words = wordsAndMusic;
                         }
-                        break;
-                    case 'Copyright':
-                        this.score.copyright = c.firstChild!.innerText;
-                        break;
-                    case 'Tabber':
-                        this.score.tab = c.firstChild!.innerText;
-                        break;
-                    case 'Instructions':
-                        this.score.instructions = c.firstChild!.innerText;
-                        break;
-                    case 'Notices':
-                        this.score.notices = c.firstChild!.innerText;
-                        break;
-                    case 'ScoreSystemsDefaultLayout':
-                        this.score.defaultSystemsLayout = parseInt(c.innerText);
-                        break;
-                    case 'ScoreSystemsLayout':
-                        this.score.systemsLayout = c.innerText.split(' ').map(i => parseInt(i));
-                        break;
-                }
+                        if (wordsAndMusic && !this.score.music) {
+                            this.score.music = wordsAndMusic;
+                        }
+                    }
+                    break;
+                case 'Copyright':
+                    this.score.copyright = c.firstChild!.innerText;
+                    break;
+                case 'Tabber':
+                    this.score.tab = c.firstChild!.innerText;
+                    break;
+                case 'Instructions':
+                    this.score.instructions = c.firstChild!.innerText;
+                    break;
+                case 'Notices':
+                    this.score.notices = c.firstChild!.innerText;
+                    break;
+                case 'ScoreSystemsDefaultLayout':
+                    this.score.defaultSystemsLayout = parseInt(c.innerText);
+                    break;
+                case 'ScoreSystemsLayout':
+                    this.score.systemsLayout = c.innerText.split(' ').map(i => parseInt(i));
+                    break;
             }
         }
     }
@@ -272,19 +268,17 @@ export class GpifParser {
     // <MasterTrack>...</MasterTrack>
     //
     private parseMasterTrackNode(node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Automations':
-                        this.parseAutomations(c, this._masterTrackAutomations, null, null);
-                        break;
-                    case 'Tracks':
-                        this._tracksMapping = c.innerText.split(' ');
-                        break;
-                    case 'Anacrusis':
-                        this._hasAnacrusis = true;
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Automations':
+                    this.parseAutomations(c, this._masterTrackAutomations, null, null);
+                    break;
+                case 'Tracks':
+                    this._tracksMapping = c.innerText.split(' ');
+                    break;
+                case 'Anacrusis':
+                    this._hasAnacrusis = true;
+                    break;
             }
         }
     }
@@ -295,13 +289,11 @@ export class GpifParser {
         sounds: Map<string, GpifSound> | null,
         sustainPedals: Map<number, SustainPedalMarker[]> | null
     ): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Automation':
-                        this.parseAutomation(c, automations, sounds, sustainPedals);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Automation':
+                    this.parseAutomation(c, automations, sounds, sustainPedals);
+                    break;
             }
         }
     }
@@ -320,41 +312,39 @@ export class GpifParser {
         let textValue: string | null = null;
         let reference: number = 0;
         let text: string | null = null;
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Type':
-                        type = c.innerText;
-                        break;
-                    case 'Linear':
-                        isLinear = c.innerText.toLowerCase() === 'true';
-                        break;
-                    case 'Bar':
-                        barIndex = parseInt(c.innerText);
-                        break;
-                    case 'Position':
-                        ratioPosition = parseFloat(c.innerText);
-                        break;
-                    case 'Value':
-                        if (c.firstElement && c.firstElement.nodeType === XmlNodeType.CDATA) {
-                            textValue = c.innerText;
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Type':
+                    type = c.innerText;
+                    break;
+                case 'Linear':
+                    isLinear = c.innerText.toLowerCase() === 'true';
+                    break;
+                case 'Bar':
+                    barIndex = parseInt(c.innerText);
+                    break;
+                case 'Position':
+                    ratioPosition = parseFloat(c.innerText);
+                    break;
+                case 'Value':
+                    if (c.firstElement && c.firstElement.nodeType === XmlNodeType.CDATA) {
+                        textValue = c.innerText;
+                    } else {
+                        let parts: string[] = c.innerText.split(' ');
+                        // Issue 391: Some GPX files might have
+                        // single floating point value.
+                        if (parts.length === 1) {
+                            numberValue = parseFloat(parts[0]);
+                            reference = 1;
                         } else {
-                            let parts: string[] = c.innerText.split(' ');
-                            // Issue 391: Some GPX files might have
-                            // single floating point value.
-                            if (parts.length === 1) {
-                                numberValue = parseFloat(parts[0]);
-                                reference = 1;
-                            } else {
-                                numberValue = parseFloat(parts[0]);
-                                reference = parseInt(parts[1]);
-                            }
+                            numberValue = parseFloat(parts[0]);
+                            reference = parseInt(parts[1]);
                         }
-                        break;
-                    case 'Text':
-                        text = c.innerText;
-                        break;
-                }
+                    }
+                    break;
+                case 'Text':
+                    text = c.innerText;
+                    break;
             }
         }
         if (!type) {
@@ -419,13 +409,11 @@ export class GpifParser {
     // <Tracks>...</Tracks>
     //
     private parseTracksNode(node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Track':
-                        this.parseTrack(c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Track':
+                    this.parseTrack(c);
+                    break;
             }
         }
     }
@@ -439,78 +427,76 @@ export class GpifParser {
         staff.showStandardNotation = true;
         let trackId: string = node.getAttribute('id');
 
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Name':
-                        track.name = c.innerText;
-                        break;
-                    case 'Color':
-                        let parts: string[] = c.innerText.split(' ');
-                        if (parts.length >= 3) {
-                            let r: number = parseInt(parts[0]);
-                            let g: number = parseInt(parts[1]);
-                            let b: number = parseInt(parts[2]);
-                            track.color = new Color(r, g, b, 0xff);
-                        }
-                        break;
-                    case 'Instrument':
-                        let instrumentName: string = c.getAttribute('ref');
-                        if (instrumentName.endsWith('-gs') || instrumentName.endsWith('GrandStaff')) {
-                            track.ensureStaveCount(2);
-                            track.staves[1].showStandardNotation = true;
-                        }
-                        break;
-                    case 'InstrumentSet':
-                        this.parseInstrumentSet(track, c);
-                        break;
-                    case 'NotationPatch':
-                        this.parseNotationPatch(track, c);
-                        break;
-                    case 'ShortName':
-                        track.shortName = c.innerText;
-                        break;
-                    case 'SystemsDefautLayout': // not a typo by alphaTab, this is a typo in the GPIF files.
-                        track.defaultSystemsLayout = parseInt(c.innerText);
-                        break;
-                    case 'SystemsLayout':
-                        track.systemsLayout = c.innerText.split(' ').map(i => parseInt(i));
-                        break;
-                    case 'Lyrics':
-                        this.parseLyrics(trackId, c);
-                        break;
-                    case 'Properties':
-                        this.parseTrackProperties(track, c);
-                        break;
-                    case 'GeneralMidi':
-                    case 'MidiConnection':
-                    case 'MIDISettings':
-                        this.parseGeneralMidi(track, c);
-                        break;
-                    case 'Sounds':
-                        this.parseSounds(trackId, track, c);
-                        break;
-                    case 'PlaybackState':
-                        let state: string = c.innerText;
-                        track.playbackInfo.isSolo = state === 'Solo';
-                        track.playbackInfo.isMute = state === 'Mute';
-                        break;
-                    case 'PartSounding':
-                        this.parsePartSounding(track, c);
-                        break;
-                    case 'Staves':
-                        this.parseStaves(track, c);
-                        break;
-                    case 'Transpose':
-                        this.parseTranspose(track, c);
-                        break;
-                    case 'RSE':
-                        this.parseRSE(track, c);
-                        break;
-                    case 'Automations':
-                        this.parseTrackAutomations(trackId, c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Name':
+                    track.name = c.innerText;
+                    break;
+                case 'Color':
+                    let parts: string[] = c.innerText.split(' ');
+                    if (parts.length >= 3) {
+                        let r: number = parseInt(parts[0]);
+                        let g: number = parseInt(parts[1]);
+                        let b: number = parseInt(parts[2]);
+                        track.color = new Color(r, g, b, 0xff);
+                    }
+                    break;
+                case 'Instrument':
+                    let instrumentName: string = c.getAttribute('ref');
+                    if (instrumentName.endsWith('-gs') || instrumentName.endsWith('GrandStaff')) {
+                        track.ensureStaveCount(2);
+                        track.staves[1].showStandardNotation = true;
+                    }
+                    break;
+                case 'InstrumentSet':
+                    this.parseInstrumentSet(track, c);
+                    break;
+                case 'NotationPatch':
+                    this.parseNotationPatch(track, c);
+                    break;
+                case 'ShortName':
+                    track.shortName = c.innerText;
+                    break;
+                case 'SystemsDefautLayout': // not a typo by alphaTab, this is a typo in the GPIF files.
+                    track.defaultSystemsLayout = parseInt(c.innerText);
+                    break;
+                case 'SystemsLayout':
+                    track.systemsLayout = c.innerText.split(' ').map(i => parseInt(i));
+                    break;
+                case 'Lyrics':
+                    this.parseLyrics(trackId, c);
+                    break;
+                case 'Properties':
+                    this.parseTrackProperties(track, c);
+                    break;
+                case 'GeneralMidi':
+                case 'MidiConnection':
+                case 'MIDISettings':
+                    this.parseGeneralMidi(track, c);
+                    break;
+                case 'Sounds':
+                    this.parseSounds(trackId, track, c);
+                    break;
+                case 'PlaybackState':
+                    let state: string = c.innerText;
+                    track.playbackInfo.isSolo = state === 'Solo';
+                    track.playbackInfo.isMute = state === 'Mute';
+                    break;
+                case 'PartSounding':
+                    this.parsePartSounding(track, c);
+                    break;
+                case 'Staves':
+                    this.parseStaves(track, c);
+                    break;
+                case 'Transpose':
+                    this.parseTranspose(track, c);
+                    break;
+                case 'RSE':
+                    this.parseRSE(track, c);
+                    break;
+                case 'Automations':
+                    this.parseTrackAutomations(trackId, c);
+                    break;
             }
         }
         this._tracksById.set(trackId, track);
@@ -527,62 +513,56 @@ export class GpifParser {
     }
 
     private parseNotationPatch(track: Track, node: XmlNode) {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'LineCount':
-                        const lineCount = parseInt(c.innerText);
-                        for (let staff of track.staves) {
-                            staff.standardNotationLineCount = lineCount;
-                        }
-                        break;
-                    case 'Elements':
-                        this.parseElements(track, c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'LineCount':
+                    const lineCount = parseInt(c.innerText);
+                    for (let staff of track.staves) {
+                        staff.standardNotationLineCount = lineCount;
+                    }
+                    break;
+                case 'Elements':
+                    this.parseElements(track, c);
+                    break;
             }
         }
     }
 
     private parseInstrumentSet(track: Track, node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Type':
-                        switch (c.innerText) {
-                            case 'drumKit':
-                                for (let staff of track.staves) {
-                                    staff.isPercussion = true;
-                                }
-                                break;
-                        }
-                        if (c.innerText === 'drumKit') {
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Type':
+                    switch (c.innerText) {
+                        case 'drumKit':
                             for (let staff of track.staves) {
                                 staff.isPercussion = true;
                             }
-                        }
-                        break;
-                    case 'Elements':
-                        this.parseElements(track, c);
-                        break;
-                    case 'LineCount':
-                        const lineCount = parseInt(c.innerText);
+                            break;
+                    }
+                    if (c.innerText === 'drumKit') {
                         for (let staff of track.staves) {
-                            staff.standardNotationLineCount = lineCount;
+                            staff.isPercussion = true;
                         }
-                        break;
-                }
+                    }
+                    break;
+                case 'Elements':
+                    this.parseElements(track, c);
+                    break;
+                case 'LineCount':
+                    const lineCount = parseInt(c.innerText);
+                    for (let staff of track.staves) {
+                        staff.standardNotationLineCount = lineCount;
+                    }
+                    break;
             }
         }
     }
     private parseElements(track: Track, node: XmlNode) {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Element':
-                        this.parseElement(track, c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Element':
+                    this.parseElement(track, c);
+                    break;
             }
         }
     }
@@ -590,25 +570,21 @@ export class GpifParser {
     private parseElement(track: Track, node: XmlNode) {
         const typeElement = node.findChildElement('Type');
         const type = typeElement ? typeElement.innerText : '';
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Name':
-                    case 'Articulations':
-                        this.parseArticulations(track, c, type);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Name':
+                case 'Articulations':
+                    this.parseArticulations(track, c, type);
+                    break;
             }
         }
     }
     private parseArticulations(track: Track, node: XmlNode, elementType: string) {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Articulation':
-                        this.parseArticulation(track, c, elementType);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Articulation':
+                    this.parseArticulation(track, c, elementType);
+                    break;
             }
         }
     }
@@ -618,64 +594,62 @@ export class GpifParser {
         articulation.outputMidiNumber = -1;
         articulation.elementType = elementType;
         let name = '';
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                const txt = c.innerText;
-                switch (c.localName) {
-                    case 'Name':
-                        name = c.innerText;
-                        break;
-                    case 'OutputMidiNumber':
-                        if (txt.length > 0) {
-                            articulation.outputMidiNumber = parseInt(txt);
-                        }
-                        break;
-                    case 'TechniqueSymbol':
-                        articulation.techniqueSymbol = this.parseTechniqueSymbol(txt);
-                        break;
-                    case 'TechniquePlacement':
-                        switch (txt) {
-                            case 'outside':
-                                articulation.techniqueSymbolPlacement = TextBaseline.Bottom;
-                                break;
-                            case 'inside':
-                                articulation.techniqueSymbolPlacement = TextBaseline.Middle;
-                                break;
-                            case 'above':
-                                articulation.techniqueSymbolPlacement = TextBaseline.Bottom;
-                                break;
-                            case 'below':
-                                articulation.techniqueSymbolPlacement = TextBaseline.Top;
-                                break;
-                        }
-                        break;
-                    case 'Noteheads':
-                        const noteHeadsTxt = txt.split(' ');
-                        if (noteHeadsTxt.length >= 1) {
-                            articulation.noteHeadDefault = this.parseNoteHead(noteHeadsTxt[0]);
-                        }
-                        if (noteHeadsTxt.length >= 2) {
-                            articulation.noteHeadHalf = this.parseNoteHead(noteHeadsTxt[1]);
-                        }
-                        if (noteHeadsTxt.length >= 3) {
-                            articulation.noteHeadWhole = this.parseNoteHead(noteHeadsTxt[2]);
-                        }
+        for (let c of node.childElements()) {
+            const txt = c.innerText;
+            switch (c.localName) {
+                case 'Name':
+                    name = c.innerText;
+                    break;
+                case 'OutputMidiNumber':
+                    if (txt.length > 0) {
+                        articulation.outputMidiNumber = parseInt(txt);
+                    }
+                    break;
+                case 'TechniqueSymbol':
+                    articulation.techniqueSymbol = this.parseTechniqueSymbol(txt);
+                    break;
+                case 'TechniquePlacement':
+                    switch (txt) {
+                        case 'outside':
+                            articulation.techniqueSymbolPlacement = TextBaseline.Bottom;
+                            break;
+                        case 'inside':
+                            articulation.techniqueSymbolPlacement = TextBaseline.Middle;
+                            break;
+                        case 'above':
+                            articulation.techniqueSymbolPlacement = TextBaseline.Bottom;
+                            break;
+                        case 'below':
+                            articulation.techniqueSymbolPlacement = TextBaseline.Top;
+                            break;
+                    }
+                    break;
+                case 'Noteheads':
+                    const noteHeadsTxt = txt.split(' ');
+                    if (noteHeadsTxt.length >= 1) {
+                        articulation.noteHeadDefault = this.parseNoteHead(noteHeadsTxt[0]);
+                    }
+                    if (noteHeadsTxt.length >= 2) {
+                        articulation.noteHeadHalf = this.parseNoteHead(noteHeadsTxt[1]);
+                    }
+                    if (noteHeadsTxt.length >= 3) {
+                        articulation.noteHeadWhole = this.parseNoteHead(noteHeadsTxt[2]);
+                    }
 
-                        if (articulation.noteHeadHalf == MusicFontSymbol.None) {
-                            articulation.noteHeadHalf = articulation.noteHeadDefault;
-                        }
+                    if (articulation.noteHeadHalf == MusicFontSymbol.None) {
+                        articulation.noteHeadHalf = articulation.noteHeadDefault;
+                    }
 
-                        if (articulation.noteHeadWhole == MusicFontSymbol.None) {
-                            articulation.noteHeadWhole = articulation.noteHeadDefault;
-                        }
+                    if (articulation.noteHeadWhole == MusicFontSymbol.None) {
+                        articulation.noteHeadWhole = articulation.noteHeadDefault;
+                    }
 
-                        break;
-                    case 'StaffLine':
-                        if (txt.length > 0) {
-                            articulation.staffLine = parseInt(txt);
-                        }
-                        break;
-                }
+                    break;
+                case 'StaffLine':
+                    if (txt.length > 0) {
+                        articulation.staffLine = parseInt(txt);
+                    }
+                    break;
             }
         }
 
@@ -762,40 +736,34 @@ export class GpifParser {
 
     private parseStaves(track: Track, node: XmlNode): void {
         let staffIndex: number = 0;
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Staff':
-                        track.ensureStaveCount(staffIndex + 1);
-                        let staff: Staff = track.staves[staffIndex];
-                        this.parseStaff(staff, c);
-                        staffIndex++;
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Staff':
+                    track.ensureStaveCount(staffIndex + 1);
+                    let staff: Staff = track.staves[staffIndex];
+                    this.parseStaff(staff, c);
+                    staffIndex++;
+                    break;
             }
         }
     }
 
     private parseStaff(staff: Staff, node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Properties':
-                        this.parseStaffProperties(staff, c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Properties':
+                    this.parseStaffProperties(staff, c);
+                    break;
             }
         }
     }
 
     private parseStaffProperties(staff: Staff, node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Property':
-                        this.parseStaffProperty(staff, c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Property':
+                    this.parseStaffProperty(staff, c);
+                    break;
             }
         }
     }
@@ -804,21 +772,19 @@ export class GpifParser {
         let propertyName: string = node.getAttribute('name');
         switch (propertyName) {
             case 'Tuning':
-                for (let c of node.childNodes) {
-                    if (c.nodeType === XmlNodeType.Element) {
-                        switch (c.localName) {
-                            case 'Pitches':
-                                let tuningParts: string[] = node.findChildElement('Pitches')!.innerText.split(' ');
-                                let tuning = new Array<number>(tuningParts.length);
-                                for (let i: number = 0; i < tuning.length; i++) {
-                                    tuning[tuning.length - 1 - i] = parseInt(tuningParts[i]);
-                                }
-                                staff.stringTuning.tunings = tuning;
-                                break;
-                            case 'Label':
-                                staff.stringTuning.name = c.innerText;
-                                break;
-                        }
+                for (let c of node.childElements()) {
+                    switch (c.localName) {
+                        case 'Pitches':
+                            let tuningParts: string[] = node.findChildElement('Pitches')!.innerText.split(' ');
+                            let tuning = new Array<number>(tuningParts.length);
+                            for (let i: number = 0; i < tuning.length; i++) {
+                                tuning[tuning.length - 1 - i] = parseInt(tuningParts[i]);
+                            }
+                            staff.stringTuning.tunings = tuning;
+                            break;
+                        case 'Label':
+                            staff.stringTuning.name = c.innerText;
+                            break;
                     }
                 }
 
@@ -840,13 +806,11 @@ export class GpifParser {
 
     private parseLyrics(trackId: string, node: XmlNode): void {
         let tracks: Lyrics[] = [];
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Line':
-                        tracks.push(this.parseLyricsLine(c));
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Line':
+                    tracks.push(this.parseLyricsLine(c));
+                    break;
             }
         }
         this._lyricsByTrack.set(trackId, tracks);
@@ -854,16 +818,14 @@ export class GpifParser {
 
     private parseLyricsLine(node: XmlNode): Lyrics {
         let lyrics: Lyrics = new Lyrics();
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Offset':
-                        lyrics.startBar = parseInt(c.innerText);
-                        break;
-                    case 'Text':
-                        lyrics.text = c.innerText;
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Offset':
+                    lyrics.startBar = parseInt(c.innerText);
+                    break;
+                case 'Text':
+                    lyrics.text = c.innerText;
+                    break;
             }
         }
         return lyrics;
@@ -871,26 +833,22 @@ export class GpifParser {
 
     private parseDiagramCollectionForTrack(track: Track, node: XmlNode): void {
         let items: XmlNode = node.findChildElement('Items')!;
-        for (let c of items.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Item':
-                        this.parseDiagramItemForTrack(track, c);
-                        break;
-                }
+        for (let c of items.childElements()) {
+            switch (c.localName) {
+                case 'Item':
+                    this.parseDiagramItemForTrack(track, c);
+                    break;
             }
         }
     }
 
     private parseDiagramCollectionForStaff(staff: Staff, node: XmlNode): void {
         let items: XmlNode = node.findChildElement('Items')!;
-        for (let c of items.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Item':
-                        this.parseDiagramItemForStaff(staff, c);
-                        break;
-                }
+        for (let c of items.childElements()) {
+            switch (c.localName) {
+                case 'Item':
+                    this.parseDiagramItemForStaff(staff, c);
+                    break;
             }
         }
     }
@@ -926,78 +884,72 @@ export class GpifParser {
         for (let i: number = 0; i < stringCount; i++) {
             chord.strings.push(-1);
         }
-        for (let c of diagram.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Fret':
-                        let guitarString: number = parseInt(c.getAttribute('string'));
-                        chord.strings[stringCount - guitarString - 1] = baseFret + parseInt(c.getAttribute('fret'));
-                        break;
-                    case 'Fingering':
-                        let existingFingers: Map<Fingers, boolean> = new Map<Fingers, boolean>();
-                        for (let p of c.childNodes) {
-                            if (p.nodeType === XmlNodeType.Element) {
-                                switch (p.localName) {
-                                    case 'Position':
-                                        let finger: Fingers = Fingers.Unknown;
-                                        let fret: number = baseFret + parseInt(p.getAttribute('fret'));
-                                        switch (p.getAttribute('finger')) {
-                                            case 'Index':
-                                                finger = Fingers.IndexFinger;
-                                                break;
-                                            case 'Middle':
-                                                finger = Fingers.MiddleFinger;
-                                                break;
-                                            case 'Rank':
-                                                finger = Fingers.AnnularFinger;
-                                                break;
-                                            case 'Pinky':
-                                                finger = Fingers.LittleFinger;
-                                                break;
-                                            case 'Thumb':
-                                                finger = Fingers.Thumb;
-                                                break;
-                                            case 'None':
-                                                break;
-                                        }
-                                        if (finger !== Fingers.Unknown) {
-                                            if (existingFingers.has(finger)) {
-                                                chord.barreFrets.push(fret);
-                                            } else {
-                                                existingFingers.set(finger, true);
-                                            }
-                                        }
+        for (let c of diagram.childElements()) {
+            switch (c.localName) {
+                case 'Fret':
+                    let guitarString: number = parseInt(c.getAttribute('string'));
+                    chord.strings[stringCount - guitarString - 1] = baseFret + parseInt(c.getAttribute('fret'));
+                    break;
+                case 'Fingering':
+                    let existingFingers: Map<Fingers, boolean> = new Map<Fingers, boolean>();
+                    for (let p of c.childElements()) {
+                        switch (p.localName) {
+                            case 'Position':
+                                let finger: Fingers = Fingers.Unknown;
+                                let fret: number = baseFret + parseInt(p.getAttribute('fret'));
+                                switch (p.getAttribute('finger')) {
+                                    case 'Index':
+                                        finger = Fingers.IndexFinger;
+                                        break;
+                                    case 'Middle':
+                                        finger = Fingers.MiddleFinger;
+                                        break;
+                                    case 'Rank':
+                                        finger = Fingers.AnnularFinger;
+                                        break;
+                                    case 'Pinky':
+                                        finger = Fingers.LittleFinger;
+                                        break;
+                                    case 'Thumb':
+                                        finger = Fingers.Thumb;
+                                        break;
+                                    case 'None':
                                         break;
                                 }
-                            }
-                        }
-                        break;
-                    case 'Property':
-                        switch (c.getAttribute('name')) {
-                            case 'ShowName':
-                                chord.showName = c.getAttribute('value') === 'true';
-                                break;
-                            case 'ShowDiagram':
-                                chord.showDiagram = c.getAttribute('value') === 'true';
-                                break;
-                            case 'ShowFingering':
-                                chord.showFingering = c.getAttribute('value') === 'true';
+                                if (finger !== Fingers.Unknown) {
+                                    if (existingFingers.has(finger)) {
+                                        chord.barreFrets.push(fret);
+                                    } else {
+                                        existingFingers.set(finger, true);
+                                    }
+                                }
                                 break;
                         }
-                        break;
-                }
+                    }
+                    break;
+                case 'Property':
+                    switch (c.getAttribute('name')) {
+                        case 'ShowName':
+                            chord.showName = c.getAttribute('value') === 'true';
+                            break;
+                        case 'ShowDiagram':
+                            chord.showDiagram = c.getAttribute('value') === 'true';
+                            break;
+                        case 'ShowFingering':
+                            chord.showFingering = c.getAttribute('value') === 'true';
+                            break;
+                    }
+                    break;
             }
         }
     }
 
     private parseTrackProperties(track: Track, node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Property':
-                        this.parseTrackProperty(track, c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Property':
+                    this.parseTrackProperty(track, c);
+                    break;
             }
         }
     }
@@ -1031,22 +983,20 @@ export class GpifParser {
     }
 
     private parseGeneralMidi(track: Track, node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Program':
-                        track.playbackInfo.program = parseInt(c.innerText);
-                        break;
-                    case 'Port':
-                        track.playbackInfo.port = parseInt(c.innerText);
-                        break;
-                    case 'PrimaryChannel':
-                        track.playbackInfo.primaryChannel = parseInt(c.innerText);
-                        break;
-                    case 'SecondaryChannel':
-                        track.playbackInfo.secondaryChannel = parseInt(c.innerText);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Program':
+                    track.playbackInfo.program = parseInt(c.innerText);
+                    break;
+                case 'Port':
+                    track.playbackInfo.port = parseInt(c.innerText);
+                    break;
+                case 'PrimaryChannel':
+                    track.playbackInfo.primaryChannel = parseInt(c.innerText);
+                    break;
+                case 'SecondaryChannel':
+                    track.playbackInfo.secondaryChannel = parseInt(c.innerText);
+                    break;
             }
         }
         let isPercussion: boolean = node.getAttribute('table') === 'Percussion';
@@ -1058,35 +1008,31 @@ export class GpifParser {
     }
 
     private parseSounds(trackId: string, track: Track, node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Sound':
-                        this.parseSound(trackId, track, c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Sound':
+                    this.parseSound(trackId, track, c);
+                    break;
             }
         }
     }
 
     private parseSound(trackId: string, track: Track, node: XmlNode): void {
         const sound = new GpifSound();
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Name':
-                        sound.name = c.innerText;
-                        break;
-                    case 'Path':
-                        sound.path = c.innerText;
-                        break;
-                    case 'Role':
-                        sound.role = c.innerText;
-                        break;
-                    case 'MIDI':
-                        this.parseSoundMidi(sound, c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Name':
+                    sound.name = c.innerText;
+                    break;
+                case 'Path':
+                    sound.path = c.innerText;
+                    break;
+                case 'Role':
+                    sound.role = c.innerText;
+                    break;
+                case 'MIDI':
+                    this.parseSoundMidi(sound, c);
+                    break;
             }
         }
 
@@ -1102,27 +1048,23 @@ export class GpifParser {
     }
 
     private parseSoundMidi(sound: GpifSound, node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Program':
-                        sound.program = parseInt(c.innerText);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Program':
+                    sound.program = parseInt(c.innerText);
+                    break;
             }
         }
     }
 
     private parsePartSounding(track: Track, node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'TranspositionPitch':
-                        for (let staff of track.staves) {
-                            staff.displayTranspositionPitch = parseInt(c.innerText);
-                        }
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'TranspositionPitch':
+                    for (let staff of track.staves) {
+                        staff.displayTranspositionPitch = parseInt(c.innerText);
+                    }
+                    break;
             }
         }
     }
@@ -1130,16 +1072,14 @@ export class GpifParser {
     private parseTranspose(track: Track, node: XmlNode): void {
         let octave: number = 0;
         let chromatic: number = 0;
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Chromatic':
-                        chromatic = parseInt(c.innerText);
-                        break;
-                    case 'Octave':
-                        octave = parseInt(c.innerText);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Chromatic':
+                    chromatic = parseInt(c.innerText);
+                    break;
+                case 'Octave':
+                    octave = parseInt(c.innerText);
+                    break;
             }
         }
         for (let staff of track.staves) {
@@ -1148,25 +1088,21 @@ export class GpifParser {
     }
 
     private parseRSE(track: Track, node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'ChannelStrip':
-                        this.parseChannelStrip(track, c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'ChannelStrip':
+                    this.parseChannelStrip(track, c);
+                    break;
             }
         }
     }
 
     private parseChannelStrip(track: Track, node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Parameters':
-                        this.parseChannelStripParameters(track, c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Parameters':
+                    this.parseChannelStripParameters(track, c);
+                    break;
             }
         }
     }
@@ -1185,13 +1121,11 @@ export class GpifParser {
     // <MasterBars>...</MasterBars>
     //
     private parseMasterBarsNode(node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'MasterBar':
-                        this.parseMasterBar(c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'MasterBar':
+                    this.parseMasterBar(c);
+                    break;
             }
         }
     }
@@ -1201,186 +1135,178 @@ export class GpifParser {
         if (this._masterBars.length === 0 && this._hasAnacrusis) {
             masterBar.isAnacrusis = true;
         }
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Time':
-                        let timeParts: string[] = c.innerText.split('/');
-                        masterBar.timeSignatureNumerator = parseInt(timeParts[0]);
-                        masterBar.timeSignatureDenominator = parseInt(timeParts[1]);
-                        break;
-                    case 'FreeTime':
-                        masterBar.isFreeTime = true;
-                        break;
-                    case 'DoubleBar':
-                        masterBar.isDoubleBar = true;
-                        break;
-                    case 'Section':
-                        masterBar.section = new Section();
-                        masterBar.section.marker = c.findChildElement('Letter')!.innerText;
-                        masterBar.section.text = c.findChildElement('Text')!.innerText;
-                        break;
-                    case 'Repeat':
-                        if (c.getAttribute('start').toLowerCase() === 'true') {
-                            masterBar.isRepeatStart = true;
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Time':
+                    let timeParts: string[] = c.innerText.split('/');
+                    masterBar.timeSignatureNumerator = parseInt(timeParts[0]);
+                    masterBar.timeSignatureDenominator = parseInt(timeParts[1]);
+                    break;
+                case 'FreeTime':
+                    masterBar.isFreeTime = true;
+                    break;
+                case 'DoubleBar':
+                    masterBar.isDoubleBar = true;
+                    break;
+                case 'Section':
+                    masterBar.section = new Section();
+                    masterBar.section.marker = c.findChildElement('Letter')!.innerText;
+                    masterBar.section.text = c.findChildElement('Text')!.innerText;
+                    break;
+                case 'Repeat':
+                    if (c.getAttribute('start').toLowerCase() === 'true') {
+                        masterBar.isRepeatStart = true;
+                    }
+                    if (c.getAttribute('end').toLowerCase() === 'true' && c.getAttribute('count')) {
+                        masterBar.repeatCount = parseInt(c.getAttribute('count'));
+                    }
+                    break;
+                case 'AlternateEndings':
+                    let alternateEndings: string[] = c.innerText.split(' ');
+                    let i: number = 0;
+                    for (let k: number = 0; k < alternateEndings.length; k++) {
+                        i = i | (1 << (-1 + parseInt(alternateEndings[k])));
+                    }
+                    masterBar.alternateEndings = i;
+                    break;
+                case 'Bars':
+                    this._barsOfMasterBar.push(c.innerText.split(' '));
+                    break;
+                case 'TripletFeel':
+                    switch (c.innerText) {
+                        case 'NoTripletFeel':
+                            masterBar.tripletFeel = TripletFeel.NoTripletFeel;
+                            break;
+                        case 'Triplet8th':
+                            masterBar.tripletFeel = TripletFeel.Triplet8th;
+                            break;
+                        case 'Triplet16th':
+                            masterBar.tripletFeel = TripletFeel.Triplet16th;
+                            break;
+                        case 'Dotted8th':
+                            masterBar.tripletFeel = TripletFeel.Dotted8th;
+                            break;
+                        case 'Dotted16th':
+                            masterBar.tripletFeel = TripletFeel.Dotted16th;
+                            break;
+                        case 'Scottish8th':
+                            masterBar.tripletFeel = TripletFeel.Scottish8th;
+                            break;
+                        case 'Scottish16th':
+                            masterBar.tripletFeel = TripletFeel.Scottish16th;
+                            break;
+                    }
+                    break;
+                case 'Key':
+                    masterBar.keySignature = parseInt(c.findChildElement('AccidentalCount')!.innerText) as KeySignature;
+                    let mode: XmlNode = c.findChildElement('Mode')!;
+                    if (mode) {
+                        switch (mode.innerText.toLowerCase()) {
+                            case 'major':
+                                masterBar.keySignatureType = KeySignatureType.Major;
+                                break;
+                            case 'minor':
+                                masterBar.keySignatureType = KeySignatureType.Minor;
+                                break;
                         }
-                        if (c.getAttribute('end').toLowerCase() === 'true' && c.getAttribute('count')) {
-                            masterBar.repeatCount = parseInt(c.getAttribute('count'));
-                        }
-                        break;
-                    case 'AlternateEndings':
-                        let alternateEndings: string[] = c.innerText.split(' ');
-                        let i: number = 0;
-                        for (let k: number = 0; k < alternateEndings.length; k++) {
-                            i = i | (1 << (-1 + parseInt(alternateEndings[k])));
-                        }
-                        masterBar.alternateEndings = i;
-                        break;
-                    case 'Bars':
-                        this._barsOfMasterBar.push(c.innerText.split(' '));
-                        break;
-                    case 'TripletFeel':
-                        switch (c.innerText) {
-                            case 'NoTripletFeel':
-                                masterBar.tripletFeel = TripletFeel.NoTripletFeel;
-                                break;
-                            case 'Triplet8th':
-                                masterBar.tripletFeel = TripletFeel.Triplet8th;
-                                break;
-                            case 'Triplet16th':
-                                masterBar.tripletFeel = TripletFeel.Triplet16th;
-                                break;
-                            case 'Dotted8th':
-                                masterBar.tripletFeel = TripletFeel.Dotted8th;
-                                break;
-                            case 'Dotted16th':
-                                masterBar.tripletFeel = TripletFeel.Dotted16th;
-                                break;
-                            case 'Scottish8th':
-                                masterBar.tripletFeel = TripletFeel.Scottish8th;
-                                break;
-                            case 'Scottish16th':
-                                masterBar.tripletFeel = TripletFeel.Scottish16th;
-                                break;
-                        }
-                        break;
-                    case 'Key':
-                        masterBar.keySignature = parseInt(
-                            c.findChildElement('AccidentalCount')!.innerText
-                        ) as KeySignature;
-                        let mode: XmlNode = c.findChildElement('Mode')!;
-                        if (mode) {
-                            switch (mode.innerText.toLowerCase()) {
-                                case 'major':
-                                    masterBar.keySignatureType = KeySignatureType.Major;
-                                    break;
-                                case 'minor':
-                                    masterBar.keySignatureType = KeySignatureType.Minor;
-                                    break;
-                            }
-                        }
-                        break;
-                    case 'Fermatas':
-                        this.parseFermatas(masterBar, c);
-                        break;
-                    case 'XProperties':
-                        this.parseMasterBarXProperties(masterBar, c);
-                        break;
-                    case 'Directions':
-                        this.parseDirections(masterBar, c);
-                        break;
-                }
+                    }
+                    break;
+                case 'Fermatas':
+                    this.parseFermatas(masterBar, c);
+                    break;
+                case 'XProperties':
+                    this.parseMasterBarXProperties(masterBar, c);
+                    break;
+                case 'Directions':
+                    this.parseDirections(masterBar, c);
+                    break;
             }
         }
         this._masterBars.push(masterBar);
     }
 
     private parseDirections(masterBar: MasterBar, node: XmlNode) {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Target':
-                        switch (c.innerText) {
-                            case 'Coda':
-                                masterBar.addDirection(Direction.TargetCoda);
-                                break;
-                            case 'DoubleCoda':
-                                masterBar.addDirection(Direction.TargetDoubleCoda);
-                                break;
-                            case 'Segno':
-                                masterBar.addDirection(Direction.TargetSegno);
-                                break;
-                            case 'SegnoSegno':
-                                masterBar.addDirection(Direction.TargetSegnoSegno);
-                                break;
-                            case 'Fine':
-                                masterBar.addDirection(Direction.TargetFine);
-                                break;
-                        }
-                        break;
-                    case 'Jump':
-                        switch (c.innerText) {
-                            case 'DaCapo':
-                                masterBar.addDirection(Direction.JumpDaCapo);
-                                break;
-                            case 'DaCapoAlCoda':
-                                masterBar.addDirection(Direction.JumpDaCapoAlCoda);
-                                break;
-                            case 'DaCapoAlDoubleCoda':
-                                masterBar.addDirection(Direction.JumpDaCapoAlDoubleCoda);
-                                break;
-                            case 'DaCapoAlFine':
-                                masterBar.addDirection(Direction.JumpDaCapoAlFine);
-                                break;
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Target':
+                    switch (c.innerText) {
+                        case 'Coda':
+                            masterBar.addDirection(Direction.TargetCoda);
+                            break;
+                        case 'DoubleCoda':
+                            masterBar.addDirection(Direction.TargetDoubleCoda);
+                            break;
+                        case 'Segno':
+                            masterBar.addDirection(Direction.TargetSegno);
+                            break;
+                        case 'SegnoSegno':
+                            masterBar.addDirection(Direction.TargetSegnoSegno);
+                            break;
+                        case 'Fine':
+                            masterBar.addDirection(Direction.TargetFine);
+                            break;
+                    }
+                    break;
+                case 'Jump':
+                    switch (c.innerText) {
+                        case 'DaCapo':
+                            masterBar.addDirection(Direction.JumpDaCapo);
+                            break;
+                        case 'DaCapoAlCoda':
+                            masterBar.addDirection(Direction.JumpDaCapoAlCoda);
+                            break;
+                        case 'DaCapoAlDoubleCoda':
+                            masterBar.addDirection(Direction.JumpDaCapoAlDoubleCoda);
+                            break;
+                        case 'DaCapoAlFine':
+                            masterBar.addDirection(Direction.JumpDaCapoAlFine);
+                            break;
 
-                            // Note: no typo on our side, GPIF has wrongly "DaSegno" instead of "DalSegno"
-                            case 'DaSegno':
-                                masterBar.addDirection(Direction.JumpDalSegno);
-                                break;
-                            case 'DaSegnoAlCoda':
-                                masterBar.addDirection(Direction.JumpDalSegnoAlCoda);
-                                break;
-                            case 'DaSegnoAlDoubleCoda':
-                                masterBar.addDirection(Direction.JumpDalSegnoAlDoubleCoda);
-                                break;
-                            case 'DaSegnoAlFine':
-                                masterBar.addDirection(Direction.JumpDalSegnoAlFine);
-                                break;
+                        // Note: no typo on our side, GPIF has wrongly "DaSegno" instead of "DalSegno"
+                        case 'DaSegno':
+                            masterBar.addDirection(Direction.JumpDalSegno);
+                            break;
+                        case 'DaSegnoAlCoda':
+                            masterBar.addDirection(Direction.JumpDalSegnoAlCoda);
+                            break;
+                        case 'DaSegnoAlDoubleCoda':
+                            masterBar.addDirection(Direction.JumpDalSegnoAlDoubleCoda);
+                            break;
+                        case 'DaSegnoAlFine':
+                            masterBar.addDirection(Direction.JumpDalSegnoAlFine);
+                            break;
 
-                            case 'DaSegnoSegno':
-                                masterBar.addDirection(Direction.JumpDalSegnoSegno);
-                                break;
-                            case 'DaSegnoSegnoAlCoda':
-                                masterBar.addDirection(Direction.JumpDalSegnoSegnoAlCoda);
-                                break;
-                            case 'DaSegnoSegnoAlDoubleCoda':
-                                masterBar.addDirection(Direction.JumpDalSegnoSegnoAlDoubleCoda);
-                                break;
-                            case 'DaSegnoSegnoAlFine':
-                                masterBar.addDirection(Direction.JumpDalSegnoSegnoAlFine);
-                                break;
+                        case 'DaSegnoSegno':
+                            masterBar.addDirection(Direction.JumpDalSegnoSegno);
+                            break;
+                        case 'DaSegnoSegnoAlCoda':
+                            masterBar.addDirection(Direction.JumpDalSegnoSegnoAlCoda);
+                            break;
+                        case 'DaSegnoSegnoAlDoubleCoda':
+                            masterBar.addDirection(Direction.JumpDalSegnoSegnoAlDoubleCoda);
+                            break;
+                        case 'DaSegnoSegnoAlFine':
+                            masterBar.addDirection(Direction.JumpDalSegnoSegnoAlFine);
+                            break;
 
-                            case 'DaCoda':
-                                masterBar.addDirection(Direction.JumpDaCoda);
-                                break;
-                            case 'DaDoubleCoda':
-                                masterBar.addDirection(Direction.JumpDaDoubleCoda);
-                                break;
-                        }
-                        break;
-                }
+                        case 'DaCoda':
+                            masterBar.addDirection(Direction.JumpDaCoda);
+                            break;
+                        case 'DaDoubleCoda':
+                            masterBar.addDirection(Direction.JumpDaDoubleCoda);
+                            break;
+                    }
+                    break;
             }
         }
     }
 
     private parseFermatas(masterBar: MasterBar, node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Fermata':
-                        this.parseFermata(masterBar, c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Fermata':
+                    this.parseFermata(masterBar, c);
+                    break;
             }
         }
     }
@@ -1388,34 +1314,32 @@ export class GpifParser {
     private parseFermata(masterBar: MasterBar, node: XmlNode): void {
         let offset: number = 0;
         let fermata: Fermata = new Fermata();
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Type':
-                        switch (c.innerText) {
-                            case 'Short':
-                                fermata.type = FermataType.Short;
-                                break;
-                            case 'Medium':
-                                fermata.type = FermataType.Medium;
-                                break;
-                            case 'Long':
-                                fermata.type = FermataType.Long;
-                                break;
-                        }
-                        break;
-                    case 'Length':
-                        fermata.length = parseFloat(c.innerText);
-                        break;
-                    case 'Offset':
-                        let parts: string[] = c.innerText.split('/');
-                        if (parts.length === 2) {
-                            let numerator: number = parseInt(parts[0]);
-                            let denominator: number = parseInt(parts[1]);
-                            offset = ((numerator / denominator) * MidiUtils.QuarterTime) | 0;
-                        }
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Type':
+                    switch (c.innerText) {
+                        case 'Short':
+                            fermata.type = FermataType.Short;
+                            break;
+                        case 'Medium':
+                            fermata.type = FermataType.Medium;
+                            break;
+                        case 'Long':
+                            fermata.type = FermataType.Long;
+                            break;
+                    }
+                    break;
+                case 'Length':
+                    fermata.length = parseFloat(c.innerText);
+                    break;
+                case 'Offset':
+                    let parts: string[] = c.innerText.split('/');
+                    if (parts.length === 2) {
+                        let numerator: number = parseInt(parts[0]);
+                        let denominator: number = parseInt(parts[1]);
+                        offset = ((numerator / denominator) * MidiUtils.QuarterTime) | 0;
+                    }
+                    break;
             }
         }
         masterBar.addFermata(offset, fermata);
@@ -1425,13 +1349,11 @@ export class GpifParser {
     // <Bars>...</Bars>
     //
     private parseBars(node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Bar':
-                        this.parseBar(c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Bar':
+                    this.parseBar(c);
+                    break;
             }
         }
     }
@@ -1439,64 +1361,62 @@ export class GpifParser {
     private parseBar(node: XmlNode): void {
         let bar: Bar = new Bar();
         let barId: string = node.getAttribute('id');
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Voices':
-                        this._voicesOfBar.set(barId, c.innerText.split(' '));
-                        break;
-                    case 'Clef':
-                        switch (c.innerText) {
-                            case 'Neutral':
-                                bar.clef = Clef.Neutral;
-                                break;
-                            case 'G2':
-                                bar.clef = Clef.G2;
-                                break;
-                            case 'F4':
-                                bar.clef = Clef.F4;
-                                break;
-                            case 'C4':
-                                bar.clef = Clef.C4;
-                                break;
-                            case 'C3':
-                                bar.clef = Clef.C3;
-                                break;
-                        }
-                        break;
-                    case 'Ottavia':
-                        switch (c.innerText) {
-                            case '8va':
-                                bar.clefOttava = Ottavia._8va;
-                                break;
-                            case '15ma':
-                                bar.clefOttava = Ottavia._15ma;
-                                break;
-                            case '8vb':
-                                bar.clefOttava = Ottavia._8vb;
-                                break;
-                            case '15mb':
-                                bar.clefOttava = Ottavia._15mb;
-                                break;
-                        }
-                        break;
-                    case 'SimileMark':
-                        switch (c.innerText) {
-                            case 'Simple':
-                                bar.simileMark = SimileMark.Simple;
-                                break;
-                            case 'FirstOfDouble':
-                                bar.simileMark = SimileMark.FirstOfDouble;
-                                break;
-                            case 'SecondOfDouble':
-                                bar.simileMark = SimileMark.SecondOfDouble;
-                                break;
-                        }
-                        break;
-                    case 'XProperties':
-                        this.parseBarXProperties(c, bar);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Voices':
+                    this._voicesOfBar.set(barId, c.innerText.split(' '));
+                    break;
+                case 'Clef':
+                    switch (c.innerText) {
+                        case 'Neutral':
+                            bar.clef = Clef.Neutral;
+                            break;
+                        case 'G2':
+                            bar.clef = Clef.G2;
+                            break;
+                        case 'F4':
+                            bar.clef = Clef.F4;
+                            break;
+                        case 'C4':
+                            bar.clef = Clef.C4;
+                            break;
+                        case 'C3':
+                            bar.clef = Clef.C3;
+                            break;
+                    }
+                    break;
+                case 'Ottavia':
+                    switch (c.innerText) {
+                        case '8va':
+                            bar.clefOttava = Ottavia._8va;
+                            break;
+                        case '15ma':
+                            bar.clefOttava = Ottavia._15ma;
+                            break;
+                        case '8vb':
+                            bar.clefOttava = Ottavia._8vb;
+                            break;
+                        case '15mb':
+                            bar.clefOttava = Ottavia._15mb;
+                            break;
+                    }
+                    break;
+                case 'SimileMark':
+                    switch (c.innerText) {
+                        case 'Simple':
+                            bar.simileMark = SimileMark.Simple;
+                            break;
+                        case 'FirstOfDouble':
+                            bar.simileMark = SimileMark.FirstOfDouble;
+                            break;
+                        case 'SecondOfDouble':
+                            bar.simileMark = SimileMark.SecondOfDouble;
+                            break;
+                    }
+                    break;
+                case 'XProperties':
+                    this.parseBarXProperties(c, bar);
+                    break;
             }
         }
         this._barsById.set(barId, bar);
@@ -1506,13 +1426,11 @@ export class GpifParser {
     // <Voices>...</Voices>
     //
     private parseVoices(node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Voice':
-                        this.parseVoice(c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Voice':
+                    this.parseVoice(c);
+                    break;
             }
         }
     }
@@ -1520,13 +1438,11 @@ export class GpifParser {
     private parseVoice(node: XmlNode): void {
         let voice: Voice = new Voice();
         let voiceId: string = node.getAttribute('id');
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Beats':
-                        this._beatsOfVoice.set(voiceId, c.innerText.split(' '));
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Beats':
+                    this._beatsOfVoice.set(voiceId, c.innerText.split(' '));
+                    break;
             }
         }
         this._voiceById.set(voiceId, voice);
@@ -1536,13 +1452,11 @@ export class GpifParser {
     // <Beats>...</Beats>
     //
     private parseBeats(node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Beat':
-                        this.parseBeat(c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Beat':
+                    this.parseBeat(c);
+                    break;
             }
         }
     }
@@ -1550,204 +1464,202 @@ export class GpifParser {
     private parseBeat(node: XmlNode): void {
         let beat: Beat = new Beat();
         let beatId: string = node.getAttribute('id');
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Notes':
-                        this._notesOfBeat.set(beatId, c.innerText.split(' '));
-                        break;
-                    case 'Rhythm':
-                        this._rhythmOfBeat.set(beatId, c.getAttribute('ref'));
-                        break;
-                    case 'Fadding':
-                        switch (c.innerText) {
-                            case 'FadeIn':
-                                beat.fade = FadeType.FadeIn;
-                                break;
-                            case 'FadeOut':
-                                beat.fade = FadeType.FadeOut;
-                                break;
-                            case 'VolumeSwell':
-                                beat.fade = FadeType.VolumeSwell;
-                                break;
-                        }
-                        break;
-                    case 'Tremolo':
-                        switch (c.innerText) {
-                            case '1/2':
-                                beat.tremoloSpeed = Duration.Eighth;
-                                break;
-                            case '1/4':
-                                beat.tremoloSpeed = Duration.Sixteenth;
-                                break;
-                            case '1/8':
-                                beat.tremoloSpeed = Duration.ThirtySecond;
-                                break;
-                        }
-                        break;
-                    case 'Chord':
-                        beat.chordId = c.innerText;
-                        break;
-                    case 'Hairpin':
-                        switch (c.innerText) {
-                            case 'Crescendo':
-                                beat.crescendo = CrescendoType.Crescendo;
-                                break;
-                            case 'Decrescendo':
-                                beat.crescendo = CrescendoType.Decrescendo;
-                                break;
-                        }
-                        break;
-                    case 'Arpeggio':
-                        if (c.innerText === 'Up') {
-                            beat.brushType = BrushType.ArpeggioUp;
-                        } else {
-                            beat.brushType = BrushType.ArpeggioDown;
-                        }
-                        break;
-                    case 'Properties':
-                        this.parseBeatProperties(c, beat);
-                        break;
-                    case 'XProperties':
-                        this.parseBeatXProperties(c, beat);
-                        break;
-                    case 'FreeText':
-                        beat.text = c.innerText;
-                        break;
-                    case 'TransposedPitchStemOrientation':
-                        switch (c.innerText) {
-                            case 'Upward':
-                                beat.preferredBeamDirection = BeamDirection.Up;
-                                break;
-                            case 'Downward':
-                                beat.preferredBeamDirection = BeamDirection.Down;
-                                break;
-                        }
-                        break;
-                    case 'Dynamic':
-                        switch (c.innerText) {
-                            case 'PPP':
-                                beat.dynamics = DynamicValue.PPP;
-                                break;
-                            case 'PP':
-                                beat.dynamics = DynamicValue.PP;
-                                break;
-                            case 'P':
-                                beat.dynamics = DynamicValue.P;
-                                break;
-                            case 'MP':
-                                beat.dynamics = DynamicValue.MP;
-                                break;
-                            case 'MF':
-                                beat.dynamics = DynamicValue.MF;
-                                break;
-                            case 'F':
-                                beat.dynamics = DynamicValue.F;
-                                break;
-                            case 'FF':
-                                beat.dynamics = DynamicValue.FF;
-                                break;
-                            case 'FFF':
-                                beat.dynamics = DynamicValue.FFF;
-                                break;
-                        }
-                        break;
-                    case 'GraceNotes':
-                        switch (c.innerText) {
-                            case 'OnBeat':
-                                beat.graceType = GraceType.OnBeat;
-                                break;
-                            case 'BeforeBeat':
-                                beat.graceType = GraceType.BeforeBeat;
-                                break;
-                        }
-                        break;
-                    case 'Legato':
-                        if (c.getAttribute('origin') === 'true') {
-                            beat.isLegatoOrigin = true;
-                        }
-                        break;
-                    case 'Whammy':
-                        let whammyOrigin: BendPoint = new BendPoint(0, 0);
-                        whammyOrigin.value = this.toBendValue(parseFloat(c.getAttribute('originValue')));
-                        whammyOrigin.offset = this.toBendOffset(parseFloat(c.getAttribute('originOffset')));
-                        beat.addWhammyBarPoint(whammyOrigin);
-                        let whammyMiddle1: BendPoint = new BendPoint(0, 0);
-                        whammyMiddle1.value = this.toBendValue(parseFloat(c.getAttribute('middleValue')));
-                        whammyMiddle1.offset = this.toBendOffset(parseFloat(c.getAttribute('middleOffset1')));
-                        beat.addWhammyBarPoint(whammyMiddle1);
-                        let whammyMiddle2: BendPoint = new BendPoint(0, 0);
-                        whammyMiddle2.value = this.toBendValue(parseFloat(c.getAttribute('middleValue')));
-                        whammyMiddle2.offset = this.toBendOffset(parseFloat(c.getAttribute('middleOffset2')));
-                        beat.addWhammyBarPoint(whammyMiddle2);
-                        let whammyDestination: BendPoint = new BendPoint(0, 0);
-                        whammyDestination.value = this.toBendValue(parseFloat(c.getAttribute('destinationValue')));
-                        whammyDestination.offset = this.toBendOffset(parseFloat(c.getAttribute('destinationOffset')));
-                        beat.addWhammyBarPoint(whammyDestination);
-                        break;
-                    case 'Ottavia':
-                        switch (c.innerText) {
-                            case '8va':
-                                beat.ottava = Ottavia._8va;
-                                break;
-                            case '8vb':
-                                beat.ottava = Ottavia._8vb;
-                                break;
-                            case '15ma':
-                                beat.ottava = Ottavia._15ma;
-                                break;
-                            case '15mb':
-                                beat.ottava = Ottavia._15mb;
-                                break;
-                        }
-                        break;
-                    case 'Lyrics':
-                        beat.lyrics = this.parseBeatLyrics(c);
-                        this._skipApplyLyrics = true;
-                        break;
-                    case 'Slashed':
-                        beat.slashed = true;
-                        break;
-                    case 'DeadSlapped':
-                        beat.deadSlapped = true;
-                        break;
-                    case 'Golpe':
-                        switch (c.innerText) {
-                            case 'Finger':
-                                beat.golpe = GolpeType.Finger;
-                                break;
-                            case 'Thumb':
-                                beat.golpe = GolpeType.Thumb;
-                                break;
-                        }
-                        break;
-                    case 'Wah':
-                        switch (c.innerText) {
-                            case 'Open':
-                                beat.wahPedal = WahPedal.Open;
-                                break;
-                            case 'Closed':
-                                beat.wahPedal = WahPedal.Closed;
-                                break;
-                        }
-                        break;
-                    case 'UserTransposedPitchStemOrientation':
-                        switch (c.innerText) {
-                            case 'Downward':
-                                beat.preferredBeamDirection = BeamDirection.Down;
-                                break;
-                            case 'Upward':
-                                beat.preferredBeamDirection = BeamDirection.Up;
-                                break;
-                        }
-                        break;
-                    case 'Timer':
-                        beat.showTimer = true;
-                        if(c.innerText.length > 0) {
-                            beat.timer = parseInt(c.innerText);
-                        }
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Notes':
+                    this._notesOfBeat.set(beatId, c.innerText.split(' '));
+                    break;
+                case 'Rhythm':
+                    this._rhythmOfBeat.set(beatId, c.getAttribute('ref'));
+                    break;
+                case 'Fadding':
+                    switch (c.innerText) {
+                        case 'FadeIn':
+                            beat.fade = FadeType.FadeIn;
+                            break;
+                        case 'FadeOut':
+                            beat.fade = FadeType.FadeOut;
+                            break;
+                        case 'VolumeSwell':
+                            beat.fade = FadeType.VolumeSwell;
+                            break;
+                    }
+                    break;
+                case 'Tremolo':
+                    switch (c.innerText) {
+                        case '1/2':
+                            beat.tremoloSpeed = Duration.Eighth;
+                            break;
+                        case '1/4':
+                            beat.tremoloSpeed = Duration.Sixteenth;
+                            break;
+                        case '1/8':
+                            beat.tremoloSpeed = Duration.ThirtySecond;
+                            break;
+                    }
+                    break;
+                case 'Chord':
+                    beat.chordId = c.innerText;
+                    break;
+                case 'Hairpin':
+                    switch (c.innerText) {
+                        case 'Crescendo':
+                            beat.crescendo = CrescendoType.Crescendo;
+                            break;
+                        case 'Decrescendo':
+                            beat.crescendo = CrescendoType.Decrescendo;
+                            break;
+                    }
+                    break;
+                case 'Arpeggio':
+                    if (c.innerText === 'Up') {
+                        beat.brushType = BrushType.ArpeggioUp;
+                    } else {
+                        beat.brushType = BrushType.ArpeggioDown;
+                    }
+                    break;
+                case 'Properties':
+                    this.parseBeatProperties(c, beat);
+                    break;
+                case 'XProperties':
+                    this.parseBeatXProperties(c, beat);
+                    break;
+                case 'FreeText':
+                    beat.text = c.innerText;
+                    break;
+                case 'TransposedPitchStemOrientation':
+                    switch (c.innerText) {
+                        case 'Upward':
+                            beat.preferredBeamDirection = BeamDirection.Up;
+                            break;
+                        case 'Downward':
+                            beat.preferredBeamDirection = BeamDirection.Down;
+                            break;
+                    }
+                    break;
+                case 'Dynamic':
+                    switch (c.innerText) {
+                        case 'PPP':
+                            beat.dynamics = DynamicValue.PPP;
+                            break;
+                        case 'PP':
+                            beat.dynamics = DynamicValue.PP;
+                            break;
+                        case 'P':
+                            beat.dynamics = DynamicValue.P;
+                            break;
+                        case 'MP':
+                            beat.dynamics = DynamicValue.MP;
+                            break;
+                        case 'MF':
+                            beat.dynamics = DynamicValue.MF;
+                            break;
+                        case 'F':
+                            beat.dynamics = DynamicValue.F;
+                            break;
+                        case 'FF':
+                            beat.dynamics = DynamicValue.FF;
+                            break;
+                        case 'FFF':
+                            beat.dynamics = DynamicValue.FFF;
+                            break;
+                    }
+                    break;
+                case 'GraceNotes':
+                    switch (c.innerText) {
+                        case 'OnBeat':
+                            beat.graceType = GraceType.OnBeat;
+                            break;
+                        case 'BeforeBeat':
+                            beat.graceType = GraceType.BeforeBeat;
+                            break;
+                    }
+                    break;
+                case 'Legato':
+                    if (c.getAttribute('origin') === 'true') {
+                        beat.isLegatoOrigin = true;
+                    }
+                    break;
+                case 'Whammy':
+                    let whammyOrigin: BendPoint = new BendPoint(0, 0);
+                    whammyOrigin.value = this.toBendValue(parseFloat(c.getAttribute('originValue')));
+                    whammyOrigin.offset = this.toBendOffset(parseFloat(c.getAttribute('originOffset')));
+                    beat.addWhammyBarPoint(whammyOrigin);
+                    let whammyMiddle1: BendPoint = new BendPoint(0, 0);
+                    whammyMiddle1.value = this.toBendValue(parseFloat(c.getAttribute('middleValue')));
+                    whammyMiddle1.offset = this.toBendOffset(parseFloat(c.getAttribute('middleOffset1')));
+                    beat.addWhammyBarPoint(whammyMiddle1);
+                    let whammyMiddle2: BendPoint = new BendPoint(0, 0);
+                    whammyMiddle2.value = this.toBendValue(parseFloat(c.getAttribute('middleValue')));
+                    whammyMiddle2.offset = this.toBendOffset(parseFloat(c.getAttribute('middleOffset2')));
+                    beat.addWhammyBarPoint(whammyMiddle2);
+                    let whammyDestination: BendPoint = new BendPoint(0, 0);
+                    whammyDestination.value = this.toBendValue(parseFloat(c.getAttribute('destinationValue')));
+                    whammyDestination.offset = this.toBendOffset(parseFloat(c.getAttribute('destinationOffset')));
+                    beat.addWhammyBarPoint(whammyDestination);
+                    break;
+                case 'Ottavia':
+                    switch (c.innerText) {
+                        case '8va':
+                            beat.ottava = Ottavia._8va;
+                            break;
+                        case '8vb':
+                            beat.ottava = Ottavia._8vb;
+                            break;
+                        case '15ma':
+                            beat.ottava = Ottavia._15ma;
+                            break;
+                        case '15mb':
+                            beat.ottava = Ottavia._15mb;
+                            break;
+                    }
+                    break;
+                case 'Lyrics':
+                    beat.lyrics = this.parseBeatLyrics(c);
+                    this._skipApplyLyrics = true;
+                    break;
+                case 'Slashed':
+                    beat.slashed = true;
+                    break;
+                case 'DeadSlapped':
+                    beat.deadSlapped = true;
+                    break;
+                case 'Golpe':
+                    switch (c.innerText) {
+                        case 'Finger':
+                            beat.golpe = GolpeType.Finger;
+                            break;
+                        case 'Thumb':
+                            beat.golpe = GolpeType.Thumb;
+                            break;
+                    }
+                    break;
+                case 'Wah':
+                    switch (c.innerText) {
+                        case 'Open':
+                            beat.wahPedal = WahPedal.Open;
+                            break;
+                        case 'Closed':
+                            beat.wahPedal = WahPedal.Closed;
+                            break;
+                    }
+                    break;
+                case 'UserTransposedPitchStemOrientation':
+                    switch (c.innerText) {
+                        case 'Downward':
+                            beat.preferredBeamDirection = BeamDirection.Down;
+                            break;
+                        case 'Upward':
+                            beat.preferredBeamDirection = BeamDirection.Up;
+                            break;
+                    }
+                    break;
+                case 'Timer':
+                    beat.showTimer = true;
+                    if (c.innerText.length > 0) {
+                        beat.timer = parseInt(c.innerText);
+                    }
+                    break;
             }
         }
         this._beatById.set(beatId, beat);
@@ -1756,13 +1668,11 @@ export class GpifParser {
     private parseBeatLyrics(node: XmlNode): string[] {
         const lines: string[] = [];
 
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Line':
-                        lines.push(c.innerText);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Line':
+                    lines.push(c.innerText);
+                    break;
             }
         }
 
@@ -1770,80 +1680,74 @@ export class GpifParser {
     }
 
     private parseBeatXProperties(node: XmlNode, beat: Beat): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'XProperty':
-                        let id: string = c.getAttribute('id');
-                        let value: number = 0;
-                        switch (id) {
-                            case '1124204546':
-                                value = parseInt(c.findChildElement('Int')!.innerText);
-                                switch (value) {
-                                    case 1:
-                                        beat.beamingMode = BeatBeamingMode.ForceMergeWithNext;
-                                        break;
-                                    case 2:
-                                        beat.beamingMode = BeatBeamingMode.ForceSplitToNext;
-                                        break;
-                                }
-                                break;
-                            case '1124204552':
-                                value = parseInt(c.findChildElement('Int')!.innerText);
-                                switch (value) {
-                                    case 1:
-                                        if (beat.beamingMode !== BeatBeamingMode.ForceSplitToNext) {
-                                            beat.beamingMode = BeatBeamingMode.ForceSplitOnSecondaryToNext;
-                                        }
-                                        break;
-                                }
-                                break;
-                            case '1124204545':
-                                value = parseInt(c.findChildElement('Int')!.innerText);
-                                beat.invertBeamDirection = value === 1;
-                                break;
-                            case '687935489':
-                                value = parseInt(c.findChildElement('Int')!.innerText);
-                                beat.brushDuration = value;
-                                break;
-                        }
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'XProperty':
+                    let id: string = c.getAttribute('id');
+                    let value: number = 0;
+                    switch (id) {
+                        case '1124204546':
+                            value = parseInt(c.findChildElement('Int')!.innerText);
+                            switch (value) {
+                                case 1:
+                                    beat.beamingMode = BeatBeamingMode.ForceMergeWithNext;
+                                    break;
+                                case 2:
+                                    beat.beamingMode = BeatBeamingMode.ForceSplitToNext;
+                                    break;
+                            }
+                            break;
+                        case '1124204552':
+                            value = parseInt(c.findChildElement('Int')!.innerText);
+                            switch (value) {
+                                case 1:
+                                    if (beat.beamingMode !== BeatBeamingMode.ForceSplitToNext) {
+                                        beat.beamingMode = BeatBeamingMode.ForceSplitOnSecondaryToNext;
+                                    }
+                                    break;
+                            }
+                            break;
+                        case '1124204545':
+                            value = parseInt(c.findChildElement('Int')!.innerText);
+                            beat.invertBeamDirection = value === 1;
+                            break;
+                        case '687935489':
+                            value = parseInt(c.findChildElement('Int')!.innerText);
+                            beat.brushDuration = value;
+                            break;
+                    }
+                    break;
             }
         }
     }
 
     private parseBarXProperties(node: XmlNode, bar: Bar) {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'XProperty':
-                        const id: string = c.getAttribute('id');
-                        switch (id) {
-                            case '1124139520':
-                                const childNode = c.findChildElement('Double') ?? c.findChildElement('Float');
-                                bar.displayScale = parseFloat(childNode!.innerText);
-                                break;
-                        }
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'XProperty':
+                    const id: string = c.getAttribute('id');
+                    switch (id) {
+                        case '1124139520':
+                            const childNode = c.findChildElement('Double') ?? c.findChildElement('Float');
+                            bar.displayScale = parseFloat(childNode!.innerText);
+                            break;
+                    }
+                    break;
             }
         }
     }
 
     private parseMasterBarXProperties(masterBar: MasterBar, node: XmlNode) {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'XProperty':
-                        const id: string = c.getAttribute('id');
-                        switch (id) {
-                            case '1124073984':
-                                masterBar.displayScale = parseFloat(c.findChildElement('Double')!.innerText);
-                                break;
-                        }
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'XProperty':
+                    const id: string = c.getAttribute('id');
+                    switch (id) {
+                        case '1124073984':
+                            masterBar.displayScale = parseFloat(c.findChildElement('Double')!.innerText);
+                            break;
+                    }
+                    break;
             }
         }
     }
@@ -1855,173 +1759,161 @@ export class GpifParser {
         let whammyMiddleOffset1: number | null = null;
         let whammyMiddleOffset2: number | null = null;
         let whammyDestination: BendPoint | null = null;
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Property':
-                        let name: string = c.getAttribute('name');
-                        switch (name) {
-                            case 'Brush':
-                                if (c.findChildElement('Direction')!.innerText === 'Up') {
-                                    beat.brushType = BrushType.BrushUp;
-                                } else {
-                                    beat.brushType = BrushType.BrushDown;
-                                }
-                                break;
-                            case 'PickStroke':
-                                if (c.findChildElement('Direction')!.innerText === 'Up') {
-                                    beat.pickStroke = PickStroke.Up;
-                                } else {
-                                    beat.pickStroke = PickStroke.Down;
-                                }
-                                break;
-                            case 'Slapped':
-                                if (c.findChildElement('Enable')) {
-                                    beat.slap = true;
-                                }
-                                break;
-                            case 'Popped':
-                                if (c.findChildElement('Enable')) {
-                                    beat.pop = true;
-                                }
-                                break;
-                            case 'VibratoWTremBar':
-                                switch (c.findChildElement('Strength')!.innerText) {
-                                    case 'Wide':
-                                        beat.vibrato = VibratoType.Wide;
-                                        break;
-                                    case 'Slight':
-                                        beat.vibrato = VibratoType.Slight;
-                                        break;
-                                }
-                                break;
-                            case 'WhammyBar':
-                                isWhammy = true;
-                                break;
-                            case 'WhammyBarExtend':
-                                // not clear what this is used for
-                                break;
-                            case 'WhammyBarOriginValue':
-                                if (!whammyOrigin) {
-                                    whammyOrigin = new BendPoint(0, 0);
-                                }
-                                whammyOrigin.value = this.toBendValue(
-                                    parseFloat(c.findChildElement('Float')!.innerText)
-                                );
-                                break;
-                            case 'WhammyBarOriginOffset':
-                                if (!whammyOrigin) {
-                                    whammyOrigin = new BendPoint(0, 0);
-                                }
-                                whammyOrigin.offset = this.toBendOffset(
-                                    parseFloat(c.findChildElement('Float')!.innerText)
-                                );
-                                break;
-                            case 'WhammyBarMiddleValue':
-                                whammyMiddleValue = this.toBendValue(
-                                    parseFloat(c.findChildElement('Float')!.innerText)
-                                );
-                                break;
-                            case 'WhammyBarMiddleOffset1':
-                                whammyMiddleOffset1 = this.toBendOffset(
-                                    parseFloat(c.findChildElement('Float')!.innerText)
-                                );
-                                break;
-                            case 'WhammyBarMiddleOffset2':
-                                whammyMiddleOffset2 = this.toBendOffset(
-                                    parseFloat(c.findChildElement('Float')!.innerText)
-                                );
-                                break;
-                            case 'WhammyBarDestinationValue':
-                                if (!whammyDestination) {
-                                    whammyDestination = new BendPoint(BendPoint.MaxPosition, 0);
-                                }
-                                whammyDestination.value = this.toBendValue(
-                                    parseFloat(c.findChildElement('Float')!.innerText)
-                                );
-                                break;
-                            case 'WhammyBarDestinationOffset':
-                                if (!whammyDestination) {
-                                    whammyDestination = new BendPoint(0, 0);
-                                }
-                                whammyDestination.offset = this.toBendOffset(
-                                    parseFloat(c.findChildElement('Float')!.innerText)
-                                );
-                                break;
-                            case 'BarreFret':
-                                beat.barreFret = parseInt(c.findChildElement('Fret')!.innerText);
-                                break;
-                            case 'BarreString':
-                                switch (c.findChildElement('String')!.innerText) {
-                                    case '0':
-                                        beat.barreShape = BarreShape.Full;
-                                        break;
-                                    case '1':
-                                        beat.barreShape = BarreShape.Half;
-                                        break;
-                                }
-                                break;
-                            case 'Rasgueado':
-                                switch (c.findChildElement('Rasgueado')!.innerText) {
-                                    case 'ii_1':
-                                        beat.rasgueado = Rasgueado.Ii;
-                                        break;
-                                    case 'mi_1':
-                                        beat.rasgueado = Rasgueado.Mi;
-                                        break;
-                                    case 'mii_1':
-                                        beat.rasgueado = Rasgueado.MiiTriplet;
-                                        break;
-                                    case 'mii_2':
-                                        beat.rasgueado = Rasgueado.MiiAnapaest;
-                                        break;
-                                    case 'pmp_1':
-                                        beat.rasgueado = Rasgueado.PmpTriplet;
-                                        break;
-                                    case 'pmp_2':
-                                        beat.rasgueado = Rasgueado.PmpAnapaest;
-                                        break;
-                                    case 'pei_1':
-                                        beat.rasgueado = Rasgueado.PeiTriplet;
-                                        break;
-                                    case 'pei_2':
-                                        beat.rasgueado = Rasgueado.PeiAnapaest;
-                                        break;
-                                    case 'pai_1':
-                                        beat.rasgueado = Rasgueado.PaiTriplet;
-                                        break;
-                                    case 'pai_2':
-                                        beat.rasgueado = Rasgueado.PaiAnapaest;
-                                        break;
-                                    case 'ami_1':
-                                        beat.rasgueado = Rasgueado.AmiTriplet;
-                                        break;
-                                    case 'ami_2':
-                                        beat.rasgueado = Rasgueado.AmiAnapaest;
-                                        break;
-                                    case 'ppp_1':
-                                        beat.rasgueado = Rasgueado.Ppp;
-                                        break;
-                                    case 'amii_1':
-                                        beat.rasgueado = Rasgueado.Amii;
-                                        break;
-                                    case 'amip_1':
-                                        beat.rasgueado = Rasgueado.Amip;
-                                        break;
-                                    case 'eami_1':
-                                        beat.rasgueado = Rasgueado.Eami;
-                                        break;
-                                    case 'eamii_1':
-                                        beat.rasgueado = Rasgueado.Eamii;
-                                        break;
-                                    case 'peami_1':
-                                        beat.rasgueado = Rasgueado.Peami;
-                                        break;
-                                }
-                                break;
-                        }
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Property':
+                    let name: string = c.getAttribute('name');
+                    switch (name) {
+                        case 'Brush':
+                            if (c.findChildElement('Direction')!.innerText === 'Up') {
+                                beat.brushType = BrushType.BrushUp;
+                            } else {
+                                beat.brushType = BrushType.BrushDown;
+                            }
+                            break;
+                        case 'PickStroke':
+                            if (c.findChildElement('Direction')!.innerText === 'Up') {
+                                beat.pickStroke = PickStroke.Up;
+                            } else {
+                                beat.pickStroke = PickStroke.Down;
+                            }
+                            break;
+                        case 'Slapped':
+                            if (c.findChildElement('Enable')) {
+                                beat.slap = true;
+                            }
+                            break;
+                        case 'Popped':
+                            if (c.findChildElement('Enable')) {
+                                beat.pop = true;
+                            }
+                            break;
+                        case 'VibratoWTremBar':
+                            switch (c.findChildElement('Strength')!.innerText) {
+                                case 'Wide':
+                                    beat.vibrato = VibratoType.Wide;
+                                    break;
+                                case 'Slight':
+                                    beat.vibrato = VibratoType.Slight;
+                                    break;
+                            }
+                            break;
+                        case 'WhammyBar':
+                            isWhammy = true;
+                            break;
+                        case 'WhammyBarExtend':
+                            // not clear what this is used for
+                            break;
+                        case 'WhammyBarOriginValue':
+                            if (!whammyOrigin) {
+                                whammyOrigin = new BendPoint(0, 0);
+                            }
+                            whammyOrigin.value = this.toBendValue(parseFloat(c.findChildElement('Float')!.innerText));
+                            break;
+                        case 'WhammyBarOriginOffset':
+                            if (!whammyOrigin) {
+                                whammyOrigin = new BendPoint(0, 0);
+                            }
+                            whammyOrigin.offset = this.toBendOffset(parseFloat(c.findChildElement('Float')!.innerText));
+                            break;
+                        case 'WhammyBarMiddleValue':
+                            whammyMiddleValue = this.toBendValue(parseFloat(c.findChildElement('Float')!.innerText));
+                            break;
+                        case 'WhammyBarMiddleOffset1':
+                            whammyMiddleOffset1 = this.toBendOffset(parseFloat(c.findChildElement('Float')!.innerText));
+                            break;
+                        case 'WhammyBarMiddleOffset2':
+                            whammyMiddleOffset2 = this.toBendOffset(parseFloat(c.findChildElement('Float')!.innerText));
+                            break;
+                        case 'WhammyBarDestinationValue':
+                            if (!whammyDestination) {
+                                whammyDestination = new BendPoint(BendPoint.MaxPosition, 0);
+                            }
+                            whammyDestination.value = this.toBendValue(
+                                parseFloat(c.findChildElement('Float')!.innerText)
+                            );
+                            break;
+                        case 'WhammyBarDestinationOffset':
+                            if (!whammyDestination) {
+                                whammyDestination = new BendPoint(0, 0);
+                            }
+                            whammyDestination.offset = this.toBendOffset(
+                                parseFloat(c.findChildElement('Float')!.innerText)
+                            );
+                            break;
+                        case 'BarreFret':
+                            beat.barreFret = parseInt(c.findChildElement('Fret')!.innerText);
+                            break;
+                        case 'BarreString':
+                            switch (c.findChildElement('String')!.innerText) {
+                                case '0':
+                                    beat.barreShape = BarreShape.Full;
+                                    break;
+                                case '1':
+                                    beat.barreShape = BarreShape.Half;
+                                    break;
+                            }
+                            break;
+                        case 'Rasgueado':
+                            switch (c.findChildElement('Rasgueado')!.innerText) {
+                                case 'ii_1':
+                                    beat.rasgueado = Rasgueado.Ii;
+                                    break;
+                                case 'mi_1':
+                                    beat.rasgueado = Rasgueado.Mi;
+                                    break;
+                                case 'mii_1':
+                                    beat.rasgueado = Rasgueado.MiiTriplet;
+                                    break;
+                                case 'mii_2':
+                                    beat.rasgueado = Rasgueado.MiiAnapaest;
+                                    break;
+                                case 'pmp_1':
+                                    beat.rasgueado = Rasgueado.PmpTriplet;
+                                    break;
+                                case 'pmp_2':
+                                    beat.rasgueado = Rasgueado.PmpAnapaest;
+                                    break;
+                                case 'pei_1':
+                                    beat.rasgueado = Rasgueado.PeiTriplet;
+                                    break;
+                                case 'pei_2':
+                                    beat.rasgueado = Rasgueado.PeiAnapaest;
+                                    break;
+                                case 'pai_1':
+                                    beat.rasgueado = Rasgueado.PaiTriplet;
+                                    break;
+                                case 'pai_2':
+                                    beat.rasgueado = Rasgueado.PaiAnapaest;
+                                    break;
+                                case 'ami_1':
+                                    beat.rasgueado = Rasgueado.AmiTriplet;
+                                    break;
+                                case 'ami_2':
+                                    beat.rasgueado = Rasgueado.AmiAnapaest;
+                                    break;
+                                case 'ppp_1':
+                                    beat.rasgueado = Rasgueado.Ppp;
+                                    break;
+                                case 'amii_1':
+                                    beat.rasgueado = Rasgueado.Amii;
+                                    break;
+                                case 'amip_1':
+                                    beat.rasgueado = Rasgueado.Amip;
+                                    break;
+                                case 'eami_1':
+                                    beat.rasgueado = Rasgueado.Eami;
+                                    break;
+                                case 'eamii_1':
+                                    beat.rasgueado = Rasgueado.Eamii;
+                                    break;
+                                case 'peami_1':
+                                    beat.rasgueado = Rasgueado.Peami;
+                                    break;
+                            }
+                            break;
+                    }
+                    break;
             }
         }
         if (isWhammy) {
@@ -2049,13 +1941,11 @@ export class GpifParser {
     // <Notes>...</Notes>
     //
     private parseNotes(node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Note':
-                        this.parseNote(c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Note':
+                    this.parseNote(c);
+                    break;
             }
         }
     }
@@ -2063,112 +1953,110 @@ export class GpifParser {
     private parseNote(node: XmlNode): void {
         let note: Note = new Note();
         let noteId: string = node.getAttribute('id');
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Properties':
-                        this.parseNoteProperties(c, note, noteId);
-                        break;
-                    case 'AntiAccent':
-                        if (c.innerText.toLowerCase() === 'normal') {
-                            note.isGhost = true;
-                        }
-                        break;
-                    case 'LetRing':
-                        note.isLetRing = true;
-                        break;
-                    case 'Trill':
-                        note.trillValue = parseInt(c.innerText);
-                        note.trillSpeed = Duration.Sixteenth;
-                        break;
-                    case 'Accent':
-                        let accentFlags: number = parseInt(c.innerText);
-                        if ((accentFlags & 0x01) !== 0) {
-                            note.isStaccato = true;
-                        }
-                        if ((accentFlags & 0x04) !== 0) {
-                            note.accentuated = AccentuationType.Heavy;
-                        }
-                        if ((accentFlags & 0x08) !== 0) {
-                            note.accentuated = AccentuationType.Normal;
-                        }
-                        if ((accentFlags & 0x10) !== 0) {
-                            note.accentuated = AccentuationType.Tenuto;
-                        }
-                        break;
-                    case 'Tie':
-                        if (c.getAttribute('destination').toLowerCase() === 'true') {
-                            note.isTieDestination = true;
-                        }
-                        break;
-                    case 'Vibrato':
-                        switch (c.innerText) {
-                            case 'Slight':
-                                note.vibrato = VibratoType.Slight;
-                                break;
-                            case 'Wide':
-                                note.vibrato = VibratoType.Wide;
-                                break;
-                        }
-                        break;
-                    case 'LeftFingering':
-                        switch (c.innerText) {
-                            case 'P':
-                                note.leftHandFinger = Fingers.Thumb;
-                                break;
-                            case 'I':
-                                note.leftHandFinger = Fingers.IndexFinger;
-                                break;
-                            case 'M':
-                                note.leftHandFinger = Fingers.MiddleFinger;
-                                break;
-                            case 'A':
-                                note.leftHandFinger = Fingers.AnnularFinger;
-                                break;
-                            case 'C':
-                                note.leftHandFinger = Fingers.LittleFinger;
-                                break;
-                        }
-                        break;
-                    case 'RightFingering':
-                        switch (c.innerText) {
-                            case 'P':
-                                note.rightHandFinger = Fingers.Thumb;
-                                break;
-                            case 'I':
-                                note.rightHandFinger = Fingers.IndexFinger;
-                                break;
-                            case 'M':
-                                note.rightHandFinger = Fingers.MiddleFinger;
-                                break;
-                            case 'A':
-                                note.rightHandFinger = Fingers.AnnularFinger;
-                                break;
-                            case 'C':
-                                note.rightHandFinger = Fingers.LittleFinger;
-                                break;
-                        }
-                        break;
-                    case 'InstrumentArticulation':
-                        note.percussionArticulation = parseInt(c.innerText);
-                        break;
-                    case 'Ornament':
-                        switch (c.innerText) {
-                            case 'Turn':
-                                note.ornament = NoteOrnament.Turn;
-                                break;
-                            case 'InvertedTurn':
-                                note.ornament = NoteOrnament.InvertedTurn;
-                                break;
-                            case 'UpperMordent':
-                                note.ornament = NoteOrnament.UpperMordent;
-                                break;
-                            case 'LowerMordent':
-                                note.ornament = NoteOrnament.LowerMordent;
-                                break;
-                        }
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Properties':
+                    this.parseNoteProperties(c, note, noteId);
+                    break;
+                case 'AntiAccent':
+                    if (c.innerText.toLowerCase() === 'normal') {
+                        note.isGhost = true;
+                    }
+                    break;
+                case 'LetRing':
+                    note.isLetRing = true;
+                    break;
+                case 'Trill':
+                    note.trillValue = parseInt(c.innerText);
+                    note.trillSpeed = Duration.Sixteenth;
+                    break;
+                case 'Accent':
+                    let accentFlags: number = parseInt(c.innerText);
+                    if ((accentFlags & 0x01) !== 0) {
+                        note.isStaccato = true;
+                    }
+                    if ((accentFlags & 0x04) !== 0) {
+                        note.accentuated = AccentuationType.Heavy;
+                    }
+                    if ((accentFlags & 0x08) !== 0) {
+                        note.accentuated = AccentuationType.Normal;
+                    }
+                    if ((accentFlags & 0x10) !== 0) {
+                        note.accentuated = AccentuationType.Tenuto;
+                    }
+                    break;
+                case 'Tie':
+                    if (c.getAttribute('destination').toLowerCase() === 'true') {
+                        note.isTieDestination = true;
+                    }
+                    break;
+                case 'Vibrato':
+                    switch (c.innerText) {
+                        case 'Slight':
+                            note.vibrato = VibratoType.Slight;
+                            break;
+                        case 'Wide':
+                            note.vibrato = VibratoType.Wide;
+                            break;
+                    }
+                    break;
+                case 'LeftFingering':
+                    switch (c.innerText) {
+                        case 'P':
+                            note.leftHandFinger = Fingers.Thumb;
+                            break;
+                        case 'I':
+                            note.leftHandFinger = Fingers.IndexFinger;
+                            break;
+                        case 'M':
+                            note.leftHandFinger = Fingers.MiddleFinger;
+                            break;
+                        case 'A':
+                            note.leftHandFinger = Fingers.AnnularFinger;
+                            break;
+                        case 'C':
+                            note.leftHandFinger = Fingers.LittleFinger;
+                            break;
+                    }
+                    break;
+                case 'RightFingering':
+                    switch (c.innerText) {
+                        case 'P':
+                            note.rightHandFinger = Fingers.Thumb;
+                            break;
+                        case 'I':
+                            note.rightHandFinger = Fingers.IndexFinger;
+                            break;
+                        case 'M':
+                            note.rightHandFinger = Fingers.MiddleFinger;
+                            break;
+                        case 'A':
+                            note.rightHandFinger = Fingers.AnnularFinger;
+                            break;
+                        case 'C':
+                            note.rightHandFinger = Fingers.LittleFinger;
+                            break;
+                    }
+                    break;
+                case 'InstrumentArticulation':
+                    note.percussionArticulation = parseInt(c.innerText);
+                    break;
+                case 'Ornament':
+                    switch (c.innerText) {
+                        case 'Turn':
+                            note.ornament = NoteOrnament.Turn;
+                            break;
+                        case 'InvertedTurn':
+                            note.ornament = NoteOrnament.InvertedTurn;
+                            break;
+                        case 'UpperMordent':
+                            note.ornament = NoteOrnament.UpperMordent;
+                            break;
+                        case 'LowerMordent':
+                            note.ornament = NoteOrnament.LowerMordent;
+                            break;
+                    }
+                    break;
             }
         }
         this._noteById.set(noteId, note);
@@ -2185,173 +2073,165 @@ export class GpifParser {
         // GP6 had percussion as element+variation
         let element: number = -1;
         let variation: number = -1;
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Property':
-                        let name: string = c.getAttribute('name');
-                        switch (name) {
-                            case 'ShowStringNumber':
-                                if (c.findChildElement('Enable')) {
-                                    note.showStringNumber = true;
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Property':
+                    let name: string = c.getAttribute('name');
+                    switch (name) {
+                        case 'ShowStringNumber':
+                            if (c.findChildElement('Enable')) {
+                                note.showStringNumber = true;
+                            }
+                            break;
+                        case 'String':
+                            note.string = parseInt(c.findChildElement('String')!.innerText) + 1;
+                            break;
+                        case 'Fret':
+                            note.fret = parseInt(c.findChildElement('Fret')!.innerText);
+                            break;
+                        case 'Element':
+                            element = parseInt(c.findChildElement('Element')!.innerText);
+                            break;
+                        case 'Variation':
+                            variation = parseInt(c.findChildElement('Variation')!.innerText);
+                            break;
+                        case 'Tapped':
+                            this._tappedNotes.set(noteId, true);
+                            break;
+                        case 'HarmonicType':
+                            let htype: XmlNode = c.findChildElement('HType')!;
+                            if (htype) {
+                                switch (htype.innerText) {
+                                    case 'NoHarmonic':
+                                        note.harmonicType = HarmonicType.None;
+                                        break;
+                                    case 'Natural':
+                                        note.harmonicType = HarmonicType.Natural;
+                                        break;
+                                    case 'Artificial':
+                                        note.harmonicType = HarmonicType.Artificial;
+                                        break;
+                                    case 'Pinch':
+                                        note.harmonicType = HarmonicType.Pinch;
+                                        break;
+                                    case 'Tap':
+                                        note.harmonicType = HarmonicType.Tap;
+                                        break;
+                                    case 'Semi':
+                                        note.harmonicType = HarmonicType.Semi;
+                                        break;
+                                    case 'Feedback':
+                                        note.harmonicType = HarmonicType.Feedback;
+                                        break;
                                 }
-                                break;
-                            case 'String':
-                                note.string = parseInt(c.findChildElement('String')!.innerText) + 1;
-                                break;
-                            case 'Fret':
-                                note.fret = parseInt(c.findChildElement('Fret')!.innerText);
-                                break;
-                            case 'Element':
-                                element = parseInt(c.findChildElement('Element')!.innerText);
-                                break;
-                            case 'Variation':
-                                variation = parseInt(c.findChildElement('Variation')!.innerText);
-                                break;
-                            case 'Tapped':
-                                this._tappedNotes.set(noteId, true);
-                                break;
-                            case 'HarmonicType':
-                                let htype: XmlNode = c.findChildElement('HType')!;
-                                if (htype) {
-                                    switch (htype.innerText) {
-                                        case 'NoHarmonic':
-                                            note.harmonicType = HarmonicType.None;
-                                            break;
-                                        case 'Natural':
-                                            note.harmonicType = HarmonicType.Natural;
-                                            break;
-                                        case 'Artificial':
-                                            note.harmonicType = HarmonicType.Artificial;
-                                            break;
-                                        case 'Pinch':
-                                            note.harmonicType = HarmonicType.Pinch;
-                                            break;
-                                        case 'Tap':
-                                            note.harmonicType = HarmonicType.Tap;
-                                            break;
-                                        case 'Semi':
-                                            note.harmonicType = HarmonicType.Semi;
-                                            break;
-                                        case 'Feedback':
-                                            note.harmonicType = HarmonicType.Feedback;
-                                            break;
-                                    }
-                                }
-                                break;
-                            case 'HarmonicFret':
-                                let hfret: XmlNode = c.findChildElement('HFret')!;
-                                if (hfret) {
-                                    note.harmonicValue = parseFloat(hfret.innerText);
-                                }
-                                break;
-                            case 'Muted':
-                                if (c.findChildElement('Enable')) {
-                                    note.isDead = true;
-                                }
-                                break;
-                            case 'PalmMuted':
-                                if (c.findChildElement('Enable')) {
-                                    note.isPalmMute = true;
-                                }
-                                break;
-                            case 'Octave':
-                                note.octave = parseInt(c.findChildElement('Number')!.innerText);
-                                // when exporting GP6 from GP7 the tone might be missing
-                                if (note.tone === -1) {
-                                    note.tone = 0;
-                                }
-                                break;
-                            case 'Tone':
-                                note.tone = parseInt(c.findChildElement('Step')!.innerText);
-                                break;
-                            case 'ConcertPitch':
-                                this.parseConcertPitch(c, note);
-                                break;
-                            case 'Bended':
-                                isBended = true;
-                                break;
-                            case 'BendOriginValue':
-                                if (!bendOrigin) {
-                                    bendOrigin = new BendPoint(0, 0);
-                                }
-                                bendOrigin.value = this.toBendValue(parseFloat(c.findChildElement('Float')!.innerText));
-                                break;
-                            case 'BendOriginOffset':
-                                if (!bendOrigin) {
-                                    bendOrigin = new BendPoint(0, 0);
-                                }
-                                bendOrigin.offset = this.toBendOffset(
-                                    parseFloat(c.findChildElement('Float')!.innerText)
-                                );
-                                break;
-                            case 'BendMiddleValue':
-                                bendMiddleValue = this.toBendValue(parseFloat(c.findChildElement('Float')!.innerText));
-                                break;
-                            case 'BendMiddleOffset1':
-                                bendMiddleOffset1 = this.toBendOffset(
-                                    parseFloat(c.findChildElement('Float')!.innerText)
-                                );
-                                break;
-                            case 'BendMiddleOffset2':
-                                bendMiddleOffset2 = this.toBendOffset(
-                                    parseFloat(c.findChildElement('Float')!.innerText)
-                                );
-                                break;
-                            case 'BendDestinationValue':
-                                if (!bendDestination) {
-                                    bendDestination = new BendPoint(BendPoint.MaxPosition, 0);
-                                }
-                                bendDestination.value = this.toBendValue(
-                                    parseFloat(c.findChildElement('Float')!.innerText)
-                                );
-                                break;
-                            case 'BendDestinationOffset':
-                                if (!bendDestination) {
-                                    bendDestination = new BendPoint(0, 0);
-                                }
-                                bendDestination.offset = this.toBendOffset(
-                                    parseFloat(c.findChildElement('Float')!.innerText)
-                                );
-                                break;
-                            case 'HopoOrigin':
-                                if (c.findChildElement('Enable')) {
-                                    note.isHammerPullOrigin = true;
-                                }
-                                break;
-                            case 'HopoDestination':
-                                // NOTE: gets automatically calculated
-                                // if (FindChildElement(node, "Enable"))
-                                //     note.isHammerPullDestination = true;
-                                break;
-                            case 'LeftHandTapped':
-                                note.isLeftHandTapped = true;
-                                break;
-                            case 'Slide':
-                                let slideFlags: number = parseInt(c.findChildElement('Flags')!.innerText);
-                                if ((slideFlags & 1) !== 0) {
-                                    note.slideOutType = SlideOutType.Shift;
-                                } else if ((slideFlags & 2) !== 0) {
-                                    note.slideOutType = SlideOutType.Legato;
-                                } else if ((slideFlags & 4) !== 0) {
-                                    note.slideOutType = SlideOutType.OutDown;
-                                } else if ((slideFlags & 8) !== 0) {
-                                    note.slideOutType = SlideOutType.OutUp;
-                                }
-                                if ((slideFlags & 16) !== 0) {
-                                    note.slideInType = SlideInType.IntoFromBelow;
-                                } else if ((slideFlags & 32) !== 0) {
-                                    note.slideInType = SlideInType.IntoFromAbove;
-                                }
-                                if ((slideFlags & 64) !== 0) {
-                                    note.slideOutType = SlideOutType.PickSlideDown;
-                                } else if ((slideFlags & 128) !== 0) {
-                                    note.slideOutType = SlideOutType.PickSlideUp;
-                                }
-                                break;
-                        }
-                        break;
-                }
+                            }
+                            break;
+                        case 'HarmonicFret':
+                            let hfret: XmlNode = c.findChildElement('HFret')!;
+                            if (hfret) {
+                                note.harmonicValue = parseFloat(hfret.innerText);
+                            }
+                            break;
+                        case 'Muted':
+                            if (c.findChildElement('Enable')) {
+                                note.isDead = true;
+                            }
+                            break;
+                        case 'PalmMuted':
+                            if (c.findChildElement('Enable')) {
+                                note.isPalmMute = true;
+                            }
+                            break;
+                        case 'Octave':
+                            note.octave = parseInt(c.findChildElement('Number')!.innerText);
+                            // when exporting GP6 from GP7 the tone might be missing
+                            if (note.tone === -1) {
+                                note.tone = 0;
+                            }
+                            break;
+                        case 'Tone':
+                            note.tone = parseInt(c.findChildElement('Step')!.innerText);
+                            break;
+                        case 'ConcertPitch':
+                            this.parseConcertPitch(c, note);
+                            break;
+                        case 'Bended':
+                            isBended = true;
+                            break;
+                        case 'BendOriginValue':
+                            if (!bendOrigin) {
+                                bendOrigin = new BendPoint(0, 0);
+                            }
+                            bendOrigin.value = this.toBendValue(parseFloat(c.findChildElement('Float')!.innerText));
+                            break;
+                        case 'BendOriginOffset':
+                            if (!bendOrigin) {
+                                bendOrigin = new BendPoint(0, 0);
+                            }
+                            bendOrigin.offset = this.toBendOffset(parseFloat(c.findChildElement('Float')!.innerText));
+                            break;
+                        case 'BendMiddleValue':
+                            bendMiddleValue = this.toBendValue(parseFloat(c.findChildElement('Float')!.innerText));
+                            break;
+                        case 'BendMiddleOffset1':
+                            bendMiddleOffset1 = this.toBendOffset(parseFloat(c.findChildElement('Float')!.innerText));
+                            break;
+                        case 'BendMiddleOffset2':
+                            bendMiddleOffset2 = this.toBendOffset(parseFloat(c.findChildElement('Float')!.innerText));
+                            break;
+                        case 'BendDestinationValue':
+                            if (!bendDestination) {
+                                bendDestination = new BendPoint(BendPoint.MaxPosition, 0);
+                            }
+                            bendDestination.value = this.toBendValue(
+                                parseFloat(c.findChildElement('Float')!.innerText)
+                            );
+                            break;
+                        case 'BendDestinationOffset':
+                            if (!bendDestination) {
+                                bendDestination = new BendPoint(0, 0);
+                            }
+                            bendDestination.offset = this.toBendOffset(
+                                parseFloat(c.findChildElement('Float')!.innerText)
+                            );
+                            break;
+                        case 'HopoOrigin':
+                            if (c.findChildElement('Enable')) {
+                                note.isHammerPullOrigin = true;
+                            }
+                            break;
+                        case 'HopoDestination':
+                            // NOTE: gets automatically calculated
+                            // if (FindChildElement(node, "Enable"))
+                            //     note.isHammerPullDestination = true;
+                            break;
+                        case 'LeftHandTapped':
+                            note.isLeftHandTapped = true;
+                            break;
+                        case 'Slide':
+                            let slideFlags: number = parseInt(c.findChildElement('Flags')!.innerText);
+                            if ((slideFlags & 1) !== 0) {
+                                note.slideOutType = SlideOutType.Shift;
+                            } else if ((slideFlags & 2) !== 0) {
+                                note.slideOutType = SlideOutType.Legato;
+                            } else if ((slideFlags & 4) !== 0) {
+                                note.slideOutType = SlideOutType.OutDown;
+                            } else if ((slideFlags & 8) !== 0) {
+                                note.slideOutType = SlideOutType.OutUp;
+                            }
+                            if ((slideFlags & 16) !== 0) {
+                                note.slideInType = SlideInType.IntoFromBelow;
+                            } else if ((slideFlags & 32) !== 0) {
+                                note.slideInType = SlideInType.IntoFromAbove;
+                            }
+                            if ((slideFlags & 64) !== 0) {
+                                note.slideOutType = SlideOutType.PickSlideDown;
+                            } else if ((slideFlags & 128) !== 0) {
+                                note.slideOutType = SlideOutType.PickSlideUp;
+                            }
+                            break;
+                    }
+                    break;
             }
         }
 
@@ -2384,26 +2264,24 @@ export class GpifParser {
     private parseConcertPitch(node: XmlNode, note: Note) {
         const pitch = node.findChildElement('Pitch');
         if (pitch) {
-            for (let c of pitch.childNodes) {
-                if (c.nodeType === XmlNodeType.Element) {
-                    switch (c.localName) {
-                        case 'Accidental':
-                            switch (c.innerText) {
-                                case 'x':
-                                    note.accidentalMode = NoteAccidentalMode.ForceDoubleSharp;
-                                    break;
-                                case '#':
-                                    note.accidentalMode = NoteAccidentalMode.ForceSharp;
-                                    break;
-                                case 'b':
-                                    note.accidentalMode = NoteAccidentalMode.ForceFlat;
-                                    break;
-                                case 'bb':
-                                    note.accidentalMode = NoteAccidentalMode.ForceDoubleFlat;
-                                    break;
-                            }
-                            break;
-                    }
+            for (let c of pitch.childElements()) {
+                switch (c.localName) {
+                    case 'Accidental':
+                        switch (c.innerText) {
+                            case 'x':
+                                note.accidentalMode = NoteAccidentalMode.ForceDoubleSharp;
+                                break;
+                            case '#':
+                                note.accidentalMode = NoteAccidentalMode.ForceSharp;
+                                break;
+                            case 'b':
+                                note.accidentalMode = NoteAccidentalMode.ForceFlat;
+                                break;
+                            case 'bb':
+                                note.accidentalMode = NoteAccidentalMode.ForceDoubleFlat;
+                                break;
+                        }
+                        break;
                 }
             }
         }
@@ -2418,13 +2296,11 @@ export class GpifParser {
     }
 
     private parseRhythms(node: XmlNode): void {
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'Rhythm':
-                        this.parseRhythm(c);
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'Rhythm':
+                    this.parseRhythm(c);
+                    break;
             }
         }
     }
@@ -2433,54 +2309,52 @@ export class GpifParser {
         let rhythm: GpifRhythm = new GpifRhythm();
         let rhythmId: string = node.getAttribute('id');
         rhythm.id = rhythmId;
-        for (let c of node.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'NoteValue':
-                        switch (c.innerText) {
-                            case 'Long':
-                                rhythm.value = Duration.QuadrupleWhole;
-                                break;
-                            case 'DoubleWhole':
-                                rhythm.value = Duration.DoubleWhole;
-                                break;
-                            case 'Whole':
-                                rhythm.value = Duration.Whole;
-                                break;
-                            case 'Half':
-                                rhythm.value = Duration.Half;
-                                break;
-                            case 'Quarter':
-                                rhythm.value = Duration.Quarter;
-                                break;
-                            case 'Eighth':
-                                rhythm.value = Duration.Eighth;
-                                break;
-                            case '16th':
-                                rhythm.value = Duration.Sixteenth;
-                                break;
-                            case '32nd':
-                                rhythm.value = Duration.ThirtySecond;
-                                break;
-                            case '64th':
-                                rhythm.value = Duration.SixtyFourth;
-                                break;
-                            case '128th':
-                                rhythm.value = Duration.OneHundredTwentyEighth;
-                                break;
-                            case '256th':
-                                rhythm.value = Duration.TwoHundredFiftySixth;
-                                break;
-                        }
-                        break;
-                    case 'PrimaryTuplet':
-                        rhythm.tupletNumerator = parseInt(c.getAttribute('num'));
-                        rhythm.tupletDenominator = parseInt(c.getAttribute('den'));
-                        break;
-                    case 'AugmentationDot':
-                        rhythm.dots = parseInt(c.getAttribute('count'));
-                        break;
-                }
+        for (let c of node.childElements()) {
+            switch (c.localName) {
+                case 'NoteValue':
+                    switch (c.innerText) {
+                        case 'Long':
+                            rhythm.value = Duration.QuadrupleWhole;
+                            break;
+                        case 'DoubleWhole':
+                            rhythm.value = Duration.DoubleWhole;
+                            break;
+                        case 'Whole':
+                            rhythm.value = Duration.Whole;
+                            break;
+                        case 'Half':
+                            rhythm.value = Duration.Half;
+                            break;
+                        case 'Quarter':
+                            rhythm.value = Duration.Quarter;
+                            break;
+                        case 'Eighth':
+                            rhythm.value = Duration.Eighth;
+                            break;
+                        case '16th':
+                            rhythm.value = Duration.Sixteenth;
+                            break;
+                        case '32nd':
+                            rhythm.value = Duration.ThirtySecond;
+                            break;
+                        case '64th':
+                            rhythm.value = Duration.SixtyFourth;
+                            break;
+                        case '128th':
+                            rhythm.value = Duration.OneHundredTwentyEighth;
+                            break;
+                        case '256th':
+                            rhythm.value = Duration.TwoHundredFiftySixth;
+                            break;
+                    }
+                    break;
+                case 'PrimaryTuplet':
+                    rhythm.tupletNumerator = parseInt(c.getAttribute('num'));
+                    rhythm.tupletDenominator = parseInt(c.getAttribute('den'));
+                    break;
+                case 'AugmentationDot':
+                    rhythm.dots = parseInt(c.getAttribute('count'));
+                    break;
             }
         }
         this._rhythmById.set(rhythmId, rhythm);

--- a/src/importer/MusicXmlImporter.ts
+++ b/src/importer/MusicXmlImporter.ts
@@ -26,7 +26,7 @@ import { Voice } from '@src/model/Voice';
 import { ModelUtils } from '@src/model/ModelUtils';
 
 import { XmlDocument } from '@src/xml/XmlDocument';
-import { XmlNode, XmlNodeType } from '@src/xml/XmlNode';
+import { XmlNode } from '@src/xml/XmlNode';
 import { IOHelper } from '@src/io/IOHelper';
 import { ZipReader } from '@src/zip/ZipReader';
 import { ZipEntry } from '@src/zip/ZipEntry';
@@ -115,8 +115,8 @@ export class MusicXmlImporter extends ScoreImporter {
         }
 
         let uncompressedFileFullPath: string = '';
-        for (const c of rootFiles.childNodes) {
-            if (c.nodeType == XmlNodeType.Element && c.localName === 'rootfile') {
+        for (const c of rootFiles.childElements()) {
+            if (c.localName === 'rootfile') {
                 // The MusicXML root must be described in the first <rootfile> element.
                 // https://www.w3.org/2021/06/musicxml40/tutorial/compressed-mxl-files/
                 uncompressedFileFullPath = c.getAttribute('full-path');
@@ -186,37 +186,33 @@ export class MusicXmlImporter extends ScoreImporter {
     }
 
     private parsePartwise(element: XmlNode): void {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'work':
-                        this.parseWork(c);
-                        break;
-                    case 'movement-title':
-                        this._score.title = c.innerText;
-                        break;
-                    case 'identification':
-                        this.parseIdentification(c);
-                        break;
-                    case 'part-list':
-                        this.parsePartList(c);
-                        break;
-                    case 'part':
-                        this.parsePart(c);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'work':
+                    this.parseWork(c);
+                    break;
+                case 'movement-title':
+                    this._score.title = c.innerText;
+                    break;
+                case 'identification':
+                    this.parseIdentification(c);
+                    break;
+                case 'part-list':
+                    this.parsePartList(c);
+                    break;
+                case 'part':
+                    this.parsePart(c);
+                    break;
             }
         }
     }
 
     private parseWork(element: XmlNode): void {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'work-title':
-                        this._score.title = c.innerText;
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'work-title':
+                    this._score.title = c.innerText;
+                    break;
             }
         }
     }
@@ -240,15 +236,13 @@ export class MusicXmlImporter extends ScoreImporter {
         let track: Track = this._trackById.get(id)!;
         let isFirstMeasure: boolean = true;
         this._maxVoices = 0;
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'measure':
-                        if (this.parseMeasure(c, track, isFirstMeasure)) {
-                            isFirstMeasure = false;
-                        }
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'measure':
+                    if (this.parseMeasure(c, track, isFirstMeasure)) {
+                        isFirstMeasure = false;
+                    }
+                    break;
             }
         }
         // ensure voices for all bars
@@ -309,34 +303,32 @@ export class MusicXmlImporter extends ScoreImporter {
         let chordsByIdForTrack = new Map<string, Chord>();
         if (masterBar) {
             let attributesParsed: boolean = false;
-            for (let c of element.childNodes) {
-                if (c.nodeType === XmlNodeType.Element) {
-                    switch (c.localName) {
-                        case 'note':
-                            this.parseNoteBeat(c, bars);
-                            break;
-                        case 'forward':
-                            this.parseForward(c, bars);
-                            break;
-                        case 'direction':
-                            this.parseDirection(c, masterBar);
-                            break;
-                        case 'attributes':
-                            if (!attributesParsed) {
-                                this.parseAttributes(c, bars, masterBar, track);
-                                attributesParsed = true;
-                            }
-                            break;
-                        case 'harmony':
-                            this.parseHarmony(c, track, chordsByIdForTrack);
-                            break;
-                        case 'sound':
-                            // TODO
-                            break;
-                        case 'barline':
-                            this.parseBarline(c, masterBar);
-                            break;
-                    }
+            for (let c of element.childElements()) {
+                switch (c.localName) {
+                    case 'note':
+                        this.parseNoteBeat(c, bars);
+                        break;
+                    case 'forward':
+                        this.parseForward(c, bars);
+                        break;
+                    case 'direction':
+                        this.parseDirection(c, masterBar);
+                        break;
+                    case 'attributes':
+                        if (!attributesParsed) {
+                            this.parseAttributes(c, bars, masterBar, track);
+                            attributesParsed = true;
+                        }
+                        break;
+                    case 'harmony':
+                        this.parseHarmony(c, track, chordsByIdForTrack);
+                        break;
+                    case 'sound':
+                        // TODO
+                        break;
+                    case 'barline':
+                        this.parseBarline(c, masterBar);
+                        break;
                 }
             }
         }
@@ -430,18 +422,16 @@ export class MusicXmlImporter extends ScoreImporter {
     }
 
     private parseStaffDetails(element: XmlNode, track: Track): void {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'staff-lines':
-                        for (let staff of track.staves) {
-                            staff.stringTuning.tunings = new Array<number>(parseInt(c.innerText)).fill(0);
-                        }
-                        break;
-                    case 'staff-tuning':
-                        this.parseStaffTuning(c, track);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'staff-lines':
+                    for (let staff of track.staves) {
+                        staff.stringTuning.tunings = new Array<number>(parseInt(c.innerText)).fill(0);
+                    }
+                    break;
+                case 'staff-tuning':
+                    this.parseStaffTuning(c, track);
+                    break;
             }
         }
         for (let staff of track.staves) {
@@ -456,19 +446,17 @@ export class MusicXmlImporter extends ScoreImporter {
         let tuningStep: string = 'C';
         let tuningOctave: string = '';
         let tuningAlter: number = 0;
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'tuning-step':
-                        tuningStep = c.innerText;
-                        break;
-                    case 'tuning-alter':
-                        tuningAlter = parseInt(c.innerText);
-                        break;
-                    case 'tuning-octave':
-                        tuningOctave = c.innerText;
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'tuning-step':
+                    tuningStep = c.innerText;
+                    break;
+                case 'tuning-alter':
+                    tuningAlter = parseInt(c.innerText);
+                    break;
+                case 'tuning-octave':
+                    tuningOctave = c.innerText;
+                    break;
             }
         }
         let tuning: number = ModelUtils.getTuningForText(tuningStep + tuningOctave) + tuningAlter;
@@ -482,19 +470,17 @@ export class MusicXmlImporter extends ScoreImporter {
 
     private parseHarmony(element: XmlNode, track: Track, chordsByIdForTrack: Map<string, Chord>): void {
         let chord: Chord = new Chord();
-        for (let childNode of element.childNodes) {
-            if (childNode.nodeType === XmlNodeType.Element) {
-                switch (childNode.localName) {
-                    case 'root':
-                        chord.name = this.parseHarmonyRoot(childNode);
-                        break;
-                    case 'kind':
-                        chord.name = chord.name + this.parseHarmonyKind(childNode);
-                        break;
-                    case 'frame':
-                        this.parseHarmonyFrame(childNode, chord);
-                        break;
-                }
+        for (let childNode of element.childElements()) {
+            switch (childNode.localName) {
+                case 'root':
+                    chord.name = this.parseHarmonyRoot(childNode);
+                    break;
+                case 'kind':
+                    chord.name = chord.name + this.parseHarmonyKind(childNode);
+                    break;
+                case 'frame':
+                    this.parseHarmonyFrame(childNode, chord);
+                    break;
             }
         }
 
@@ -528,32 +514,30 @@ export class MusicXmlImporter extends ScoreImporter {
     private parseHarmonyRoot(xmlNode: XmlNode): string {
         let rootStep: string = '';
         let rootAlter: string = '';
-        for (let rootChild of xmlNode.childNodes) {
-            if (rootChild.nodeType === XmlNodeType.Element) {
-                switch (rootChild.localName) {
-                    case 'root-step':
-                        rootStep = rootChild.innerText;
-                        break;
-                    case 'root-alter':
-                        switch (parseInt(xmlNode.innerText)) {
-                            case -2:
-                                rootAlter = 'bb';
-                                break;
-                            case -1:
-                                rootAlter = 'b';
-                                break;
-                            case 0:
-                                rootAlter = '';
-                                break;
-                            case 1:
-                                rootAlter = '#';
-                                break;
-                            case 2:
-                                rootAlter = '##';
-                                break;
-                        }
-                        break;
-                }
+        for (let rootChild of xmlNode.childElements()) {
+            switch (rootChild.localName) {
+                case 'root-step':
+                    rootStep = rootChild.innerText;
+                    break;
+                case 'root-alter':
+                    switch (parseInt(xmlNode.innerText)) {
+                        case -2:
+                            rootAlter = 'bb';
+                            break;
+                        case -1:
+                            rootAlter = 'b';
+                            break;
+                        case 0:
+                            rootAlter = '';
+                            break;
+                        case 1:
+                            rootAlter = '#';
+                            break;
+                        case 2:
+                            rootAlter = '##';
+                            break;
+                    }
+                    break;
             }
         }
         return rootStep + rootAlter;
@@ -671,58 +655,54 @@ export class MusicXmlImporter extends ScoreImporter {
     }
 
     private parseHarmonyFrame(xmlNode: XmlNode, chord: Chord) {
-        for (let frameChild of xmlNode.childNodes) {
-            if (frameChild.nodeType === XmlNodeType.Element) {
-                switch (frameChild.localName) {
-                    case 'frame-strings':
-                        const stringsCount: number = parseInt(frameChild.innerText);
-                        chord.strings = new Array<number>(stringsCount);
-                        for (let i = 0; i < stringsCount; i++) {
-                            // set strings unplayed as default
-                            chord.strings[i] = -1;
+        for (let frameChild of xmlNode.childElements()) {
+            switch (frameChild.localName) {
+                case 'frame-strings':
+                    const stringsCount: number = parseInt(frameChild.innerText);
+                    chord.strings = new Array<number>(stringsCount);
+                    for (let i = 0; i < stringsCount; i++) {
+                        // set strings unplayed as default
+                        chord.strings[i] = -1;
+                    }
+                    break;
+                case 'first-fret':
+                    chord.firstFret = parseInt(frameChild.innerText);
+                    break;
+                case 'frame-note':
+                    let stringNo: number | null = null;
+                    let fretNo: number | null = null;
+                    for (let noteChild of frameChild.childElements()) {
+                        switch (noteChild.localName) {
+                            case 'string':
+                                stringNo = parseInt(noteChild.innerText);
+                                break;
+                            case 'fret':
+                                fretNo = parseInt(noteChild.innerText);
+                                if (stringNo && fretNo >= 0) {
+                                    chord.strings[stringNo - 1] = fretNo;
+                                }
+                                break;
+                            case 'barre':
+                                if (stringNo && fretNo && noteChild.getAttribute('type') === 'start') {
+                                    chord.barreFrets.push(fretNo);
+                                }
+                                break;
                         }
-                        break;
-                    case 'first-fret':
-                        chord.firstFret = parseInt(frameChild.innerText);
-                        break;
-                    case 'frame-note':
-                        let stringNo: number | null = null;
-                        let fretNo: number | null = null;
-                        for (let noteChild of frameChild.childNodes) {
-                            switch (noteChild.localName) {
-                                case 'string':
-                                    stringNo = parseInt(noteChild.innerText);
-                                    break;
-                                case 'fret':
-                                    fretNo = parseInt(noteChild.innerText);
-                                    if (stringNo && fretNo >= 0) {
-                                        chord.strings[stringNo - 1] = fretNo;
-                                    }
-                                    break;
-                                case 'barre':
-                                    if (stringNo && fretNo && noteChild.getAttribute('type') === 'start') {
-                                        chord.barreFrets.push(fretNo);
-                                    }
-                                    break;
-                            }
-                        }
-                        break;
-                }
+                    }
+                    break;
             }
         }
     }
 
     private parseBarline(element: XmlNode, masterBar: MasterBar): void {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'repeat':
-                        this.parseRepeat(c, masterBar);
-                        break;
-                    case 'ending':
-                        this.parseEnding(c, masterBar);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'repeat':
+                    this.parseRepeat(c, masterBar);
+                    break;
+                case 'ending':
+                    this.parseEnding(c, masterBar);
+                    break;
             }
         }
     }
@@ -772,106 +752,104 @@ export class MusicXmlImporter extends ScoreImporter {
         beat.addNote(note);
         beat.dots = 0;
         let isFullBarRest = false;
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'grace':
-                        // var slash = e.GetAttribute("slash");
-                        // var makeTime = Platform.ParseInt(e.GetAttribute("make-time"));
-                        // var stealTimePrevious = Platform.ParseInt(e.GetAttribute("steal-time-previous"));
-                        // var stealTimeFollowing = Platform.ParseInt(e.GetAttribute("steal-time-following"));
-                        beat.graceType = GraceType.BeforeBeat;
-                        beat.duration = Duration.ThirtySecond;
-                        break;
-                    case 'duration':
-                        if (beat.isRest && !isFullBarRest) {
-                            // unit: divisions per quarter note
-                            let duration: number = parseInt(c.innerText);
-                            switch (duration) {
-                                case 1:
-                                    beat.duration = Duration.Whole;
-                                    break;
-                                case 2:
-                                    beat.duration = Duration.Half;
-                                    break;
-                                case 4:
-                                    beat.duration = Duration.Quarter;
-                                    break;
-                                case 8:
-                                    beat.duration = Duration.Eighth;
-                                    break;
-                                case 16:
-                                    beat.duration = Duration.Sixteenth;
-                                    break;
-                                case 32:
-                                    beat.duration = Duration.ThirtySecond;
-                                    break;
-                                case 64:
-                                    beat.duration = Duration.SixtyFourth;
-                                    break;
-                                default:
-                                    beat.duration = Duration.Quarter;
-                                    break;
-                            }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'grace':
+                    // var slash = e.GetAttribute("slash");
+                    // var makeTime = Platform.ParseInt(e.GetAttribute("make-time"));
+                    // var stealTimePrevious = Platform.ParseInt(e.GetAttribute("steal-time-previous"));
+                    // var stealTimeFollowing = Platform.ParseInt(e.GetAttribute("steal-time-following"));
+                    beat.graceType = GraceType.BeforeBeat;
+                    beat.duration = Duration.ThirtySecond;
+                    break;
+                case 'duration':
+                    if (beat.isRest && !isFullBarRest) {
+                        // unit: divisions per quarter note
+                        let duration: number = parseInt(c.innerText);
+                        switch (duration) {
+                            case 1:
+                                beat.duration = Duration.Whole;
+                                break;
+                            case 2:
+                                beat.duration = Duration.Half;
+                                break;
+                            case 4:
+                                beat.duration = Duration.Quarter;
+                                break;
+                            case 8:
+                                beat.duration = Duration.Eighth;
+                                break;
+                            case 16:
+                                beat.duration = Duration.Sixteenth;
+                                break;
+                            case 32:
+                                beat.duration = Duration.ThirtySecond;
+                                break;
+                            case 64:
+                                beat.duration = Duration.SixtyFourth;
+                                break;
+                            default:
+                                beat.duration = Duration.Quarter;
+                                break;
                         }
-                        break;
-                    case 'tie':
-                        this.parseTied(c, note);
-                        break;
-                    case 'cue':
-                        // not supported
-                        break;
-                    case 'instrument':
-                        // not supported
-                        break;
-                    case 'type':
-                        beat.duration = this.getDuration(c.innerText);
-                        if (beat.graceType !== GraceType.None && beat.duration < Duration.Sixteenth) {
-                            beat.duration = Duration.Eighth;
-                        }
-                        break;
-                    case 'dot':
-                        beat.dots++;
-                        break;
-                    case 'accidental':
-                        this.parseAccidental(c, note);
-                        break;
-                    case 'time-modification':
-                        this.parseTimeModification(c, beat);
-                        break;
-                    case 'stem':
-                        // not supported
-                        break;
-                    case 'notehead':
-                        if (c.getAttribute('parentheses') === 'yes') {
-                            note.isGhost = true;
-                        }
-                        break;
-                    case 'beam':
-                        let beamMode: string = c.innerText;
-                        if (beamMode === 'continue') {
-                            this._isBeamContinue = true;
-                        }
-                        break;
-                    case 'notations':
-                        this.parseNotations(c, beat, note);
-                        break;
-                    case 'lyric':
-                        this.parseLyric(c, beat);
-                        break;
-                    case 'pitch':
-                        this.parsePitch(c, note);
-                        break;
-                    case 'unpitched':
-                        this.parseUnpitched(c, note);
-                        break;
-                    case 'rest':
-                        isFullBarRest = c.getAttribute('measure') === 'yes';
-                        beat.isEmpty = false;
-                        beat.notes = [];
-                        beat.duration = Duration.Whole;
-                        break;
-                }
+                    }
+                    break;
+                case 'tie':
+                    this.parseTied(c, note);
+                    break;
+                case 'cue':
+                    // not supported
+                    break;
+                case 'instrument':
+                    // not supported
+                    break;
+                case 'type':
+                    beat.duration = this.getDuration(c.innerText);
+                    if (beat.graceType !== GraceType.None && beat.duration < Duration.Sixteenth) {
+                        beat.duration = Duration.Eighth;
+                    }
+                    break;
+                case 'dot':
+                    beat.dots++;
+                    break;
+                case 'accidental':
+                    this.parseAccidental(c, note);
+                    break;
+                case 'time-modification':
+                    this.parseTimeModification(c, beat);
+                    break;
+                case 'stem':
+                    // not supported
+                    break;
+                case 'notehead':
+                    if (c.getAttribute('parentheses') === 'yes') {
+                        note.isGhost = true;
+                    }
+                    break;
+                case 'beam':
+                    let beamMode: string = c.innerText;
+                    if (beamMode === 'continue') {
+                        this._isBeamContinue = true;
+                    }
+                    break;
+                case 'notations':
+                    this.parseNotations(c, beat, note);
+                    break;
+                case 'lyric':
+                    this.parseLyric(c, beat);
+                    break;
+                case 'pitch':
+                    this.parsePitch(c, note);
+                    break;
+                case 'unpitched':
+                    this.parseUnpitched(c, note);
+                    break;
+                case 'rest':
+                    isFullBarRest = c.getAttribute('measure') === 'yes';
+                    beat.isEmpty = false;
+                    beat.notes = [];
+                    beat.duration = Duration.Whole;
+                    break;
             }
         }
         // check if new note is duplicate on string
@@ -910,17 +888,15 @@ export class MusicXmlImporter extends ScoreImporter {
     }
 
     private parseLyric(element: XmlNode, beat: Beat): void {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'text':
-                        if (beat.text) {
-                            beat.text += ' ' + c.innerText;
-                        } else {
-                            beat.text = c.innerText;
-                        }
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'text':
+                    if (beat.text) {
+                        beat.text += ' ' + c.innerText;
+                    } else {
+                        beat.text = c.innerText;
+                    }
+                    break;
             }
         }
     }
@@ -981,80 +957,76 @@ export class MusicXmlImporter extends ScoreImporter {
     }
 
     private parseNotations(element: XmlNode, beat: Beat, note: Note): void {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'articulations':
-                        this.parseArticulations(c, note);
-                        break;
-                    case 'tied':
-                        this.parseTied(c, note);
-                        break;
-                    case 'slide':
-                    case 'glissando':
-                        if (c.getAttribute('type') === 'start') {
-                            note.slideOutType = SlideOutType.Shift;
-                        }
-                        break;
-                    case 'dynamics':
-                        this.parseDynamics(c, beat);
-                        break;
-                    case 'technical':
-                        this.parseTechnical(c, note);
-                        break;
-                    case 'ornaments':
-                        this.parseOrnaments(c, note);
-                        break;
-                    case 'slur':
-                        let slurNumber: string = c.getAttribute('number');
-                        if (!slurNumber) {
-                            slurNumber = '1';
-                        }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'articulations':
+                    this.parseArticulations(c, note);
+                    break;
+                case 'tied':
+                    this.parseTied(c, note);
+                    break;
+                case 'slide':
+                case 'glissando':
+                    if (c.getAttribute('type') === 'start') {
+                        note.slideOutType = SlideOutType.Shift;
+                    }
+                    break;
+                case 'dynamics':
+                    this.parseDynamics(c, beat);
+                    break;
+                case 'technical':
+                    this.parseTechnical(c, note);
+                    break;
+                case 'ornaments':
+                    this.parseOrnaments(c, note);
+                    break;
+                case 'slur':
+                    let slurNumber: string = c.getAttribute('number');
+                    if (!slurNumber) {
+                        slurNumber = '1';
+                    }
 
-                        // slur numbers are unique in the way that they have the same ID across
-                        // staffs/tracks etc. as long they represent the logically same slur.
-                        // but in our case it must be globally unique to link the correct notes.
-                        // adding the staff ID should be enough to achieve this
-                        slurNumber = beat.voice.bar.staff.index + '_' + slurNumber;
+                    // slur numbers are unique in the way that they have the same ID across
+                    // staffs/tracks etc. as long they represent the logically same slur.
+                    // but in our case it must be globally unique to link the correct notes.
+                    // adding the staff ID should be enough to achieve this
+                    slurNumber = beat.voice.bar.staff.index + '_' + slurNumber;
 
-                        switch (c.getAttribute('type')) {
-                            case 'start':
-                                this._slurStarts.set(slurNumber, note);
-                                break;
-                            case 'stop':
-                                if (this._slurStarts.has(slurNumber)) {
-                                    note.isSlurDestination = true;
-                                    let slurStart: Note = this._slurStarts.get(slurNumber)!;
-                                    slurStart.slurDestination = note;
-                                    note.slurOrigin = slurStart;
-                                }
-                                break;
-                        }
-                        break;
-                }
+                    switch (c.getAttribute('type')) {
+                        case 'start':
+                            this._slurStarts.set(slurNumber, note);
+                            break;
+                        case 'stop':
+                            if (this._slurStarts.has(slurNumber)) {
+                                note.isSlurDestination = true;
+                                let slurStart: Note = this._slurStarts.get(slurNumber)!;
+                                slurStart.slurDestination = note;
+                                note.slurOrigin = slurStart;
+                            }
+                            break;
+                    }
+                    break;
             }
         }
     }
 
     private parseOrnaments(element: XmlNode, note: Note): void {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'tremolo':
-                        let tremoloSpeed: number = parseInt(c.innerText);
-                        switch (tremoloSpeed) {
-                            case 1:
-                                note.beat.tremoloSpeed = Duration.Eighth;
-                                break;
-                            case 2:
-                                note.beat.tremoloSpeed = Duration.Sixteenth;
-                                break;
-                            case 3:
-                                note.beat.tremoloSpeed = Duration.ThirtySecond;
-                                break;
-                        }
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'tremolo':
+                    let tremoloSpeed: number = parseInt(c.innerText);
+                    switch (tremoloSpeed) {
+                        case 1:
+                            note.beat.tremoloSpeed = Duration.Eighth;
+                            break;
+                        case 2:
+                            note.beat.tremoloSpeed = Duration.Sixteenth;
+                            break;
+                        case 3:
+                            note.beat.tremoloSpeed = Duration.ThirtySecond;
+                            break;
+                    }
+                    break;
             }
         }
     }
@@ -1062,28 +1034,26 @@ export class MusicXmlImporter extends ScoreImporter {
     private parseTechnical(element: XmlNode, note: Note): void {
         let bends: XmlNode[] = [];
 
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'string':
-                        note.string = parseInt(c.innerText);
-                        if (note.string !== -2147483648) {
-                            note.string = note.beat.voice.bar.staff.tuning.length - note.string + 1;
-                        }
-                        break;
-                    case 'fret':
-                        note.fret = parseInt(c.innerText);
-                        break;
-                    case 'down-bow':
-                        note.beat.pickStroke = PickStroke.Down;
-                        break;
-                    case 'up-bow':
-                        note.beat.pickStroke = PickStroke.Up;
-                        break;
-                    case 'bend':
-                        bends.push(c);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'string':
+                    note.string = parseInt(c.innerText);
+                    if (note.string !== -2147483648) {
+                        note.string = note.beat.voice.bar.staff.tuning.length - note.string + 1;
+                    }
+                    break;
+                case 'fret':
+                    note.fret = parseInt(c.innerText);
+                    break;
+                case 'down-bow':
+                    note.beat.pickStroke = PickStroke.Down;
+                    break;
+                case 'up-bow':
+                    note.beat.pickStroke = PickStroke.Up;
+                    break;
+                case 'bend':
+                    bends.push(c);
+                    break;
             }
         }
 
@@ -1139,7 +1109,7 @@ export class MusicXmlImporter extends ScoreImporter {
     }
 
     private parseArticulations(element: XmlNode, note: Note): void {
-        for (let c of element.childNodes) {
+        for (let c of element.childElements()) {
             switch (c.localName) {
                 case 'accent':
                     note.accentuated = AccentuationType.Normal;
@@ -1159,49 +1129,45 @@ export class MusicXmlImporter extends ScoreImporter {
     }
 
     private parseDynamics(element: XmlNode, beat: Beat): void {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'p':
-                        beat.dynamics = DynamicValue.P;
-                        break;
-                    case 'pp':
-                        beat.dynamics = DynamicValue.PP;
-                        break;
-                    case 'ppp':
-                        beat.dynamics = DynamicValue.PPP;
-                        break;
-                    case 'f':
-                        beat.dynamics = DynamicValue.F;
-                        break;
-                    case 'ff':
-                        beat.dynamics = DynamicValue.FF;
-                        break;
-                    case 'fff':
-                        beat.dynamics = DynamicValue.FFF;
-                        break;
-                    case 'mp':
-                        beat.dynamics = DynamicValue.MP;
-                        break;
-                    case 'mf':
-                        beat.dynamics = DynamicValue.MF;
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'p':
+                    beat.dynamics = DynamicValue.P;
+                    break;
+                case 'pp':
+                    beat.dynamics = DynamicValue.PP;
+                    break;
+                case 'ppp':
+                    beat.dynamics = DynamicValue.PPP;
+                    break;
+                case 'f':
+                    beat.dynamics = DynamicValue.F;
+                    break;
+                case 'ff':
+                    beat.dynamics = DynamicValue.FF;
+                    break;
+                case 'fff':
+                    beat.dynamics = DynamicValue.FFF;
+                    break;
+                case 'mp':
+                    beat.dynamics = DynamicValue.MP;
+                    break;
+                case 'mf':
+                    beat.dynamics = DynamicValue.MF;
+                    break;
             }
         }
     }
 
     private parseTimeModification(element: XmlNode, beat: Beat): void {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'actual-notes':
-                        beat.tupletNumerator = parseInt(c.innerText);
-                        break;
-                    case 'normal-notes':
-                        beat.tupletDenominator = parseInt(c.innerText);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'actual-notes':
+                    beat.tupletNumerator = parseInt(c.innerText);
+                    break;
+                case 'normal-notes':
+                    beat.tupletDenominator = parseInt(c.innerText);
+                    break;
             }
         }
     }
@@ -1210,20 +1176,18 @@ export class MusicXmlImporter extends ScoreImporter {
         let step: string = '';
         let semitones: number = 0;
         let octave: number = 0;
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'display-step':
-                        step = c.innerText;
-                        break;
-                    case 'display-alter':
-                        semitones = parseInt(c.innerText);
-                        break;
-                    case 'display-octave':
-                        // 0-9, 4 for middle C
-                        octave = parseInt(c.innerText);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'display-step':
+                    step = c.innerText;
+                    break;
+                case 'display-alter':
+                    semitones = parseInt(c.innerText);
+                    break;
+                case 'display-octave':
+                    // 0-9, 4 for middle C
+                    octave = parseInt(c.innerText);
+                    break;
             }
         }
         let value: number = octave * 12 + ModelUtils.getToneForText(step).noteValue + semitones;
@@ -1235,23 +1199,21 @@ export class MusicXmlImporter extends ScoreImporter {
         let step: string = '';
         let semitones: number = 0;
         let octave: number = 0;
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'step':
-                        step = c.innerText;
-                        break;
-                    case 'alter':
-                        semitones = parseFloat(c.innerText);
-                        if (isNaN(semitones)) {
-                            semitones = 0;
-                        }
-                        break;
-                    case 'octave':
-                        // 0-9, 4 for middle C
-                        octave = parseInt(c.innerText) + 1;
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'step':
+                    step = c.innerText;
+                    break;
+                case 'alter':
+                    semitones = parseFloat(c.innerText);
+                    if (isNaN(semitones)) {
+                        semitones = 0;
+                    }
+                    break;
+                case 'octave':
+                    // 0-9, 4 for middle C
+                    octave = parseInt(c.innerText) + 1;
+                    break;
             }
         }
         let value: number = octave * 12 + ModelUtils.getToneForText(step).noteValue + (semitones | 0);
@@ -1271,34 +1233,32 @@ export class MusicXmlImporter extends ScoreImporter {
     }
 
     private parseDirection(element: XmlNode, masterBar: MasterBar): void {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'sound':
-                        let tempo: string = c.getAttribute('tempo');
-                        if (tempo) {
-                            let tempoAutomation: Automation = new Automation();
-                            tempoAutomation.isLinear = true;
-                            tempoAutomation.type = AutomationType.Tempo;
-                            tempoAutomation.value = parseInt(tempo);
-                            masterBar.tempoAutomations.push(tempoAutomation);
-                            if (masterBar.index === 0) {
-                                masterBar.score.tempo = tempoAutomation.value;
-                            }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'sound':
+                    let tempo: string = c.getAttribute('tempo');
+                    if (tempo) {
+                        let tempoAutomation: Automation = new Automation();
+                        tempoAutomation.isLinear = true;
+                        tempoAutomation.type = AutomationType.Tempo;
+                        tempoAutomation.value = parseInt(tempo);
+                        masterBar.tempoAutomations.push(tempoAutomation);
+                        if (masterBar.index === 0) {
+                            masterBar.score.tempo = tempoAutomation.value;
                         }
-                        break;
-                    case 'direction-type':
-                        let directionType: XmlNode = c.firstElement!;
-                        switch (directionType.localName) {
-                            case 'words':
-                                this._currentDirection = directionType.innerText;
-                                break;
-                            case 'metronome':
-                                this.parseMetronome(directionType, masterBar);
-                                break;
-                        }
-                        break;
-                }
+                    }
+                    break;
+                case 'direction-type':
+                    let directionType: XmlNode = c.firstElement!;
+                    switch (directionType.localName) {
+                        case 'words':
+                            this._currentDirection = directionType.innerText;
+                            break;
+                        case 'metronome':
+                            this.parseMetronome(directionType, masterBar);
+                            break;
+                    }
+                    break;
             }
         }
     }
@@ -1306,16 +1266,14 @@ export class MusicXmlImporter extends ScoreImporter {
     private parseMetronome(element: XmlNode, masterBar: MasterBar): void {
         let unit: Duration = Duration.Quarter;
         let perMinute: number = 120;
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'beat-unit':
-                        unit = this.getDuration(c.innerText);
-                        break;
-                    case 'per-minute':
-                        perMinute = parseInt(c.innerText);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'beat-unit':
+                    unit = this.getDuration(c.innerText);
+                    break;
+                case 'per-minute':
+                    perMinute = parseInt(c.innerText);
+                    break;
             }
         }
         let tempoAutomation: Automation = new Automation();
@@ -1341,33 +1299,31 @@ export class MusicXmlImporter extends ScoreImporter {
     private parseAttributes(element: XmlNode, bars: Bar[], masterBar: MasterBar, track: Track): void {
         let num: number = 0;
         let hasTime: boolean = false;
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'divisions':
-                        this._divisionsPerQuarterNote = parseInt(c.innerText);
-                        break;
-                    case 'key':
-                        this.parseKey(c, masterBar);
-                        break;
-                    case 'time':
-                        this.parseTime(c, masterBar);
-                        hasTime = true;
-                        break;
-                    case 'clef':
-                        num = parseInt(c.getAttribute('number'));
-                        if (isNaN(num)) {
-                            num = 1;
-                        }
-                        this.parseClef(c, bars[num - 1]);
-                        break;
-                    case 'staff-details':
-                        this.parseStaffDetails(c, track);
-                        break;
-                    case 'transpose':
-                        this.parseTranspose(c, track);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'divisions':
+                    this._divisionsPerQuarterNote = parseInt(c.innerText);
+                    break;
+                case 'key':
+                    this.parseKey(c, masterBar);
+                    break;
+                case 'time':
+                    this.parseTime(c, masterBar);
+                    hasTime = true;
+                    break;
+                case 'clef':
+                    num = parseInt(c.getAttribute('number'));
+                    if (isNaN(num)) {
+                        num = 1;
+                    }
+                    this.parseClef(c, bars[num - 1]);
+                    break;
+                case 'staff-details':
+                    this.parseStaffDetails(c, track);
+                    break;
+                case 'transpose':
+                    this.parseTranspose(c, track);
+                    break;
             }
         }
         if (!hasTime) {
@@ -1377,16 +1333,14 @@ export class MusicXmlImporter extends ScoreImporter {
 
     private parseTranspose(element: XmlNode, track: Track): void {
         let semitones: number = 0;
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'chromatic':
-                        semitones += parseInt(c.innerText);
-                        break;
-                    case 'octave-change':
-                        semitones += parseInt(c.innerText) * 12;
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'chromatic':
+                    semitones += parseInt(c.innerText);
+                    break;
+                case 'octave-change':
+                    semitones += parseInt(c.innerText) * 12;
+                    break;
             }
         }
         for (let staff of track.staves) {
@@ -1397,32 +1351,30 @@ export class MusicXmlImporter extends ScoreImporter {
     private parseClef(element: XmlNode, bar: Bar): void {
         let sign: string = 's';
         let line: number = 0;
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'sign':
-                        sign = c.innerText.toLowerCase();
-                        break;
-                    case 'line':
-                        line = parseInt(c.innerText);
-                        break;
-                    case 'clef-octave-change':
-                        switch (parseInt(c.innerText)) {
-                            case -2:
-                                bar.clefOttava = Ottavia._15mb;
-                                break;
-                            case -1:
-                                bar.clefOttava = Ottavia._8vb;
-                                break;
-                            case 1:
-                                bar.clefOttava = Ottavia._8va;
-                                break;
-                            case 2:
-                                bar.clefOttava = Ottavia._15mb;
-                                break;
-                        }
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'sign':
+                    sign = c.innerText.toLowerCase();
+                    break;
+                case 'line':
+                    line = parseInt(c.innerText);
+                    break;
+                case 'clef-octave-change':
+                    switch (parseInt(c.innerText)) {
+                        case -2:
+                            bar.clefOttava = Ottavia._15mb;
+                            break;
+                        case -1:
+                            bar.clefOttava = Ottavia._8vb;
+                            break;
+                        case 1:
+                            bar.clefOttava = Ottavia._8va;
+                            break;
+                        case 2:
+                            bar.clefOttava = Ottavia._15mb;
+                            break;
+                    }
+                    break;
             }
         }
         switch (sign) {
@@ -1459,31 +1411,29 @@ export class MusicXmlImporter extends ScoreImporter {
         }
         let beatsParsed: boolean = false;
         let beatTypeParsed: boolean = false;
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                let v: string = c.innerText;
-                switch (c.localName) {
-                    case 'beats':
-                        if (!beatsParsed) {
-                            if (v.indexOf('+') === -1) {
-                                masterBar.timeSignatureNumerator = parseInt(v);
-                            } else {
-                                masterBar.timeSignatureNumerator = 4;
-                            }
-                            beatsParsed = true;
+        for (let c of element.childElements()) {
+            let v: string = c.innerText;
+            switch (c.localName) {
+                case 'beats':
+                    if (!beatsParsed) {
+                        if (v.indexOf('+') === -1) {
+                            masterBar.timeSignatureNumerator = parseInt(v);
+                        } else {
+                            masterBar.timeSignatureNumerator = 4;
                         }
-                        break;
-                    case 'beat-type':
-                        if (!beatTypeParsed) {
-                            if (v.indexOf('+') === -1) {
-                                masterBar.timeSignatureDenominator = parseInt(v);
-                            } else {
-                                masterBar.timeSignatureDenominator = 4;
-                            }
-                            beatTypeParsed = true;
+                        beatsParsed = true;
+                    }
+                    break;
+                case 'beat-type':
+                    if (!beatTypeParsed) {
+                        if (v.indexOf('+') === -1) {
+                            masterBar.timeSignatureDenominator = parseInt(v);
+                        } else {
+                            masterBar.timeSignatureDenominator = 4;
                         }
-                        break;
-                }
+                        beatTypeParsed = true;
+                    }
+                    break;
             }
         }
     }
@@ -1493,22 +1443,20 @@ export class MusicXmlImporter extends ScoreImporter {
         //let keyStep: number = -2147483648;
         //let keyAlter: number = -2147483648;
         let mode: string = '';
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'fifths':
-                        fifths = parseInt(c.innerText);
-                        break;
-                    case 'key-step':
-                        //keyStep = parseInt(c.innerText);
-                        break;
-                    case 'key-alter':
-                        //keyAlter = parseInt(c.innerText);
-                        break;
-                    case 'mode':
-                        mode = c.innerText;
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'fifths':
+                    fifths = parseInt(c.innerText);
+                    break;
+                case 'key-step':
+                    //keyStep = parseInt(c.innerText);
+                    break;
+                case 'key-alter':
+                    //keyAlter = parseInt(c.innerText);
+                    break;
+                case 'mode':
+                    mode = c.innerText;
+                    break;
             }
         }
         if (-7 <= fifths && fifths <= 7) {
@@ -1544,36 +1492,32 @@ export class MusicXmlImporter extends ScoreImporter {
     }
 
     private parseIdentification(element: XmlNode): void {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'creator':
-                        if (c.getAttribute('type') === 'composer') {
-                            this._score.music = c.innerText;
-                        }
-                        break;
-                    case 'rights':
-                        if (this._score.copyright) {
-                            this._score.copyright += '\n';
-                        }
-                        this._score.copyright += c.innerText;
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'creator':
+                    if (c.getAttribute('type') === 'composer') {
+                        this._score.music = c.innerText;
+                    }
+                    break;
+                case 'rights':
+                    if (this._score.copyright) {
+                        this._score.copyright += '\n';
+                    }
+                    this._score.copyright += c.innerText;
+                    break;
             }
         }
     }
 
     private parsePartList(element: XmlNode): void {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'part-group':
-                        this.parsePartGroup(c);
-                        break;
-                    case 'score-part':
-                        this.parseScorePart(c);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'part-group':
+                    this.parsePartGroup(c);
+                    break;
+                case 'score-part':
+                    this.parseScorePart(c);
+                    break;
             }
         }
     }
@@ -1602,19 +1546,17 @@ export class MusicXmlImporter extends ScoreImporter {
         if (this._currentPartGroup) {
             this._partGroups.get(this._currentPartGroup)!.push(track);
         }
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'part-name':
-                        track.name = c.innerText;
-                        break;
-                    case 'part-abbreviation':
-                        track.shortName = c.innerText;
-                        break;
-                    case 'midi-instrument':
-                        this.parseMidiInstrument(c, track);
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'part-name':
+                    track.name = c.innerText;
+                    break;
+                case 'part-abbreviation':
+                    track.shortName = c.innerText;
+                    break;
+                case 'midi-instrument':
+                    this.parseMidiInstrument(c, track);
+                    break;
             }
         }
         if (this.isEmptyTuning(track.staves[0].tuning)) {
@@ -1635,25 +1577,23 @@ export class MusicXmlImporter extends ScoreImporter {
     }
 
     private parseMidiInstrument(element: XmlNode, track: Track): void {
-        for (let c of element.childNodes) {
-            if (c.nodeType === XmlNodeType.Element) {
-                switch (c.localName) {
-                    case 'midi-channel':
-                        track.playbackInfo.primaryChannel = parseInt(c.innerText);
-                        break;
-                    case 'midi-program':
-                        track.playbackInfo.program = parseInt(c.innerText);
-                        break;
-                    case 'volume':
-                        track.playbackInfo.volume = Math.floor((parseInt(c.innerText) / 100) * 16);
-                        break;
-                    case 'pan':
-                        track.playbackInfo.balance = Math.max(
-                            0,
-                            Math.min(16, Math.floor(((parseInt(c.innerText) + 90) / 180) * 16))
-                        );
-                        break;
-                }
+        for (let c of element.childElements()) {
+            switch (c.localName) {
+                case 'midi-channel':
+                    track.playbackInfo.primaryChannel = parseInt(c.innerText);
+                    break;
+                case 'midi-program':
+                    track.playbackInfo.program = parseInt(c.innerText);
+                    break;
+                case 'volume':
+                    track.playbackInfo.volume = Math.floor((parseInt(c.innerText) / 100) * 16);
+                    break;
+                case 'pan':
+                    track.playbackInfo.balance = Math.max(
+                        0,
+                        Math.min(16, Math.floor(((parseInt(c.innerText) + 90) / 180) * 16))
+                    );
+                    break;
             }
         }
     }

--- a/src/xml/XmlNode.ts
+++ b/src/xml/XmlNode.ts
@@ -27,7 +27,7 @@ export enum XmlNodeType {
     Text,
     CDATA,
     Document,
-    DocumentType,
+    DocumentType
 }
 
 export class XmlNode {
@@ -38,6 +38,14 @@ export class XmlNode {
     public attributes: Map<string, string> = new Map<string, string>();
     public firstChild: XmlNode | null = null;
     public firstElement: XmlNode | null = null;
+
+    public *childElements() {
+        for (const c of this.childNodes) {
+            if (c.nodeType === XmlNodeType.Element) {
+                yield c;
+            }
+        }
+    }
 
     public addChild(node: XmlNode): void {
         this.childNodes.push(node);
@@ -90,7 +98,7 @@ export class XmlNode {
 
     public get innerText(): string {
         if (this.nodeType === XmlNodeType.Element || this.nodeType === XmlNodeType.Document) {
-            if(this.firstElement && this.firstElement.nodeType === XmlNodeType.CDATA) {
+            if (this.firstElement && this.firstElement.nodeType === XmlNodeType.CDATA) {
                 return this.firstElement.innerText;
             }
             let txt: string = '';
@@ -103,7 +111,6 @@ export class XmlNode {
         return this.value ?? '';
     }
 
-
     public set innerText(value: string) {
         const textNode = new XmlNode();
         textNode.nodeType = XmlNodeType.Text;
@@ -111,7 +118,7 @@ export class XmlNode {
         this.childNodes = [textNode];
     }
 
-    public setCData(s:string) {
+    public setCData(s: string) {
         const textNode = new XmlNode();
         textNode.nodeType = XmlNodeType.CDATA;
         textNode.value = s;


### PR DESCRIPTION
### Issues
Preparation for #1887

### Proposed changes
Introduces a `childElements` iterator to reduce a bit the repetitive checks in the XML based importers. 
### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
