### PR TITLE
fix(android): Incorrect sample decoding and missing assets

### DIFF
--- a/src.csharp/AlphaTab.Test/TestPlatform.cs
+++ b/src.csharp/AlphaTab.Test/TestPlatform.cs
@@ -48,7 +48,7 @@ static partial class TestPlatform
         var path = Path.Combine(RepositoryRoot.Value, name);
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         await using var fs = new FileStream(path, FileMode.Create);
-        await fs.WriteAsync(data.Data.Array!, data.Data.Offset, data.Data.Count);
+        await fs.WriteAsync(data.Buffer.Raw, (int)data.ByteOffset, (int)data.Length);
     }
 
     public static Task<IList<string>> ListDirectory(string path)

--- a/src.csharp/AlphaTab/Core/Dom/TextDecoder.cs
+++ b/src.csharp/AlphaTab/Core/Dom/TextDecoder.cs
@@ -13,6 +13,6 @@ internal class TextDecoder
 
     public string Decode(ArrayBuffer data)
     {
-        return _encoding.GetString(data.Raw.Array, data.Raw.Offset, data.Raw.Count);
+        return _encoding.GetString(data.Raw, 0, (int)data.ByteLength);
     }
 }

--- a/src.csharp/AlphaTab/Core/EcmaScript/ArrayBuffer.cs
+++ b/src.csharp/AlphaTab/Core/EcmaScript/ArrayBuffer.cs
@@ -1,21 +1,15 @@
-﻿using System;
-
-namespace AlphaTab.Core.EcmaScript;
+﻿namespace AlphaTab.Core.EcmaScript;
 
 public class ArrayBuffer
 {
-    public ArraySegment<byte> Raw { get; }
-    public double ByteLength => Raw.Count;
+    public byte[] Raw { get; }
+    public double ByteLength => Raw.Length;
 
     public ArrayBuffer(double size)
     {
-        Raw = new ArraySegment<byte>(new byte[(int) size]);
+        Raw = new byte[(int) size];
     }
     public ArrayBuffer(byte[] raw)
-    {
-        Raw = new ArraySegment<byte>(raw, 0, raw.Length);
-    }
-    public ArrayBuffer(ArraySegment<byte> raw)
     {
         Raw = raw;
     }

--- a/src.csharp/AlphaTab/Core/EcmaScript/DataView.cs
+++ b/src.csharp/AlphaTab/Core/EcmaScript/DataView.cs
@@ -5,138 +5,47 @@ namespace AlphaTab.Core.EcmaScript;
 internal class DataView
 {
     public ArrayBuffer Buffer { get; }
+    public double ByteOffset { get; }
+    public double ByteLength { get; }
+
 
     public DataView(ArrayBuffer buffer)
     {
         Buffer = buffer;
     }
 
-    public double GetUint8(double offset)
+    public DataView(ArrayBuffer buffer, double byteOffset, double byteLength)
     {
-        return Buffer.Raw.Array![Buffer.Raw.Offset + (int) offset];
-    }
-
-    public void SetUint16(double offset, double value, bool littleEndian)
-    {
-        var bytes = BitConverter.GetBytes((ushort) value);
-        if (littleEndian != BitConverter.IsLittleEndian)
-        {
-            System.Array.Reverse(bytes);
-        }
-
-        System.Buffer.BlockCopy(bytes, 0, Buffer.Raw.Array!, Buffer.Raw.Offset + (int) offset,
-            bytes.Length);
+        Buffer = buffer;
+        ByteOffset = byteOffset;
+        ByteLength = byteLength;
     }
 
     public double GetInt16(double offset, bool littleEndian)
     {
+        if (littleEndian == BitConverter.IsLittleEndian)
+        {
+            return BitConverter.ToInt16(Buffer.Raw, (int)(ByteOffset + offset));
+        }
+
         var bytes = new byte[sizeof(short)];
-        System.Buffer.BlockCopy(Buffer.Raw.Array!, Buffer.Raw.Offset + (int) offset, bytes, 0,
+        System.Buffer.BlockCopy(Buffer.Raw, (int)(ByteOffset + offset), bytes, 0,
             bytes.Length);
-        if (littleEndian != BitConverter.IsLittleEndian)
-        {
-            System.Array.Reverse(bytes);
-        }
-
+        System.Array.Reverse(bytes);
         return BitConverter.ToInt16(bytes, 0);
-    }
-
-    public void SetInt16(double offset, double value, bool littleEndian)
-    {
-        var bytes = BitConverter.GetBytes((short) value);
-        if (littleEndian != BitConverter.IsLittleEndian)
-        {
-            System.Array.Reverse(bytes);
-        }
-
-        System.Buffer.BlockCopy(bytes, 0, Buffer.Raw.Array!, Buffer.Raw.Offset + (int) offset,
-            bytes.Length);
-    }
-
-    public double GetUint32(double offset, bool littleEndian)
-    {
-        var bytes = new byte[sizeof(uint)];
-        System.Buffer.BlockCopy(Buffer.Raw.Array!, Buffer.Raw.Offset + (int) offset, bytes, 0,
-            bytes.Length);
-        if (littleEndian != BitConverter.IsLittleEndian)
-        {
-            System.Array.Reverse(bytes);
-        }
-
-        return BitConverter.ToUInt32(bytes, 0);
-    }
-
-    public double GetInt32(double offset, bool littleEndian)
-    {
-        var bytes = new byte[sizeof(uint)];
-        System.Buffer.BlockCopy(Buffer.Raw.Array!, Buffer.Raw.Offset + (int) offset, bytes, 0,
-            bytes.Length);
-        if (littleEndian != BitConverter.IsLittleEndian)
-        {
-            System.Array.Reverse(bytes);
-        }
-
-        return BitConverter.ToInt32(bytes, 0);
-    }
-
-    public void SetInt32(double offset, double value, bool littleEndian)
-    {
-        var bytes = BitConverter.GetBytes((int) value);
-        if (littleEndian != BitConverter.IsLittleEndian)
-        {
-            System.Array.Reverse(bytes);
-        }
-
-        System.Buffer.BlockCopy(bytes, 0, Buffer.Raw.Array!, Buffer.Raw.Offset + (int) offset, bytes
-            .Length);
-    }
-
-    public double GetUint16(double offset, bool littleEndian)
-    {
-        var bytes = new byte[sizeof(ushort)];
-        System.Buffer.BlockCopy(Buffer.Raw.Array!, Buffer.Raw.Offset + (int) offset, bytes, 0,
-            bytes.Length);
-        if (littleEndian != BitConverter.IsLittleEndian)
-        {
-            System.Array.Reverse(bytes);
-        }
-
-        return BitConverter.ToUInt16(bytes, 0);
     }
 
     public double GetFloat32(double offset, bool littleEndian = true)
     {
+        if (littleEndian == BitConverter.IsLittleEndian)
+        {
+            return BitConverter.ToSingle(Buffer.Raw, (int)(ByteOffset + offset));
+        }
+
         var bytes = new byte[sizeof(float)];
-        System.Buffer.BlockCopy(Buffer.Raw.Array!, Buffer.Raw.Offset + (int) offset, bytes, 0,
+        System.Buffer.BlockCopy(Buffer.Raw, (int)(ByteOffset + offset), bytes, 0,
             bytes.Length);
-        if (littleEndian != BitConverter.IsLittleEndian)
-        {
-            System.Array.Reverse(bytes);
-        }
-
+        System.Array.Reverse(bytes);
         return BitConverter.ToSingle(bytes, 0);
-    }
-
-    public void SetUint8(double offset, double value)
-    {
-        Buffer.Raw.Array![Buffer.Raw.Offset + (int) offset] = (byte) value;
-    }
-
-    public double GetInt8(double offset)
-    {
-        return (sbyte) Buffer.Raw.Array![Buffer.Raw.Offset + (int) offset];
-    }
-
-    public double SetUint32(double offset, double value, bool littleEndian)
-    {
-        var bytes = BitConverter.GetBytes((uint)value);
-        if (littleEndian != BitConverter.IsLittleEndian)
-        {
-            System.Array.Reverse(bytes);
-        }
-
-        System.Buffer.BlockCopy(bytes, 0, Buffer.Raw.Array!, Buffer.Raw.Offset + (int) offset, bytes
-            .Length);
-        return value;
     }
 }

--- a/src.csharp/AlphaTab/Core/EcmaScript/Int16Array.cs
+++ b/src.csharp/AlphaTab/Core/EcmaScript/Int16Array.cs
@@ -1,72 +1,30 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace AlphaTab.Core.EcmaScript;
 
 internal class Int16Array : IEnumerable<short>
 {
-    private readonly short[]? _data;
-    private readonly ArrayBuffer? _buffer;
+    private readonly short[] _data;
 
-    public double Length => _data?.Length ?? _buffer.ByteLength / 2;
+    public double Length => _data.Length;
 
     public Int16Array(double size)
     {
         _data = new short[(int)size];
     }
 
-    internal Int16Array(ArrayBuffer buffer)
-    {
-        _buffer = buffer;
-    }
-
     public double this[double index]
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get
-        {
-            return _data != null
-                ? _data[(int)index]
-                : GetInt16FromBuffer(index);
-        }
+        get => _data[(int)index];
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        set
-        {
-            if (_data != null)
-            {
-                _data[(int)index] = (short)value;
-            }
-            else
-            {
-                var bytes = BitConverter.GetBytes(value);
-
-                Buffer.BlockCopy(bytes,
-                    0, _buffer.Raw.Array!,
-                    (_buffer.Raw.Offset + ((int)index * sizeof(short))),
-                    bytes.Length * sizeof(short)
-                );
-            }
-        }
-    }
-
-    private short GetInt16FromBuffer(double index)
-    {
-        return BitConverter.ToInt16(_buffer.Raw.Array!,
-            _buffer.Raw.Offset + ((int)index * sizeof(short)));
+        set => _data[(int)index] = (short)value;
     }
 
     public IEnumerator<short> GetEnumerator()
     {
-        if (_data == null)
-        {
-            return Enumerable.Range(0, (int)Length)
-                .Select(i => GetInt16FromBuffer(i))
-                .GetEnumerator();
-        }
-
         return ((IEnumerable<short>)_data).GetEnumerator();
     }
 

--- a/src.csharp/AlphaTab/Io/TypeConversions.cs
+++ b/src.csharp/AlphaTab/Io/TypeConversions.cs
@@ -6,7 +6,14 @@ internal static class TypeConversions
 {
     public static double BytesToFloat32LE(Uint8Array array)
     {
-        return BitConverter.ToSingle(array.Data.Array!, array.Data.Offset);
+        if (!BitConverter.IsLittleEndian)
+        {
+            // not optimal but we know the only usage is in IOHelper
+            // where an own dedicated array is passed-in
+            System.Array.Reverse(array.Buffer.Raw, (int)array.ByteOffset, (int)array.Length);
+        }
+
+        return BitConverter.ToSingle(array.Buffer.Raw, (int)array.ByteOffset);
     }
 
     public static Uint8Array Float32BEToBytes(double v)
@@ -21,7 +28,14 @@ internal static class TypeConversions
 
     public static double BytesToFloat64LE(Uint8Array array)
     {
-        return BitConverter.ToDouble(array.Data.Array!, array.Data.Offset);
+        if (!BitConverter.IsLittleEndian)
+        {
+            // not optimal but we know the only usage is in IOHelper
+            // where an own dedicated array is passed-in
+            System.Array.Reverse(array.Buffer.Raw, (int)array.ByteOffset, (int)array.Length);
+        }
+
+        return BitConverter.ToDouble(array.Buffer.Raw, (int)array.ByteOffset);
     }
 
     public static double Int32ToUint16(double v)
@@ -51,7 +65,13 @@ internal static class TypeConversions
 
     public static double BytesToInt64LE(Uint8Array array)
     {
-        return BitConverter.ToInt64(array.Buffer.Raw.Array!,
-            array.Buffer.Raw.Offset + (int)array.ByteOffset);
+        if (!BitConverter.IsLittleEndian)
+        {
+            // not optimal but we know the only usage is in IOHelper
+            // where an own dedicated array is passed-in
+            System.Array.Reverse(array.Buffer.Raw, (int)array.ByteOffset, (int)array.Length);
+        }
+
+        return BitConverter.ToInt64(array.Buffer.Raw, (int)array.ByteOffset);
     }
 }

--- a/src.csharp/AlphaTab/Platform/Skia/AlphaSkiaBridge/AlphaSkiaBridge.cs
+++ b/src.csharp/AlphaTab/Platform/Skia/AlphaSkiaBridge/AlphaSkiaBridge.cs
@@ -48,7 +48,7 @@ public class AlphaSkiaImage : IDisposable
             return null;
         }
 
-        return new ArrayBuffer(new ArraySegment<byte>(data, 0, data.Length));
+        return new ArrayBuffer(data);
     }
 
     internal ArrayBuffer? ToPng()
@@ -59,19 +59,19 @@ public class AlphaSkiaImage : IDisposable
             return null;
         }
 
