### PR TITLE
fix: Wrong staff ID for numbered bar renderer

### DIFF
--- a/src/rendering/BarRendererBase.ts
+++ b/src/rendering/BarRendererBase.ts
@@ -92,14 +92,14 @@ export class BarRendererBase {
         if (!this.bar || !this.bar.nextBar) {
             return null;
         }
-        return this.scoreRenderer.layout!.getRendererForBar(this.staff.staveId, this.bar.nextBar);
+        return this.scoreRenderer.layout!.getRendererForBar(this.staff.staffId, this.bar.nextBar);
     }
 
     public get previousRenderer(): BarRendererBase | null {
         if (!this.bar || !this.bar.previousBar) {
             return null;
         }
-        return this.scoreRenderer.layout!.getRendererForBar(this.staff.staveId, this.bar.previousBar);
+        return this.scoreRenderer.layout!.getRendererForBar(this.staff.staffId, this.bar.previousBar);
     }
 
     public scoreRenderer: ScoreRenderer;

--- a/src/rendering/NumberedBarRendererFactory.ts
+++ b/src/rendering/NumberedBarRendererFactory.ts
@@ -1,7 +1,6 @@
 import type { Bar } from '@src/model/Bar';
 import type { BarRendererBase } from '@src/rendering/BarRendererBase';
 import { BarRendererFactory } from '@src/rendering/BarRendererFactory';
-import { SlashBarRenderer } from '@src/rendering/SlashBarRenderer';
 import type { ScoreRenderer } from '@src/rendering/ScoreRenderer';
 import type { Track } from '@src/model/Track';
 import type { Staff } from '@src/model/Staff';
