### PR TITLE
fix: Ensure synth stops voices when end is reached

### DIFF
--- a/src/synth/AlphaSynth.ts
+++ b/src/synth/AlphaSynth.ts
@@ -446,36 +446,49 @@ export class AlphaSynth implements IAlphaSynth {
             endTick = this._sequencer.currentEndTick;
         }
 
-        if (this._tickPosition >= endTick && this._notPlayedSamples <= 0) {
-            this._notPlayedSamples = 0;
-            if (this._sequencer.isPlayingCountIn) {
-                Logger.debug('AlphaSynth', 'Finished playback (count-in)');
-                this._sequencer.resetCountIn();
-                this.timePosition = this._sequencer.currentTime;
-                this.playInternal();
-                this.output.resetSamples();
-            } else if (this._sequencer.isPlayingOneTimeMidi) {
-                Logger.debug('AlphaSynth', 'Finished playback (one time)');
-                this.output.resetSamples();
-                this.state = PlayerState.Paused;
-                this.stopOneTimeMidi();
-            } else if (this.isLooping) {
-                Logger.debug('AlphaSynth', 'Finished playback (main looping)');
-                (this.finished as EventEmitter).trigger();
-                this.tickPosition = startTick;
-                this._synthStopping = false;
-            } else if (this._synthesizer.activeVoiceCount > 0) {
-                // smooth stop
+        if (this._tickPosition >= endTick) {
+            // fully done with playback of remaining samples? 
+            if(this._notPlayedSamples <= 0) {
+                this._notPlayedSamples = 0;
+                if (this._sequencer.isPlayingCountIn) {
+                    Logger.debug('AlphaSynth', 'Finished playback (count-in)');
+                    this._sequencer.resetCountIn();
+                    this.timePosition = this._sequencer.currentTime;
+                    this.playInternal();
+                    this.output.resetSamples();
+                } else if (this._sequencer.isPlayingOneTimeMidi) {
+                    Logger.debug('AlphaSynth', 'Finished playback (one time)');
+                    this.output.resetSamples();
+                    this.state = PlayerState.Paused;
+                    this.stopOneTimeMidi();
+                } else if (this.isLooping) {
+                    Logger.debug('AlphaSynth', 'Finished playback (main looping)');
+                    (this.finished as EventEmitter).trigger();
+                    this.tickPosition = startTick;
+                    this._synthStopping = false;
+                } else if (this._synthesizer.activeVoiceCount > 0) {
+                    // smooth stop
+                    if (!this._synthStopping) {
+                        Logger.debug('AlphaSynth', 'Signaling synth to stop all voices (all samples played)');
+                        this._synthesizer.noteOffAll(true);
+                        this._synthStopping = true;
+                    }
+                } else {
+                    this._synthStopping = false;
+                    Logger.debug('AlphaSynth', 'Finished playback (main)');
+                    (this.finished as EventEmitter).trigger();
+                    this.stop();
+                }
+            } else {
+                // the output still has to play some samples, signal the synth to stop
+                // to eventually bring the voices down to 0 and stop playing
                 if (!this._synthStopping) {
+                    Logger.debug('AlphaSynth', 'Signaling synth to stop all voices (not all samples played)');
                     this._synthesizer.noteOffAll(true);
                     this._synthStopping = true;
                 }
-            } else {
-                this._synthStopping = false;
-                Logger.debug('AlphaSynth', 'Finished playback (main)');
-                (this.finished as EventEmitter).trigger();
-                this.stop();
             }
+          
         }
     }
 


### PR DESCRIPTION
### Issues
Fixes #2076

### Proposed changes
It can happen that the synth keeps producing samples endlessly even though the end of the song is reached. The output keeps requesting samples, and the synth keeps producing them (and the voices stay active). 

With the adaptions in this PR we ensure we signal the synth to stop all voices. The ramp down should stil be smooth enough to avoid crackling noises on the output. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