-        return new ArrayBuffer(new ArraySegment<byte>(data, 0, data.Length));
+        return new ArrayBuffer(data);
     }
 
     internal static AlphaSkiaImage? Decode(ArrayBuffer buffer)
     {
-        var underlying = AlphaSkia.AlphaSkiaImage.Decode(buffer.Raw.Array!);
+        var underlying = AlphaSkia.AlphaSkiaImage.Decode(buffer.Raw);
         return underlying == null ? null : new AlphaSkiaImage(underlying);
     }
 
     internal static AlphaSkiaImage? FromPixels(double width, double height, ArrayBuffer pixels)
     {
         var underlying =
-            AlphaSkia.AlphaSkiaImage.FromPixels((int)width, (int)height, pixels.Raw.Array!);
+            AlphaSkia.AlphaSkiaImage.FromPixels((int)width, (int)height, pixels.Raw);
         return underlying == null ? null : new AlphaSkiaImage(underlying);
     }
 }
@@ -258,7 +258,7 @@ internal class AlphaSkiaTypeface : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static AlphaSkiaTypeface? Register(ArrayBuffer buffer)
     {
-        var underlying = AlphaSkia.AlphaSkiaTypeface.Register(buffer.Raw.Array!);
+        var underlying = AlphaSkia.AlphaSkiaTypeface.Register(buffer.Raw);
         return underlying == null
             ? null
             : new AlphaSkiaTypeface(underlying);

--- a/src.kotlin/alphaTab/android/build.gradle.kts
+++ b/src.kotlin/alphaTab/android/build.gradle.kts
@@ -144,6 +144,17 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
 }
 
