### PR TITLE
fix(alphatex): Wrong instrument articulations for export

### DIFF
--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -2588,7 +2588,7 @@ export class AlphaTexImporter extends ScoreImporter {
                 articulationIndex = this._articulationValueToIndex.get(articulationValue)!;
             } else {
                 articulationIndex = this._currentTrack.percussionArticulations.length;
-                const articulation = PercussionMapper.getArticulationByValue(articulationValue);
+                const articulation = PercussionMapper.getArticulationByInputMidiNumber(articulationValue);
                 if (articulation === null) {
                     this.errorMessage(`Unknown articulation value ${articulationValue}`);
                 }

--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -2594,7 +2594,7 @@ export class AlphaTexImporter extends ScoreImporter {
                 }
 
                 this._currentTrack.percussionArticulations.push(articulation!);
-                this._articulationValueToIndex.set(articulationValue, articulationIndex)!;
+                this._articulationValueToIndex.set(articulationValue, articulationIndex);
             }
 
             note.percussionArticulation = articulationIndex;

--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -187,6 +187,8 @@ export class AlphaTexImporter extends ScoreImporter {
 
     private _slurs: Map<string, Note> = new Map<string, Note>();
 
+    private _articulationValueToIndex = new Map<number, number>();
+
     private _accidentalMode: AlphaTexAccidentalMode = AlphaTexAccidentalMode.Explicit;
 
     public logErrors: boolean = false;
@@ -380,6 +382,7 @@ export class AlphaTexImporter extends ScoreImporter {
         const staff = this._currentTrack.staves[0];
         staff.displayTranspositionPitch = 0;
         staff.stringTuning.tunings = Tuning.getDefaultTuningFor(6)!.tunings;
+        this._articulationValueToIndex.clear();
 
         this.beginStaff(staff);
 
@@ -2579,7 +2582,22 @@ export class AlphaTexImporter extends ScoreImporter {
                 note.fret = fret;
             }
         } else if (this._currentStaff.isPercussion) {
-            note.percussionArticulation = fret;
+            const articulationValue = fret;
+            let articulationIndex: number = 0;
+            if (this._articulationValueToIndex.has(articulationValue)) {
+                articulationIndex = this._articulationValueToIndex.get(articulationValue)!;
+            } else {
+                articulationIndex = this._currentTrack.percussionArticulations.length;
+                const articulation = PercussionMapper.getArticulationByValue(articulationValue);
+                if (articulation === null) {
+                    this.errorMessage(`Unknown articulation value ${articulationValue}`);
+                }
+
+                this._currentTrack.percussionArticulations.push(articulation!);
+                this._articulationValueToIndex.set(articulationValue, articulationIndex)!;
+            }
+
+            note.percussionArticulation = articulationIndex;
         } else {
             note.octave = octave;
             note.tone = tone;

--- a/src/model/PercussionMapper.ts
+++ b/src/model/PercussionMapper.ts
@@ -1266,7 +1266,7 @@ export class PercussionMapper {
             return trackArticulations[articulationIndex];
         }
 
-        return PercussionMapper.getArticulationByValue(articulationIndex);
+        return PercussionMapper.getArticulationByInputMidiNumber(articulationIndex);
     }
 
     public static getElementAndVariation(n: Note): number[] {
@@ -1279,7 +1279,7 @@ export class PercussionMapper {
         for (let element = 0; element < PercussionMapper.gp6ElementAndVariationToArticulation.length; element++) {
             const variations = PercussionMapper.gp6ElementAndVariationToArticulation[element];
             for (let variation = 0; variation < variations.length; variation++) {
-                const gp6Articulation = PercussionMapper.getArticulationByValue(variations[variation]);
+                const gp6Articulation = PercussionMapper.getArticulationByInputMidiNumber(variations[variation]);
                 if (gp6Articulation?.outputMidiNumber === articulation.outputMidiNumber) {
                     return [element, variation];
                 }
@@ -1289,9 +1289,9 @@ export class PercussionMapper {
         return [-1, -1];
     }
 
-    public static getArticulationByValue(midiNumber: number): InstrumentArticulation | null {
-        if (PercussionMapper.instrumentArticulations.has(midiNumber)) {
-            return PercussionMapper.instrumentArticulations.get(midiNumber)!;
+    public static getArticulationByInputMidiNumber(inputMidiNumber: number): InstrumentArticulation | null {
+        if (PercussionMapper.instrumentArticulations.has(inputMidiNumber)) {
+            return PercussionMapper.instrumentArticulations.get(inputMidiNumber)!;
         }
         return null;
     }

--- a/src/rendering/utils/AccidentalHelper.ts
+++ b/src/rendering/utils/AccidentalHelper.ts
@@ -125,7 +125,7 @@ export class AccidentalHelper {
         if (noteValue < bar.staff.track.percussionArticulations.length) {
             return bar.staff.track.percussionArticulations[noteValue]!.staffLine;
         }
-        return PercussionMapper.getArticulationByValue(noteValue)?.staffLine ?? 0;
+        return PercussionMapper.getArticulationByInputMidiNumber(noteValue)?.staffLine ?? 0;
     }
 
     public static getNoteValue(note: Note) {

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -1266,10 +1266,14 @@ describe('AlphaTexImporterTest', () => {
         `);
         expect(score.tracks[0].playbackInfo.primaryChannel).to.equal(9);
         expect(score.tracks[0].staves[0].isPercussion).to.be.true;
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].notes[0].percussionArticulation).to.equal(30);
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[1].notes[0].percussionArticulation).to.equal(31);
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[2].notes[0].percussionArticulation).to.equal(33);
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[3].notes[0].percussionArticulation).to.equal(34);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].notes[0].percussionArticulation).to.equal(0);
+        expect(score.tracks[0].percussionArticulations[0].outputMidiNumber).to.equal(49);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[1].notes[0].percussionArticulation).to.equal(1);
+        expect(score.tracks[0].percussionArticulations[1].outputMidiNumber).to.equal(40);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[2].notes[0].percussionArticulation).to.equal(2);
+        expect(score.tracks[0].percussionArticulations[2].outputMidiNumber).to.equal(37);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[3].notes[0].percussionArticulation).to.equal(3);
+        expect(score.tracks[0].percussionArticulations[3].outputMidiNumber).to.equal(38);
     });
 
     it('percussion-custom-articulation', () => {
@@ -1284,10 +1288,14 @@ describe('AlphaTexImporterTest', () => {
         `);
         expect(score.tracks[0].playbackInfo.primaryChannel).to.equal(9);
         expect(score.tracks[0].staves[0].isPercussion).to.be.true;
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].notes[0].percussionArticulation).to.equal(30);
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[1].notes[0].percussionArticulation).to.equal(31);
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[2].notes[0].percussionArticulation).to.equal(33);
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[3].notes[0].percussionArticulation).to.equal(34);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].notes[0].percussionArticulation).to.equal(0);
+        expect(score.tracks[0].percussionArticulations[0].outputMidiNumber).to.equal(49);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[1].notes[0].percussionArticulation).to.equal(1);
+        expect(score.tracks[0].percussionArticulations[1].outputMidiNumber).to.equal(40);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[2].notes[0].percussionArticulation).to.equal(2);
+        expect(score.tracks[0].percussionArticulations[2].outputMidiNumber).to.equal(37);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[3].notes[0].percussionArticulation).to.equal(3);
+        expect(score.tracks[0].percussionArticulations[3].outputMidiNumber).to.equal(38);
     });
 
     it('percussion-default-articulations', () => {
@@ -1299,10 +1307,14 @@ describe('AlphaTexImporterTest', () => {
         `);
         expect(score.tracks[0].playbackInfo.primaryChannel).to.equal(9);
         expect(score.tracks[0].staves[0].isPercussion).to.be.true;
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].notes[0].percussionArticulation).to.equal(30);
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[1].notes[0].percussionArticulation).to.equal(31);
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[2].notes[0].percussionArticulation).to.equal(33);
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[3].notes[0].percussionArticulation).to.equal(34);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].notes[0].percussionArticulation).to.equal(0);
+        expect(score.tracks[0].percussionArticulations[0].outputMidiNumber).to.equal(49);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[1].notes[0].percussionArticulation).to.equal(1);
+        expect(score.tracks[0].percussionArticulations[1].outputMidiNumber).to.equal(40);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[2].notes[0].percussionArticulation).to.equal(2);
+        expect(score.tracks[0].percussionArticulations[2].outputMidiNumber).to.equal(37);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[3].notes[0].percussionArticulation).to.equal(3);
+        expect(score.tracks[0].percussionArticulations[3].outputMidiNumber).to.equal(38);
     });
 
     it('percussion-default-articulations-short', () => {
@@ -1314,10 +1326,14 @@ describe('AlphaTexImporterTest', () => {
         `);
         expect(score.tracks[0].playbackInfo.primaryChannel).to.equal(9);
         expect(score.tracks[0].staves[0].isPercussion).to.be.true;
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].notes[0].percussionArticulation).to.equal(30);
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[1].notes[0].percussionArticulation).to.equal(31);
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[2].notes[0].percussionArticulation).to.equal(33);
-        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[3].notes[0].percussionArticulation).to.equal(34);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[0].notes[0].percussionArticulation).to.equal(0);
+        expect(score.tracks[0].percussionArticulations[0].outputMidiNumber).to.equal(49);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[1].notes[0].percussionArticulation).to.equal(1);
+        expect(score.tracks[0].percussionArticulations[1].outputMidiNumber).to.equal(40);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[2].notes[0].percussionArticulation).to.equal(2);
+        expect(score.tracks[0].percussionArticulations[2].outputMidiNumber).to.equal(37);
+        expect(score.tracks[0].staves[0].bars[0].voices[0].beats[3].notes[0].percussionArticulation).to.equal(3);
+        expect(score.tracks[0].percussionArticulations[3].outputMidiNumber).to.equal(38);
     });
 
     it('beat-tempo-change', () => {


### PR DESCRIPTION
### Issues
Fixes #2056 

### Proposed changes
We wrongly used the midi number as percussion articulation on notes. While this worked internally in alphaTab thanks to some fallback mechanism, it fails when we export to GP.

Now we collect the articulations in the track and reference with the currect index. This way the values will match what GP expects. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
