### PR TITLE
feat(player): Cursor fine-tuning

### DIFF
--- a/playground-template/control.mjs
+++ b/playground-template/control.mjs
@@ -129,6 +129,10 @@ function hideBackingTrack(at) {
 
 
 async function showBackingTrack(at) {
+    if(!at.score.backingTrack) {
+        hideBackingTrack();
+        return;
+    }
 
     const audioElement = at.player.output.audioElement;
     if(audioElement !== backingTrackAudioElement) {

--- a/playground-template/youtube.html
+++ b/playground-template/youtube.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8" />
-    <title>AlphaTab Control Demo</title>
+    <title>AlphaTab Youtube Sync</title>
 
     <script src="/node_modules/@popperjs/core/dist/umd/popper.min.js"></script>
     <script src="/node_modules/bootstrap/dist/js/bootstrap.min.js"></script>

--- a/src.csharp/AlphaTab.Windows/DelegatedEventEmitter.cs
+++ b/src.csharp/AlphaTab.Windows/DelegatedEventEmitter.cs
@@ -13,9 +13,10 @@ namespace AlphaTab
             _off = off;
         }
 
-        public void On(Action value)
+        public System.Action On(Action value)
         {
             _on(value);
+            return () => _off(value);
         }
 
         public void Off(Action value)
@@ -35,9 +36,10 @@ namespace AlphaTab
             _off = off;
         }
 
-        public void On(Action value)
+        public System.Action On(Action value)
         {
 			// not used internally
+            return () => {};
         }
 
         public void Off(Action value)
@@ -45,9 +47,10 @@ namespace AlphaTab
             // not used internally
         }
 		
-        public void On(Action<T> value)
+        public System.Action On(Action<T> value)
         {
             _on(value);
+            return () => _off(value);
         }
 
         public void Off(Action<T> value)

--- a/src.csharp/AlphaTab/EventEmitter.cs
+++ b/src.csharp/AlphaTab/EventEmitter.cs
@@ -4,7 +4,7 @@ namespace AlphaTab;
 
 partial interface IEventEmitterOfT<T>
 {
-    void On(System.Action value);
+    System.Action On(System.Action value);
     void Off(System.Action value);
 }
 	
@@ -14,7 +14,7 @@ partial class EventEmitterOfT<T>
         new System.Collections.Generic.Dictionary<System.Action, System.Action<T>>();
        
     [Obsolete("Use event registration overload with parameter.", false)]
-    public void On(System.Action value) 
+    public System.Action On(System.Action value) 
     {
         var wrapper = new Action<T>(_=> 
         {
@@ -22,6 +22,7 @@ partial class EventEmitterOfT<T>
         });
         _wrappers[value] = wrapper;
         On(wrapper);
+        return () => Off(value);
     }
 
     [Obsolete("Use event unregistration with parameter.", false)]

