### PR TITLE
build: Publish NPM package with type commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
         "test-csharp": "cd src.csharp && dotnet test -c Release",
         "test-kotlin": "node scripts/gradlew.mjs testReleaseUnitTest --info",
         "test-accept-reference": "tsx scripts/accept-new-reference-files.ts",
-        "typecheck": "tsc --noEmit"
+        "typecheck": "tsc --noEmit",
+        "prepack": "node scripts/prepack.mjs"
     },
     "devDependencies": {
         "@biomejs/biome": "^1.9.4",

--- a/scripts/prepack.mjs
+++ b/scripts/prepack.mjs
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import url from 'node:url';
+import fs from 'node:fs';
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+const packageJsonPath = path.resolve(__dirname, '..', 'package.json');
+
+
+let packageJsonContent = await fs.promises.readFile(packageJsonPath, 'utf-8');
+packageJsonContent = packageJsonContent.replace('"type": "module"', '"type": "commonjs"');
+await fs.promises.writeFile(packageJsonPath, packageJsonContent);


### PR DESCRIPTION
### Issues
Fixes #2045 #2044

### Proposed changes
Node.js seems to have a bit a wierd behavior when it comes to loading modules. Despite the `exports` section defining (seemingly) the format and path for it, it behaves different.

Likely this started to become a problem with Node 22 which added support to load ESM files from CommonJS files:

The conditional `export` is only used to resolve the path to the file. But then if `.js` is used as extension, they load the file based on `type` in the parent package.json. 

We have `type: module` as we mainly use ESM stuff in our own repo and a lot of tooling, and also node itself when executing scripts, rely on this. Again some tooling do not support extensions like `.mts`. 

Using `.cjs` is also not fully correct as alphaTab itself is rather a UMD than a CJS only. The extension change would be a breaking one and could lead to problems when using this file in browser scenarios. 

Putting this all together, our best choice is to rewrite the package.json before packing/publishing the NPM to mark publicly that `.js` files in this package are commonjs, but keeping things as ESM when working on this project. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
