### PR TITLE
fix(musicxml): Allow empty direction-type

### DIFF
--- a/src/importer/MusicXmlImporter.ts
+++ b/src/importer/MusicXmlImporter.ts
@@ -1922,7 +1922,11 @@ export class MusicXmlImporter extends ScoreImporter {
         for (const c of element.childElements()) {
             switch (c.localName) {
                 case 'direction-type':
-                    directionTypes.push(c.firstElement!);
+                    // See https://github.com/CoderLine/alphaTab/issues/2102
+                    const type = c.firstElement;
+                    if(type) {
+                        directionTypes.push(type);
+                    }
                     break;
                 case 'offset':
                     offset = Number.parseFloat(c.innerText);

--- a/test-data/musicxml4/2102-corrupt-direction.xml
+++ b/test-data/musicxml4/2102-corrupt-direction.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Track 1</part-name>
+      <part-abbreviation>T1</part-abbreviation>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+      </attributes>
+
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <type>quarter</type>
+      </note>
+
+      <direction placement="below">
+        <!-- Malformed: no direction type -->
+        <direction-type>
+        </direction-type>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/test/importer/MusicXmlImporter.test.ts
+++ b/test/importer/MusicXmlImporter.test.ts
@@ -253,4 +253,9 @@ describe('MusicXmlImporterTests', () => {
         const score = await MusicXmlImporterTestHelper.loadFile('test-data/musicxml4/barlines.xml');
         expect(score).toMatchSnapshot();
     });
+
+    it('2102-corrupt-direction', async () => {
+        const score = await MusicXmlImporterTestHelper.loadFile('test-data/musicxml4/2102-corrupt-direction.xml');
+        expect(score).toMatchSnapshot();
+    });
 });

--- a/test/importer/__snapshots__/musicxmlimporter.test.ts.snap
+++ b/test/importer/__snapshots__/musicxmlimporter.test.ts.snap
@@ -1,5 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`MusicXmlImporterTests 2102-corrupt-direction 1`] = `
+Map {
+  "__kind" => "Score",
+  "masterbars" => Array [
+    Map {
+      "__kind" => "MasterBar",
+    },
+  ],
+  "tracks" => Array [
+    Map {
+      "__kind" => "Track",
+      "staves" => Array [
+        Map {
+          "__kind" => "Staff",
+          "bars" => Array [
+            Map {
+              "__kind" => "Bar",
+              "id" => 0,
+              "voices" => Array [
+                Map {
+                  "__kind" => "Voice",
+                  "id" => 0,
+                  "beats" => Array [
+                    Map {
+                      "__kind" => "Beat",
+                      "id" => 0,
+                      "notes" => Array [
+                        Map {
+                          "__kind" => "Note",
+                          "id" => 0,
+                          "octave" => 5,
+                          "tone" => 0,
+                        },
+                      ],
+                      "automations" => Array [
+                        Map {
+                          "islinear" => false,
+                          "type" => 2,
+                          "value" => 0,
+                          "ratioposition" => 0,
+                          "text" => "",
+                        },
+                      ],
+                      "displayduration" => 960,
+                      "playbackduration" => 960,
+                      "overridedisplayduration" => 960,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      "playbackinfo" => Map {
+        "secondarychannel" => 1,
+      },
+      "name" => "Track 1",
+      "shortname" => "T1",
+    },
+  ],
+  "stylesheet" => Map {
+    "hidedynamics" => true,
+  },
+}
+`;
+
 exports[`MusicXmlImporterTests barlines 1`] = `
 Map {
   "__kind" => "Score",


### PR DESCRIPTION
### Issues
Fixes #2102

### Proposed changes
In old MuseScore versions exported MusicXML `direction-type` might be empty. This PR handles this edge case for the importer.

Despite the schema requiring it: 
https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/direction-type/
https://usermanuals.musicxml.com/MusicXML/MusicXML.htm#EL-MusicXML-direction-type.htm%3FTocPath%3DMusicXML%2520Reference%7CScore%2520Schema%2520(XSD)%7CElements%7Cdirection%7C_____22

Related bug on MuseScore side: https://musescore.org/en/node/293441

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