+publishing {
+    repositories{
+        maven {
+            name = "DistPath"
+            url = rootProject.projectDir.resolve("dist").toURI()
+        }
+    }
+}
+
+internal fun Project.findOptionalProperty(propertyName: String) = findProperty(propertyName)?.toString()
+
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
     coordinates(libGroup, libArtifactId, libVersion)
@@ -155,7 +166,14 @@ mavenPublishing {
         publishJavadocJar = true
     ))
 
-    signAllPublications()
+    val inMemoryKeyFile = project.findOptionalProperty("signingInMemoryKeyFile")
+    if (inMemoryKeyFile != null) {
+        val inMemoryKeyId = project.findOptionalProperty("signingInMemoryKeyId")
+        val inMemoryKeyPassword = project.findOptionalProperty("signingInMemoryKeyPassword").orEmpty()
+        val signing = project.extensions.getByType(SigningExtension::class.java)
+        val inMemoryKey = File(inMemoryKeyFile).readText()
+        signing.useInMemoryPgpKeys(inMemoryKeyId, inMemoryKey, inMemoryKeyPassword)
+    }
 
     pom {
         name = libArtifactId

--- a/src.kotlin/alphaTab/android/build.gradle.kts
+++ b/src.kotlin/alphaTab/android/build.gradle.kts
@@ -155,6 +155,8 @@ mavenPublishing {
         publishJavadocJar = true
     ))
 