--- a/src.kotlin/alphaTab/android/src/main/java/alphaTab/platform/android/AndroidUiFacade.kt
+++ b/src.kotlin/alphaTab/android/src/main/java/alphaTab/platform/android/AndroidUiFacade.kt
@@ -63,13 +63,14 @@ internal class AndroidUiFacade : IUiFacade<AlphaTabView> {
 
         rootContainerBecameVisible = object : IEventEmitter,
             ViewTreeObserver.OnGlobalLayoutListener, View.OnLayoutChangeListener {
-            override fun on(value: () -> Unit) {
+            override fun on(value: () -> Unit): () -> Unit {
                 if (rootContainer.isVisible) {
                     value()
                 } else {
                     outerScroll.viewTreeObserver.addOnGlobalLayoutListener(this)
                     outerScroll.addOnLayoutChangeListener(this)
                 }
+                return fun() { off(value) }
             }
 
             override fun off(value: () -> Unit) {

--- a/src/EventEmitter.ts
+++ b/src/EventEmitter.ts
@@ -1,21 +1,50 @@
+/**
+ * An emitter for an event without any value passed to the listeners.
+ */
 export interface IEventEmitter {
-    on(value: () => void): void;
+    /**
+     * Registers to the event with the given handler
+     * @param value The function to call when the event occurs.
+     * @returns A function which can be called to unregister the registered handler.
+     * This is usedful if the original function passed to this is not stored somewhere but
+     * unregistering of the event needs to be done.
+     */
+    on(value: () => void): () => void;
+    /**
+     * Unregisters the given handler from this event.
+     * @param value The value originally passed into {@link on}, NOT the function returned by it.
+     */
     off(value: () => void): void;
 }
 
 /**
+ * An emitter for an event with a single parameter passed to the listeners.
  * @partial
  */
 export interface IEventEmitterOfT<T> {
-    on(value: (arg: T) => void): void;
+    /**
+     * Registers to the event with the given handler
+     * @param value The function to call when the event occurs.
+     * @returns A function which can be called to unregister the registered handler.
+     * This is usedful if the original function passed to this is not stored somewhere but
+     * unregistering of the event needs to be done.
+     */
+    on(value: (arg: T) => void): () => void;
+    /**
+     * Unregisters the given handler from this event.
+     * @param value The value originally passed into {@link on}, NOT the function returned by it.
+     */
     off(value: (arg: T) => void): void;
 }
 
 export class EventEmitter implements IEventEmitter {
     private _listeners: (() => void)[] = [];
 
-    public on(value: () => void): void {
+    public on(value: () => void): () => void {
         this._listeners.push(value);
+        return () => {
+            this.off(value);
+        };
     }
 
     public off(value: () => void): void {
@@ -35,8 +64,11 @@ export class EventEmitter implements IEventEmitter {
 export class EventEmitterOfT<T> implements IEventEmitterOfT<T> {
     private _listeners: ((arg: T) => void)[] = [];
 
-    public on(value: (arg: T) => void): void {
+    public on(value: (arg: T) => void): () => void {
         this._listeners.push(value);
+        return () => {
+            this.off(value);
+        };
     }
 
     public off(value: (arg: T) => void): void {

--- a/src/platform/javascript/AlphaSynthWebWorkerApi.ts
+++ b/src/platform/javascript/AlphaSynthWebWorkerApi.ts
@@ -10,8 +10,6 @@ import { JsonConverter } from '@src/model/JsonConverter';
 import { Logger } from '@src/Logger';
 import type { LogLevel } from '@src/LogLevel';
 import { SynthConstants } from '@src/synth/SynthConstants';
-import { ProgressEventArgs } from '@src/ProgressEventArgs';
-import { FileLoadError } from '@src/FileLoadError';
 import { MidiEventsPlayedEventArgs } from '@src/synth/MidiEventsPlayedEventArgs';
 import type { MidiEventType } from '@src/midi/MidiEvent';
 import { Environment } from '@src/Environment';
@@ -276,28 +274,6 @@ export class AlphaSynthWebWorkerApi implements IAlphaSynth {
             data: data,
             append: append
         });
-    }
-
-    public loadSoundFontFromUrl(url: string, append: boolean, progress: (e: ProgressEventArgs) => void): void {
-        Logger.debug('AlphaSynth', `Start loading Soundfont from url ${url}`);
-        const request: XMLHttpRequest = new XMLHttpRequest();
-        request.open('GET', url, true, null, null);
-        request.responseType = 'arraybuffer';
-        request.onload = _ => {
-            const buffer: Uint8Array = new Uint8Array(request.response);
-            this.loadSoundFont(buffer, append);
-        };
-        request.onerror = e => {
-            Logger.error('AlphaSynth', `Loading failed: ${(e as any).message}`);
-            (this.soundFontLoadFailed as EventEmitterOfT<Error>).trigger(
-                new FileLoadError((e as any).message, request)
-            );
-        };
-        request.onprogress = e => {
-            Logger.debug('AlphaSynth', `Soundfont downloading: ${e.loaded}/${e.total} bytes`);
-            progress(new ProgressEventArgs(e.loaded, e.total));
-        };
-        request.send();
     }
 
     public resetSoundFonts(): void {

--- a/src/platform/javascript/AudioElementBackingTrackSynthOutput.ts
+++ b/src/platform/javascript/AudioElementBackingTrackSynthOutput.ts
@@ -63,7 +63,11 @@ export class AudioElementBackingTrackSynthOutput implements IAudioElementBacking
         this._padding = backingTrack.padding / 1000;
 
         const blob = new Blob([backingTrack.rawAudioFile!]);
+        // https://html.spec.whatwg.org/multipage/media.html#loading-the-media-resource
+        // Step 8. resets the playbackRate, we need to remember and restore it. 
+        const playbackRate = this.audioElement.playbackRate;
         this.audioElement.src = URL.createObjectURL(blob);
+        this.audioElement.playbackRate = playbackRate;
     }
 
     public open(_bufferTimeInMilliseconds: number): void {

--- a/src/platform/javascript/HtmlElementContainer.ts
+++ b/src/platform/javascript/HtmlElementContainer.ts
@@ -70,13 +70,13 @@ export class HtmlElementContainer implements IContainer {
 
         this.mouseDown = {
             on: (value: any) => {
-                this.element.addEventListener(
-                    'mousedown',
-                    e => {
-                        value(new BrowserMouseEventArgs(e));
-                    },
-                    true
-                );
+                const nativeListener: (e: MouseEvent) => void = e => {
+                    value(new BrowserMouseEventArgs(e));
+                };
+                this.element.addEventListener('mousedown', nativeListener, true);
+                return () => {
+                    this.element.removeEventListener('mousedown', nativeListener, true);
+                };
             },
             off: (value: any) => {
                 // not supported due to wrapping
@@ -85,13 +85,15 @@ export class HtmlElementContainer implements IContainer {
 
         this.mouseUp = {
             on: (value: any) => {
-                this.element.addEventListener(
-                    'mouseup',
-                    e => {
-                        value(new BrowserMouseEventArgs(e));
-                    },
-                    true
-                );
+                const nativeListener: (e: MouseEvent) => void = e => {
+                    value(new BrowserMouseEventArgs(e));
+                };
+
+                this.element.addEventListener('mouseup', nativeListener, true);
+
+                return () => {
+                    this.element.removeEventListener('mouseup', nativeListener, true);
+                };
             },
             off: (value: any) => {
                 // not supported due to wrapping
@@ -100,26 +102,30 @@ export class HtmlElementContainer implements IContainer {
 
         this.mouseMove = {
             on: (value: any) => {
-                this.element.addEventListener(
-                    'mousemove',
-                    e => {
-                        value(new BrowserMouseEventArgs(e));
-                    },
-                    true
-                );
+                const nativeListener: (e: MouseEvent) => void = e => {
+                    value(new BrowserMouseEventArgs(e));
+                };
+                this.element.addEventListener('mousemove', nativeListener, true);
+
+                return () => {
+                    this.element.removeEventListener('mousemove', nativeListener, true);
+                };
             },
             off: (_: any) => {
                 // not supported due to wrapping
             }
         };
 
+        const container = this;
         this.resize = {
-            on: (value: any) => {
-                if (this._resizeListeners === 0) {
-                    HtmlElementContainer.resizeObserver.value.observe(this.element);
+            on: function (value: any) {
+                if (container._resizeListeners === 0) {
+                    HtmlElementContainer.resizeObserver.value.observe(container.element);
                 }
-                this.element.addEventListener('resize', value, true);
-                this._resizeListeners++;
+                container.element.addEventListener('resize', value, true);
+                container._resizeListeners++;
+
+                return () => this.off(value);
             },
             off: (value: any) => {
                 this.element.removeEventListener('resize', value, true);

--- a/src/synth/AlphaSynth.ts
+++ b/src/synth/AlphaSynth.ts
@@ -116,7 +116,6 @@ export class AlphaSynthBase implements IAlphaSynth {
         this.timePosition = this.timePosition * (oldSpeed / value);
     }
 
-
     public get tickPosition(): number {
         return this._tickPosition;
     }
@@ -464,8 +463,8 @@ export class AlphaSynthBase implements IAlphaSynth {
         }
 
         if (this._tickPosition >= endTick) {
-            // fully done with playback of remaining samples? 
-            if(this._notPlayedSamples <= 0) {
+            // fully done with playback of remaining samples?
+            if (this._notPlayedSamples <= 0) {
                 this._notPlayedSamples = 0;
                 if (this.sequencer.isPlayingCountIn) {
                     Logger.debug('AlphaSynth', 'Finished playback (count-in)');
@@ -505,7 +504,6 @@ export class AlphaSynthBase implements IAlphaSynth {
                     this._synthStopping = true;
                 }
             }
-          
         }
     }
 
@@ -601,7 +599,7 @@ export class AlphaSynthBase implements IAlphaSynth {
         return this.synthesizer.hasSamplesForPercussion(key);
     }
 
-    public loadBackingTrack(_score: Score, _syncPoints:BackingTrackSyncPoint[]): void {
+    public loadBackingTrack(_score: Score, _syncPoints: BackingTrackSyncPoint[]): void {
         // ignore
     }
 }

--- a/src/synth/AlphaSynthWrapper.ts
+++ b/src/synth/AlphaSynthWrapper.ts
@@ -1,0 +1,353 @@
+import { EventEmitter, EventEmitterOfT, type IEventEmitter, type IEventEmitterOfT } from '@src/EventEmitter';
+import { Logger } from '@src/Logger';
+import type { LogLevel } from '@src/LogLevel';
+import type { MidiEventType } from '@src/midi/MidiEvent';
+import type { MidiFile } from '@src/midi/MidiFile';
+import type { Score } from '@src/model/Score';
+import type { BackingTrackSyncPoint, IAlphaSynth } from '@src/synth/IAlphaSynth';
+import type { ISynthOutput } from '@src/synth/ISynthOutput';
+import type { MidiEventsPlayedEventArgs } from '@src/synth/MidiEventsPlayedEventArgs';
+import type { PlaybackRange } from '@src/synth/PlaybackRange';
+import type { PlaybackRangeChangedEventArgs } from '@src/synth/PlaybackRangeChangedEventArgs';
+import { PlayerState } from '@src/synth/PlayerState';
+import type { PlayerStateChangedEventArgs } from '@src/synth/PlayerStateChangedEventArgs';
+import type { PositionChangedEventArgs } from '@src/synth/PositionChangedEventArgs';
+import { SynthConstants } from '@src/synth/SynthConstants';
+
+/**
+ * A {@link IAlphaSynth} implementation wrapping and underling other {@link IAlphaSynth}
+ * allowing dynamic changing of the underlying instance without loosing aspects like the
+ * main playback information and event listeners.
+ *
+ * @remarks
+ * This wrapper is used when re-exposing the underlying player via {@link AlphaTabApiBase} to integrators.
+ * Even with dynamic switching between synthesizer, backing tracks etc. aspects like volume, playbackspeed,
+ * event listeners etc. should not be lost.
+ */
+export class AlphaSynthWrapper implements IAlphaSynth {
+    // relevant state information we want to remember when switching between player instances
+    private _masterVolume: number = 1;
+    private _metronomeVolume: number = 0;
+    private _countInVolume: number = 0;
+    private _playbackSpeed: number = 1;
+    private _isLooping: boolean = false;
+    private _midiEventsPlayedFilter: MidiEventType[] = [];
+
+    private _instance?: IAlphaSynth;
+    private _instanceEventUnregister?: (() => void)[];
+
+    public get instance(): IAlphaSynth | undefined {
+        return this._instance;
+    }
+
+    public set instance(value: IAlphaSynth | undefined) {
+        this._instance = value;
+
+        // unregister all events from previous instance
+        const unregister = this._instanceEventUnregister;
+        if (unregister) {
+            for (const e of unregister) {
+                e();
+            }
+        }
+
+        if (value) {
+            // regsiter to events of new player and forward them to existing listeners
+            const newUnregister: (() => void)[] = [];
+            newUnregister.push(value.ready.on(() => (this.ready as EventEmitter).trigger()));
+            newUnregister.push(value.readyForPlayback.on(() => (this.readyForPlayback as EventEmitter).trigger()));
+            newUnregister.push(value.finished.on(() => (this.finished as EventEmitter).trigger()));
+            newUnregister.push(value.soundFontLoaded.on(() => (this.soundFontLoaded as EventEmitter).trigger()));
+            newUnregister.push(
+                value.soundFontLoadFailed.on(e => (this.soundFontLoadFailed as EventEmitterOfT<Error>).trigger(e))
+            );
+            newUnregister.push(
+                value.midiLoaded.on(e => (this.midiLoaded as EventEmitterOfT<PositionChangedEventArgs>).trigger(e))
+            );
+            newUnregister.push(
+                value.midiLoadFailed.on(e => (this.midiLoadFailed as EventEmitterOfT<Error>).trigger(e))
+            );
+            newUnregister.push(
+                value.stateChanged.on(e =>
+                    (this.stateChanged as EventEmitterOfT<PlayerStateChangedEventArgs>).trigger(e)
+                )
+            );
+            newUnregister.push(
+                value.positionChanged.on(e =>
+                    (this.positionChanged as EventEmitterOfT<PositionChangedEventArgs>).trigger(e)
+                )
+            );
+            newUnregister.push(
+                value.midiEventsPlayed.on(e =>
+                    (this.midiEventsPlayed as EventEmitterOfT<MidiEventsPlayedEventArgs>).trigger(e)
+                )
+            );
+            newUnregister.push(
+                value.playbackRangeChanged.on(e =>
+                    (this.playbackRangeChanged as EventEmitterOfT<PlaybackRangeChangedEventArgs>).trigger(e)
+                )
+            );
+
+            this._instanceEventUnregister = newUnregister;
+
+            // restore state on new player
+            if (this.isReady) {
+                value.masterVolume = this._masterVolume;
+                value.metronomeVolume = this._metronomeVolume;
+                value.countInVolume = this._countInVolume;
+                value.playbackSpeed = this._playbackSpeed;
+                value.isLooping = this._isLooping;
+                value.midiEventsPlayedFilter = this._midiEventsPlayedFilter;
+            } else {
+                newUnregister.push(
+                    value.ready.on(() => {
+                        value.masterVolume = this._masterVolume;
+                        value.metronomeVolume = this._metronomeVolume;
+                        value.countInVolume = this._countInVolume;
+                        value.playbackSpeed = this._playbackSpeed;
+                        value.isLooping = this._isLooping;
+                        value.midiEventsPlayedFilter = this._midiEventsPlayedFilter;
+                    })
+                );
+            }
+        } else {
+            this._instanceEventUnregister = undefined;
+        }
+    }
+
+    public get output(): ISynthOutput {
+        return this._instance!.output;
+    }
+
+    public get isReady(): boolean {
+        return this._instance ? this._instance!.isReady : false;
+    }
+
+    public get isReadyForPlayback(): boolean {
+        return this._instance ? this._instance!.isReadyForPlayback : false;
+    }
+
+    public get state(): PlayerState {
+        return this._instance ? this._instance!.state : PlayerState.Paused;
+    }
+
+    public get logLevel(): LogLevel {
+        return Logger.logLevel;
+    }
+
+    public set logLevel(value: LogLevel) {
+        Logger.logLevel = value;
+        if (this._instance) {
+            this._instance!.logLevel = value;
+        }
+    }
+
+    public get masterVolume(): number {
+        return this._masterVolume;
+    }
+
+    public set masterVolume(value: number) {
+        value = Math.max(value, SynthConstants.MinVolume);
+        this._masterVolume = value;
+        if (this._instance) {
+            this._instance!.masterVolume = value;
+        }
+    }
+
+    public get metronomeVolume(): number {
+        return this._metronomeVolume;
+    }
+
+    public set metronomeVolume(value: number) {
+        value = Math.max(value, SynthConstants.MinVolume);
+        this._metronomeVolume = value;
+        if (this._instance) {
+            this._instance!.metronomeVolume = value;
+        }
+    }
+
+    public get playbackSpeed(): number {
+        return this._playbackSpeed;
+    }
+
+    public set playbackSpeed(value: number) {
+        this._playbackSpeed = value;
+        if (this._instance) {
+            this._instance!.playbackSpeed = value;
+        }
+    }
+
+    public get tickPosition(): number {
+        return this._instance ? this._instance.tickPosition : 0;
+    }
+
+    public set tickPosition(value: number) {
+        if (this._instance) {
+            this._instance.tickPosition = value;
+        }
+    }
+
+    public get timePosition(): number {
+        return this._instance ? this._instance!.timePosition : 0;
+    }
+
+    public set timePosition(value: number) {
+        if (this._instance) {
+            this._instance.timePosition = value;
+        }
+    }
+
+    public get playbackRange(): PlaybackRange | null {
+        return this._instance ? this._instance.playbackRange : null;
+    }
+
+    public set playbackRange(value: PlaybackRange | null) {
+        if (this._instance) {
+            this._instance!.playbackRange = value;
+        }
+    }
+
+    public get isLooping(): boolean {
+        return this._isLooping;
+    }
+
+    public set isLooping(value: boolean) {
+        this._isLooping = value;
+        if (this._instance) {
+            this._instance!.isLooping = value;
+        }
+    }
+
+    public get countInVolume(): number {
+        return this._countInVolume;
+    }
+
+    public set countInVolume(value: number) {
+        this._countInVolume = value;
+        if (this._instance) {
+            this._instance.countInVolume = value;
+        }
+    }
+
+    public get midiEventsPlayedFilter(): MidiEventType[] {
+        return this._midiEventsPlayedFilter;
+    }
+
+    public set midiEventsPlayedFilter(value: MidiEventType[]) {
+        this._midiEventsPlayedFilter = value;
+        if (this._instance) {
+            this._instance.midiEventsPlayedFilter = value;
+        }
+    }
+
+    public destroy(): void {
+        if (this._instance) {
+            this._instance!.destroy();
+            this._instance = undefined;
+        }
+    }
+
+    public play(): boolean {
+        return this._instance ? this._instance!.play() : false;
+    }
+
+    public pause(): void {
+        if (this._instance) {
+            this._instance!.pause();
+        }
+    }
+
+    public playPause(): void {
+        if (this._instance) {
+            this._instance!.playPause();
+        }
+    }
+
+    public stop(): void {
+        if (this._instance) {
+            this._instance!.stop();
+        }
+    }
+
+    public playOneTimeMidiFile(midi: MidiFile): void {
+        if (this._instance) {
+            this._instance!.playOneTimeMidiFile(midi);
+        }
+    }
+
+    public loadSoundFont(data: Uint8Array, append: boolean): void {
+        if (this._instance) {
+            this._instance!.loadSoundFont(data, append);
+        }
+    }
+
+    public resetSoundFonts(): void {
+        if (this._instance) {
+            this._instance!.resetSoundFonts();
+        }
+    }
+
+    public loadMidiFile(midi: MidiFile): void {
+        if (this._instance) {
+            this._instance!.loadMidiFile(midi);
+        }
+    }
+
+    public loadBackingTrack(score: Score, syncPoints: BackingTrackSyncPoint[]): void {
+        if (this._instance) {
+            this._instance!.loadBackingTrack(score, syncPoints);
+        }
+    }
+
+    public applyTranspositionPitches(transpositionPitches: Map<number, number>): void {
+        if (this._instance) {
+            this._instance!.applyTranspositionPitches(transpositionPitches);
+        }
+    }
+
+    public setChannelTranspositionPitch(channel: number, semitones: number): void {
+        if (this._instance) {
+            this._instance!.setChannelTranspositionPitch(channel, semitones);
+        }
+    }
+
+    public setChannelMute(channel: number, mute: boolean): void {
+        if (this._instance) {
+            this._instance!.setChannelMute(channel, mute);
+        }
+    }
+
+    public resetChannelStates(): void {
+        if (this._instance) {
+            this._instance!.resetChannelStates();
+        }
+    }
+
+    public setChannelSolo(channel: number, solo: boolean): void {
+        if (this._instance) {
+            this._instance!.setChannelSolo(channel, solo);
+        }
+    }
+
+    public setChannelVolume(channel: number, volume: number): void {
+        if (this._instance) {
+            this._instance!.setChannelVolume(channel, volume);
+        }
+    }
+
+    readonly ready: IEventEmitter = new EventEmitter();
+    readonly readyForPlayback: IEventEmitter = new EventEmitter();
+    readonly finished: IEventEmitter = new EventEmitter();
+    readonly soundFontLoaded: IEventEmitter = new EventEmitter();
+    readonly soundFontLoadFailed: IEventEmitterOfT<Error> = new EventEmitterOfT<Error>();
+    readonly midiLoaded: IEventEmitterOfT<PositionChangedEventArgs> = new EventEmitterOfT<PositionChangedEventArgs>();
+    readonly midiLoadFailed: IEventEmitterOfT<Error> = new EventEmitterOfT<Error>();
+    readonly stateChanged: IEventEmitterOfT<PlayerStateChangedEventArgs> =
+        new EventEmitterOfT<PlayerStateChangedEventArgs>();
+    readonly positionChanged: IEventEmitterOfT<PositionChangedEventArgs> =
+        new EventEmitterOfT<PositionChangedEventArgs>();
+    readonly midiEventsPlayed: IEventEmitterOfT<MidiEventsPlayedEventArgs> =
+        new EventEmitterOfT<MidiEventsPlayedEventArgs>();
+    readonly playbackRangeChanged: IEventEmitterOfT<PlaybackRangeChangedEventArgs> =
+        new EventEmitterOfT<PlaybackRangeChangedEventArgs>();
+}

--- a/src/synth/synthesis/TinySoundFont.ts
+++ b/src/synth/synthesis/TinySoundFont.ts
@@ -217,7 +217,7 @@ export class TinySoundFont implements IAudioSampleSynthesizer {
     }
 
     private processMidiMessage(e: MidiEvent): void {
-        Logger.debug('Midi', `Processing Midi message ${MidiEventType[e.type]}/${e.tick}`);
+        //Logger.debug('Midi', `Processing Midi message ${MidiEventType[e.type]}/${e.tick}`);
         const command: MidiEventType = e.type;
         switch (command) {
             case MidiEventType.TimeSignature:


### PR DESCRIPTION
### Issues
Fixes #2078

### Proposed changes
Improves and refactors quite some bits around the player and cursor handling. 

1. We need a final sync point at the end of the song which matches the BPM (not the song end) for correct synchronization with guitar pro files. 
2. The general tempo and sync point handling is not better integrated. Tempo and sync points update as part of the playback (time position update) and not the synth part. This is more accurate and avoids some cursor speed problems on tempo changes. 
3. The time to tick position translation is now more efficeint thanks to incremental updates of the current tempo change. 
4. Removed a small playground error when handling backing tracks.
5. Smooth the cursor by letting it animate 2-times the distance in double the time. This avoids stopping cursors when its too fast.
6. Smooth the cursor by not "snapping" it to the start beat as long we are animating the standard left-to-right during playback. 
7. Removed the log message for processing midi events, can get quite noisy on seek.
8. Refactored how we handle internally the player switching. We now remember the state and event listeners better. Also change of the player mode doesn't require re-registering events. 

With all these tunings, the cursor is a lot more smooth and there are no problems when changing songs with and without backing tracks. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
