### PR TITLE
feat: Add basic implementation for external media backing track

### DIFF
--- a/playground-template/control.mjs
+++ b/playground-template/control.mjs
@@ -224,14 +224,13 @@ export function setupControl(selector, customSettings) {
 
     const settings = new alphaTab.Settings();
     applyFonts(settings);
+    settings.fillFromJson(defaultSettings);
     settings.fillFromJson({
-        ...defaultSettings,
         player: {
-            ...defaultSettings.player,
             scrollElement: viewPort
         },
-        ...customSettings
     });
+    settings.fillFromJson(customSettings);
 
     const at = new alphaTab.AlphaTabApi(el, settings);
     at.error.on(function (e) {

--- a/playground-template/youtube.css
+++ b/playground-template/youtube.css
@@ -1,0 +1,10 @@
+
+.at-wrap {
+    height: calc(90vh - 360px);
+    margin: 0;
+}
+.youtube-wrap {
+    height: 360px;
+    display: flex;
+    justify-content: center;
+}

--- a/playground-template/youtube.html
+++ b/playground-template/youtube.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <title>AlphaTab Control Demo</title>
+
+    <script src="/node_modules/@popperjs/core/dist/umd/popper.min.js"></script>
+    <script src="/node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
+
+    <script src="/node_modules/handlebars/dist/handlebars.min.js"></script>
+
+    <link rel="stylesheet" href="control.css" />
+    <link rel="stylesheet" href="youtube.css" />
+</head>
+
+<body>
+    <div class="youtube-wrap">
+        <div id="youtube"></div>
+    </div>
+    <div id="placeholder"></div>
+
+    <script type="module">
+        import { setupControl } from './control.mjs';
+        import * as alphaTab from '../src/alphaTab.main';
+
+        const playerElement = document.getElementById('youtube');
+        const tag = document.createElement('script');
+        tag.src = "https://www.youtube.com/player_api";
+        playerElement.parentNode.insertBefore(tag, playerElement);
+
+        const youtubeApiReady = Promise.withResolvers();
+        window.onYouTubePlayerAPIReady = youtubeApiReady.resolve;
+
+        const req = new XMLHttpRequest();
+        req.onload = async (data) => {
+            document.getElementById('placeholder').outerHTML = req.responseText;
+            const at = setupControl('#alphaTab', {
+                core: {
+                    file: '/test-data/guitarpro8/canon-audio-track.gp'
+                },
+                player: {
+                    playerMode: alphaTab.PlayerMode.EnabledExternalMedia
+                }
+            });
+            window.at = at;
+
+
+            //
+            // Youtube
+
+            // Wait for Youtube API
+            await youtubeApiReady.promise; // wait for API
+
+            // Setup youtube player
+            const youtubePlayerReady = Promise.withResolvers();
+            let currentTimeInterval  = undefined;
+            const player = new YT.Player(playerElement, {
+                height: '360',
+                width: '640',
+                videoId: 'by8oyJztzwo',
+                playerVars: { 'autoplay': 0 },
+                events: {
+                    'onReady': (e) => {
+                        youtubePlayerReady.resolve();
+                        console.log('YT onReady', player, e)
+                    },
+                    'onStateChange': (e) => {
+                        switch (e.data) {
+                            case YT.PlayerState.PLAYING:
+                                currentTimeInterval = setInterval(() => {
+                                    at.player.output.updatePosition(player.getCurrentTime() * 1000)
+                                }, 50);
+                                at.play();
+                                break;
+                            case YT.PlayerState.ENDED:
+                                clearInterval(currentTimeInterval);
+                                at.stop();
+                                break;
+                            case YT.PlayerState.PAUSED:
+                                clearInterval(currentTimeInterval);
+                                at.pause();
+                                break;
+                            default:
+                                break;
+                        }
+                    },
+                    'onPlaybackRateChange': (e) => {
+                        at.playbackRate = e.data;
+                    },
+                    'onError': (e) => {
+                        youtubePlayerReady.reject(e);
+                        console.log('YT onError', player, e)
+                    },
+                }
+            });
+
+            await youtubePlayerReady.promise;
+
+            // Setup alphaTab with youtube handler
+            const alphaTabYoutubeHandler = {
+                get backingTrackDuration() {
+                    return player ? player?.getDuration() * 1000 : 0;
+                },
+                get playbackRate() {
+                    return player ? player.getPlaybackRate() : 1;
+                },
+                set playbackRate(value) {
+                    if (player) {
+                        player.setPlaybackRate(value);
+                    }
+                },
+                get masterVolume() {
+                    return player ? player.getVolume() / 100 : 1;
+                },
+                set masterVolume(value) {
+                    if (player) {
+                        player.setVolume(value * 100);
+                    }
+                },
+                seekTo(time) {
+                    if (player) {
+                        player.seekTo(time / 1000);
+                    }
+                },
+                play() {
+                    if (player) {
+                        player.playVideo();
+                    }
+                },
+                pause() {
+                    if (player) {
+                        player.pauseVideo();
+                    }
+                }
+            };
+            at.player.output.handler = alphaTabYoutubeHandler;
+        };
+        req.open('GET', 'control-template.html');
+        req.send();
+    </script>
+</body>
+
+</html>

--- a/src/AlphaTabApiBase.ts
+++ b/src/AlphaTabApiBase.ts
@@ -931,9 +931,6 @@ export class AlphaTabApiBase<TSettings> {
         return this.renderer.boundsLookup;
     }
 
-    // the previously configured player mode to detect changes
-    private _playerMode: PlayerMode = PlayerMode.Disabled;
-
     /**
      * The alphaSynth player used for playback.
      * @remarks
@@ -1455,7 +1452,7 @@ export class AlphaTabApiBase<TSettings> {
             }
         }
 
-        if (mode !== this._playerMode) {
+        if (mode !== this._actualPlayerMode) {
             this.destroyPlayer();
         }
         this.updateCursors();
@@ -1463,7 +1460,6 @@ export class AlphaTabApiBase<TSettings> {
         this._actualPlayerMode = mode;
         switch (mode) {
             case PlayerMode.Disabled:
-                this._playerMode = PlayerMode.Disabled;
                 this.destroyPlayer();
                 return false;
 


### PR DESCRIPTION
### Issues
Fixes #1961

### Proposed changes
Adds a first implementation and demo for integrating alphaTab with an external media backing track. It adds a separate handler developers need to implement and pass into alphaTab. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website