+    signAllPublications()
+
     pom {
         name = libArtifactId
         description = libDescription

--- a/src.kotlin/alphaTab/android/build.gradle.kts
+++ b/src.kotlin/alphaTab/android/build.gradle.kts
@@ -102,11 +102,28 @@ android {
         getByName("main") {
             java.srcDirs("../../../dist/lib.kotlin/commonMain/generated")
             kotlin.srcDirs("../../../dist/lib.kotlin/commonMain/generated")
+            assets.srcDirs(
+                "../../../font/bravura",
+                "../../../font/sonivox"
+            )
         }
         getByName("test") {
             java.srcDirs("../../../dist/lib.kotlin/commonTest/generated")
             kotlin.srcDirs("../../../dist/lib.kotlin/commonTest/generated")
         }
+    }
+
+    androidResources {
+        ignoreAssetsPattern = arrayOf(
+            "eot",
+            "ttf",
+            "svg",
+            "woff",
+            "woff2",
+            "json",
+            "txt",
+            "md"
+        ).joinToString(":") { "!*.${it}" }
     }
 }
 

--- a/src.kotlin/alphaTab/android/src/main/java/alphaTab/core/ecmaScript/DataView.kt
+++ b/src.kotlin/alphaTab/android/src/main/java/alphaTab/core/ecmaScript/DataView.kt
@@ -3,14 +3,51 @@ package alphaTab.core.ecmaScript
 import java.nio.ByteOrder
 
 @ExperimentalUnsignedTypes