@@ -13,7 +12,7 @@ import { NumberedBarRenderer } from '@src/rendering/NumberedBarRenderer';
  */
 export class NumberedBarRendererFactory extends BarRendererFactory {
     public get staffId(): string {
-        return SlashBarRenderer.StaffId;
+        return NumberedBarRenderer.StaffId;
     }
 
     public override getStaffPaddingTop(staff: RenderStaff): number {

--- a/src/rendering/glyphs/NumberedSlurGlyph.ts
+++ b/src/rendering/glyphs/NumberedSlurGlyph.ts
@@ -61,7 +61,7 @@ export class NumberedSlurGlyph extends TabTieGlyph {
 
     public override paint(cx: number, cy: number, canvas: ICanvas): void {
         const startNoteRenderer: BarRendererBase = this.renderer.scoreRenderer.layout!.getRendererForBar(
-            this.renderer.staff.staveId,
+            this.renderer.staff.staffId,
             this.startBeat!.voice.bar
         )!;
         const direction: BeamDirection = this.getBeamDirection(this.startBeat!, startNoteRenderer);

--- a/src/rendering/glyphs/ScoreBendGlyph.ts
+++ b/src/rendering/glyphs/ScoreBendGlyph.ts
@@ -116,7 +116,7 @@ export class ScoreBendGlyph extends ScoreHelperNotesBaseGlyph {
     public override paint(cx: number, cy: number, canvas: ICanvas): void {
         // Draw note heads
         const startNoteRenderer: ScoreBarRenderer = this.renderer.scoreRenderer.layout!.getRendererForBar(
-            this.renderer.staff.staveId,
+            this.renderer.staff.staffId,
             this._beat.voice.bar
         )! as ScoreBarRenderer;
         const startX: number =
@@ -166,7 +166,7 @@ export class ScoreBendGlyph extends ScoreHelperNotesBaseGlyph {
                 const endNoteRenderer: ScoreBarRenderer | null = !endNote
                     ? null
                     : (this.renderer.scoreRenderer.layout!.getRendererForBar(
-                          this.renderer.staff.staveId,
+                          this.renderer.staff.staffId,
                           endNote.beat.voice.bar
                       ) as ScoreBarRenderer);
                 // if we have a line break we draw only a line until the end

--- a/src/rendering/glyphs/ScoreSlideLineGlyph.ts
+++ b/src/rendering/glyphs/ScoreSlideLineGlyph.ts
@@ -90,7 +90,7 @@ export class ScoreSlideLineGlyph extends Glyph {
                 if (this._startNote.slideTarget) {
                     const endNoteRenderer: BarRendererBase | null =
                         this.renderer.scoreRenderer.layout!.getRendererForBar(
-                            this.renderer.staff.staveId,
+                            this.renderer.staff.staffId,
                             this._startNote.slideTarget.beat.voice.bar
                         );
                     if (!endNoteRenderer || endNoteRenderer.staff !== startNoteRenderer.staff) {

--- a/src/rendering/glyphs/ScoreWhammyBarGlyph.ts
+++ b/src/rendering/glyphs/ScoreWhammyBarGlyph.ts
@@ -113,7 +113,7 @@ export class ScoreWhammyBarGlyph extends ScoreHelperNotesBaseGlyph {
         }
         const whammyMode: NotationMode = this.renderer.settings.notation.notationMode;
         const startNoteRenderer: ScoreBarRenderer = this.renderer.scoreRenderer.layout!.getRendererForBar(
-            this.renderer.staff.staveId,
+            this.renderer.staff.staffId,
             beat.voice.bar
         )! as ScoreBarRenderer;
 
@@ -151,7 +151,7 @@ export class ScoreWhammyBarGlyph extends ScoreHelperNotesBaseGlyph {
             let endNoteRenderer: ScoreBarRenderer | null = null;
             if (note.isTieOrigin) {
                 endNoteRenderer = this.renderer.scoreRenderer.layout!.getRendererForBar(
-                    this.renderer.staff.staveId,
+                    this.renderer.staff.staffId,
                     note.tieDestination!.beat.voice.bar
                 ) as ScoreBarRenderer | null;
                 if (endNoteRenderer && endNoteRenderer.staff === startNoteRenderer.staff) {

--- a/src/rendering/glyphs/TabBendGlyph.ts
+++ b/src/rendering/glyphs/TabBendGlyph.ts
@@ -225,7 +225,7 @@ export class TabBendGlyph extends Glyph {
             while (endNote.isTieOrigin) {
                 const nextNote: Note = endNote.tieDestination!;
                 endNoteRenderer = this.renderer.scoreRenderer.layout!.getRendererForBar(
-                    this.renderer.staff.staveId,
+                    this.renderer.staff.staffId,
                     nextNote.beat.voice.bar
                 );
                 if (!endNoteRenderer || startNoteRenderer.staff !== endNoteRenderer.staff) {
@@ -245,7 +245,7 @@ export class TabBendGlyph extends Glyph {
 
             endBeat = endNote.beat;
             endNoteRenderer = this.renderer.scoreRenderer.layout!.getRendererForBar(
-                this.renderer.staff.staveId,
+                this.renderer.staff.staffId,
                 endBeat.voice.bar
             ) as TabBarRenderer;
             if (

--- a/src/rendering/glyphs/TabSlideLineGlyph.ts
+++ b/src/rendering/glyphs/TabSlideLineGlyph.ts
@@ -101,7 +101,7 @@ export class TabSlideLineGlyph extends Glyph {
                 if (this._startNote.slideTarget) {
                     const endNoteRenderer: BarRendererBase | null =
                         this.renderer.scoreRenderer.layout!.getRendererForBar(
-                            this.renderer.staff.staveId,
+                            this.renderer.staff.staffId,
                             this._startNote.slideTarget.beat.voice.bar
                         );
                     if (!endNoteRenderer || endNoteRenderer.staff !== startNoteRenderer.staff) {

--- a/src/rendering/glyphs/TabSlurGlyph.ts
+++ b/src/rendering/glyphs/TabSlurGlyph.ts
@@ -66,7 +66,7 @@ export class TabSlurGlyph extends TabTieGlyph {
 
     public override paint(cx: number, cy: number, canvas: ICanvas): void {
         const startNoteRenderer: BarRendererBase = this.renderer.scoreRenderer.layout!.getRendererForBar(
-            this.renderer.staff.staveId,
+            this.renderer.staff.staffId,
             this.startBeat!.voice.bar
         )!;
         const direction: BeamDirection = this.getBeamDirection(this.startBeat!, startNoteRenderer);

--- a/src/rendering/glyphs/TabWhammyBarGlyph.ts
+++ b/src/rendering/glyphs/TabWhammyBarGlyph.ts
@@ -113,7 +113,7 @@ export class TabWhammyBarGlyph extends Glyph {
         let endXPositionType: BeatXPosition = BeatXPosition.PreNotes;
         if (endBeat) {
             endNoteRenderer = this.renderer.scoreRenderer.layout!.getRendererForBar(
-                this.renderer.staff.staveId,
+                this.renderer.staff.staffId,
                 endBeat.voice.bar
             ) as TabBarRenderer | null;
             if (!endNoteRenderer || endNoteRenderer.staff !== startNoteRenderer.staff) {

--- a/src/rendering/glyphs/TieGlyph.ts
+++ b/src/rendering/glyphs/TieGlyph.ts
@@ -38,12 +38,12 @@ export class TieGlyph extends Glyph {
         }
 
         const startNoteRenderer = this.renderer.scoreRenderer.layout!.getRendererForBar(
-            this.renderer.staff.staveId,
+            this.renderer.staff.staffId,
             this.startBeat!.voice.bar
         );
         this.startNoteRenderer = startNoteRenderer;
         const endNoteRenderer = this.renderer.scoreRenderer.layout!.getRendererForBar(
-            this.renderer.staff.staveId,
+            this.renderer.staff.staffId,
             this.endBeat.voice.bar
         );
         this.endNoteRenderer = endNoteRenderer;

--- a/src/rendering/staves/RenderStaff.ts
+++ b/src/rendering/staves/RenderStaff.ts
@@ -36,7 +36,7 @@ export class RenderStaff {
     public trackIndex: number = 0;
     public modelStaff: Staff;
 
-    public get staveId(): string {
+    public get staffId(): string {
         return this._factory.staffId;
     }
 
@@ -103,7 +103,7 @@ export class RenderStaff {
         renderer.index = this.barRenderers.length;
         renderer.reLayout();
         this.barRenderers.push(renderer);
-        this.system.layout.registerBarRenderer(this.staveId, renderer);
+        this.system.layout.registerBarRenderer(this.staffId, renderer);
     }
 
     public addBar(bar: Bar, layoutingInfo: BarLayoutingInfo, additionalMultiBarsRestBars: Bar[] | null): void {
@@ -127,14 +127,14 @@ export class RenderStaff {
 
         this.barRenderers.push(renderer);
         if (bar) {
-            this.system.layout.registerBarRenderer(this.staveId, renderer);
+            this.system.layout.registerBarRenderer(this.staffId, renderer);
         }
     }
 
     public revertLastBar(): BarRendererBase {
         const lastBar: BarRendererBase = this.barRenderers[this.barRenderers.length - 1];
         this.barRenderers.splice(this.barRenderers.length - 1, 1);
-        this.system.layout.unregisterBarRenderer(this.staveId, lastBar);
+        this.system.layout.unregisterBarRenderer(this.staffId, lastBar);
         for (const r of this.barRenderers) {
             r.applyLayoutingInfo();
         }

--- a/src/rendering/staves/StaffSystem.ts
+++ b/src/rendering/staves/StaffSystem.ts
@@ -785,7 +785,7 @@ export class StaffSystem {
             return 0;
         }
         const bar: Bar = this.layout.renderer.tracks![0].staves[0].bars[index];
-        const renderer: BarRendererBase = this.layout.getRendererForBar(this._firstStaffInBrackets.staveId, bar)!;
+        const renderer: BarRendererBase = this.layout.getRendererForBar(this._firstStaffInBrackets.staffId, bar)!;
         return renderer.x;
     }
 }

--- a/src/rendering/utils/AccidentalHelper.ts
+++ b/src/rendering/utils/AccidentalHelper.ts
@@ -334,7 +334,7 @@ export class AccidentalHelper {
                     if (note && note.isTieDestination && note.beat.index === 0) {
                         // candidate for skip, check further if start note is on the same line
                         const tieOriginBarRenderer = this._barRenderer.scoreRenderer.layout?.getRendererForBar(
-                            this._barRenderer.staff.staveId,
+                            this._barRenderer.staff.staffId,
                             note.tieOrigin!.beat.voice.bar
                         ) as ScoreBarRenderer | null;
                         if (tieOriginBarRenderer && tieOriginBarRenderer.staff === this._barRenderer.staff) {


### PR DESCRIPTION
### Issues
Fixes #2050

### Proposed changes
1. Use the correct staffId for the numbered bar renderer staff.
2. rename plural `staveId` to singluar `staffId`

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