-internal class DataView(val buffer: ArrayBuffer) {
-    private val _bufferView = java.nio.ByteBuffer.wrap(buffer.asByteArray()).order(ByteOrder.LITTLE_ENDIAN)
+internal class DataView {
+    private val _littleEndianBufferView: java.nio.ByteBuffer
+    private val _bigEndianBufferView: java.nio.ByteBuffer
+
+    val buffer: ArrayBuffer
+    val byteOffset: Double
+    val byteLength: Double
+
+    constructor(buffer: ArrayBuffer) {
+        this.buffer = buffer
+        byteOffset = 0.0
+        byteLength = buffer.size.toDouble()
+        this._littleEndianBufferView =
+            java.nio.ByteBuffer.wrap(buffer.asByteArray()).order(ByteOrder.LITTLE_ENDIAN)
+        this._bigEndianBufferView =
+            java.nio.ByteBuffer.wrap(buffer.asByteArray()).order(ByteOrder.BIG_ENDIAN)
+
+    }
+
+    constructor(buffer: ArrayBuffer, byteOffset: Double, byteLength: Double) {
+        this.buffer = buffer
+        this.byteOffset = byteOffset
+        this.byteLength = byteLength
+        this._littleEndianBufferView =
+            java.nio.ByteBuffer.wrap(buffer.asByteArray(), byteOffset.toInt(), byteLength.toInt())
+                .order(ByteOrder.LITTLE_ENDIAN)
+        this._bigEndianBufferView =
+            java.nio.ByteBuffer.wrap(buffer.asByteArray(), byteOffset.toInt(), byteLength.toInt())
+                .order(ByteOrder.BIG_ENDIAN)
+    }
 
     fun getFloat32(index: Double, littleEndian: Boolean): Double {
         return if (littleEndian) {
-            _bufferView.getFloat(index.toInt()).toDouble()
+            _littleEndianBufferView
         } else {
-            _bufferView.order(ByteOrder.BIG_ENDIAN).getFloat(index.toInt()).toDouble()
-        }
+            _bigEndianBufferView
+        }.getFloat((byteOffset + index).toInt()).toDouble()
+    }
+
+
+    fun getInt16(index: Double, littleEndian: Boolean): Double {
+        return if (littleEndian) {
+            _littleEndianBufferView
+        } else {
+            _bigEndianBufferView
+        }.getShort((byteOffset + index).toInt()).toDouble()
     }
 }

--- a/src.kotlin/alphaTab/android/src/main/java/alphaTab/core/ecmaScript/Float32Array.kt
+++ b/src.kotlin/alphaTab/android/src/main/java/alphaTab/core/ecmaScript/Float32Array.kt
@@ -43,7 +43,7 @@ public class Float32Array : Iterable<Float> {
         data[idx] = value.toFloat()
     }
 
-    override fun iterator(): Iterator<Float> {
+    override fun iterator(): FloatIterator {
         return data.iterator()
     }
 

--- a/src.kotlin/alphaTab/android/src/main/java/alphaTab/core/ecmaScript/Int16Array.kt
+++ b/src.kotlin/alphaTab/android/src/main/java/alphaTab/core/ecmaScript/Int16Array.kt
@@ -5,56 +5,32 @@ import alphaTab.core.byteLength
 @Suppress("NOTHING_TO_INLINE")
 @ExperimentalUnsignedTypes
 internal class Int16Array : Iterable<Short> {
-    private val _data: ShortArray?
-    private val _buffer: ArrayBuffer?
-    private val _byteBuffer: java.nio.ByteBuffer?
+    private val _data: ShortArray
 
     public val length: Double
-        get() {
-            return _data?.size?.toDouble() ?: (_buffer!!.byteLength / 2.0)
-        }
+        get() = _data.size.toDouble()
 
     public constructor(size: Double) {
         _data = ShortArray(size.toInt())
-        _buffer = null
-        _byteBuffer = null
-    }
-
-    public constructor(buffer: ArrayBuffer) {
-        _data = null
-        _buffer = buffer
-        _byteBuffer = java.nio.ByteBuffer.wrap(buffer.asByteArray())
     }
 
     public inline operator fun get(index: Double): Double {
         return get(index.toInt())
     }
 
-    fun getInt16FromBuffer(index: Int): Short {
-        return _byteBuffer!!.getShort(index * 2)
-    }
-
     public inline operator fun set(index: Double, value: Double) {
         set(index.toInt(), value)
-
     }
 
     public inline operator fun get(index: Int): Double {
-        return if (_data != null) _data[index].toDouble() else getInt16FromBuffer(index).toDouble()
+        return _data[index].toDouble()
     }
 
     public inline operator fun set(index: Int, value: Double) {
-        if (_data != null) {
-            _data[index] = value.toInt().toShort()
-        } else {
-            _byteBuffer!!.putShort((index * 2), value.toInt().toShort())
-        }
+        _data[index] = value.toInt().toShort()
     }
 
-    override fun iterator(): Iterator<Short> {
-        if (_data == null) {
-            return (0 until length.toInt()).map { getInt16FromBuffer(it) }.iterator()
-        }
+    override fun iterator(): ShortIterator {
         return _data.iterator()
     }
 }

--- a/src.kotlin/alphaTab/android/src/main/java/alphaTab/core/ecmaScript/Int32Array.kt
+++ b/src.kotlin/alphaTab/android/src/main/java/alphaTab/core/ecmaScript/Int32Array.kt
@@ -47,8 +47,14 @@ internal class Int32Array : Iterable<Int> {
         _data.fill(i)
     }
 
-    override fun iterator(): Iterator<Int> {
-        return (0 until length.toInt()).map { _data[_offset + it] }.iterator()
+    override fun iterator(): IntIterator {
+        return ArrayIntIterator(this)
+    }
+
+    private class ArrayIntIterator(private val array: Int32Array) : IntIterator() {
+        private var index = 0
+        override fun hasNext() = index < array.length
+        override fun nextInt() = array._data[array._offset + index++]
     }
 
     fun subarray(start: Double, end: Double): Int32Array {

--- a/src.kotlin/alphaTab/android/src/main/java/alphaTab/core/ecmaScript/Uint8Array.kt
+++ b/src.kotlin/alphaTab/android/src/main/java/alphaTab/core/ecmaScript/Uint8Array.kt
@@ -47,7 +47,9 @@ public class Uint8Array : Iterable<UByte> {
     }
 
     internal inline fun set(subarray: Uint8Array, pos: Double) {
-        subarray.buffer.copyInto(buffer, pos.toInt(), this.byteOffset.toInt(), subarray.buffer.size)
+        subarray.buffer.copyInto(buffer, (byteOffset + pos).toInt(),
+            subarray.byteOffset.toInt(),
+            (subarray.byteOffset + subarray.length).toInt())
     }
 
     override fun iterator(): Iterator<UByte> {
@@ -56,7 +58,11 @@ public class Uint8Array : Iterable<UByte> {
     }
 
     internal fun subarray(begin: Double, end: Double): Uint8Array {
-        return Uint8Array(buffer.copyOfRange((this.byteOffset + begin).toInt(), (this.byteOffset + end).toInt()))
+        return Uint8Array(
+            buffer,
+            this.byteOffset + begin,
+            end - begin
+        )
     }
 
     internal fun reverse() {
@@ -65,7 +71,8 @@ public class Uint8Array : Iterable<UByte> {
 
     internal fun slice(startByte: Double, endByte: Double): Uint8Array {
         return Uint8Array(
-            this.buffer, this.byteOffset + startByte,
+            this.buffer,
+            this.byteOffset + startByte,
             endByte - startByte)
     }
 }

--- a/src.kotlin/alphaTab/android/src/main/java/alphaTab/platform/android/AndroidAudioWorker.kt
+++ b/src.kotlin/alphaTab/android/src/main/java/alphaTab/platform/android/AndroidAudioWorker.kt
@@ -89,7 +89,7 @@ internal class AndroidAudioWorker(
             _updateSchedule = _updateTimer.scheduleWithFixedDelay(
                 {
                     this@AndroidAudioWorker.onUpdatePlayedSamples()
-                }, 0L, 0, TimeUnit.MILLISECONDS
+                }, 0L, 50L, TimeUnit.MILLISECONDS
             )
 
             _playingSemaphore.release() // proceed thread

--- a/src.kotlin/alphaTab/gradle/libs.versions.toml
+++ b/src.kotlin/alphaTab/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 alphaskia = "2.3.120"
-mavenPublish = "0.31.1-SNAPSHOT"
+mavenPublish = "0.31.0"
 
 
 [libraries]

--- a/src/synth/soundfont/Hydra.ts
+++ b/src/synth/soundfont/Hydra.ts
@@ -48,10 +48,10 @@ export class Hydra {
                 // 6.1 Sample Data Format in the smpl Sub-chunk
                 // The smpl sub-chunk, if present, contains one or more "samples" of digital audio information in the form
                 // of linearly coded sixteen bit, signed, little endian (least significant byte first) words.
-                let shorts = new Int16Array(sampleBytes.buffer);
-                samples = new Float32Array(shorts.length);
-                for (let i: number = 0; i < shorts.length; i++) {
-                    samples[i] = shorts[i] / 32767;
+                const dataView = new DataView(sampleBytes.buffer, sampleBytes.byteOffset, sampleBytes.length);
+                samples = new Float32Array(sampleBytes.length / 2);
+                for (let i: number = 0; i < samples.length; i++) {
+                    samples[i] = dataView.getInt16(i * 2, true) / 32767;
                 }
             }
 


### PR DESCRIPTION
### Issues
Relates to #1959 

### Proposed changes
Fixes some problematic bits on the android env:

1. Font and SoundFont were not embedded anymore
2. The sample decoding was wrong due to BigEndian platform endianess.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
