### PR TITLE
feat: Add option for custom smufl font sources

### DIFF
--- a/src.compiler/typescript/Serializer.setProperty.ts
+++ b/src.compiler/typescript/Serializer.setProperty.ts
@@ -321,9 +321,10 @@ function generateSetPropertyBody(serializable: TypeSchema, importer: (name: stri
 
             // obj.fieldName = TypeName.fromJson(value)!
             // return true;
+            const notNull =  prop.type.isNullable || prop.type.isOptional ? '' : '!';
             caseStatements.push(
                 createNodeFromSource<ts.ExpressionStatement>(
-                    `obj.${fieldName} = ${prop.type.typeAsString}.fromJson(v)!;`,
+                    `obj.${fieldName} = ${prop.type.typeAsString}.fromJson(v)${notNull};`,
                     ts.SyntaxKind.ExpressionStatement
                 )
             );

--- a/src.compiler/typescript/Serializer.toJson.ts
+++ b/src.compiler/typescript/Serializer.toJson.ts
@@ -235,7 +235,7 @@ function generateToJsonBody(serializable: TypeSchema, importer: (name: string, m
             }
         } else if (prop.type.isJsonImmutable) {
             importer(prop.type.typeAsString, prop.type.modulePath);
-            const notNull = !prop.type.isNullable ? '!' : '';
+            const notNull = prop.type.isNullable || prop.type.isOptional ? '' : '!';
             propertyStatements.push(
                 createNodeFromSource<ts.ExpressionStatement>(
                     `

--- a/src/CoreSettings.ts
+++ b/src/CoreSettings.ts
@@ -4,6 +4,42 @@ import { LogLevel } from '@src/LogLevel';
 import type { BoundsLookup } from '@src/rendering/utils/BoundsLookup';
 
 /**
+ * Lists the known file formats for font files.
+ * @target web
+ */
+export enum FontFileFormat {
+    /**
+     * .eot
+     */
+    EmbeddedOpenType = 0,
+
+    /**
+     * .woff
+     */
+    Woff = 1,
+
+    /**
+     * .woff2
+     */
+    Woff2 = 2,
+
+    /**
+     * .otf
+     */
+    OpenType = 3,
+
+    /**
+     * .ttf
+     */
+    TrueType = 4,
+
+    /**
+     * .svg
+     */
+    Svg = 5
+}
+
+/**
  * All main settings of alphaTab controlling rather general aspects of its behavior.
  * @json
  * @json_declaration
@@ -35,8 +71,37 @@ export class CoreSettings {
      * @category Core - JavaScript Specific
      * @target web
      * @since 0.9.6
+     * @deprecated Use {@link smfulFontSources} for more flexible font configuration.
      */
     public fontDirectory: string | null = null;
+
+    /**
+     * Defines the URLs from which to load the SMuFL compliant font files.
+     * @remarks
+     * These sources will be used to load and register the webfonts on the page so
+     * they are available for rendering the music sheet.
+     * @defaultValue Bravura files located at {@link fontDirectory} .
+     * @category Core - JavaScript Specific
+     * @target web
+     * @since 1.6.0
+     */
+    public smfulFontSources: Map<FontFileFormat, string> | null = null;
+
+    /**
+     * Builds the default SMuFL font sources for the usage with alphaTab in cases
+     * where no custom {@link smfulFontSources} are provided.
+     * @param fontDirectory The {@link fontDirectory} configured.
+     * @target web
+     */
+    public static buildDefaultSmuflFontSources(fontDirectory: string | null): Map<FontFileFormat, string> {
+        const map = new Map<FontFileFormat, string>();
+        // WOFF, WOFF2 and OTF should cover all our platform needs
+        const prefix = fontDirectory ?? '';
+        map.set(FontFileFormat.Woff2, `${prefix}Bravura.woff2`);
+        map.set(FontFileFormat.Woff, `${prefix}Bravura.woff`);
+        map.set(FontFileFormat.OpenType, `${prefix}Bravura.otf`);
+        return map;
+    }
 
     /**
      * The full URL to the input file to be loaded.

--- a/src/CoreSettings.ts
+++ b/src/CoreSettings.ts
@@ -67,11 +67,12 @@ export class CoreSettings {
      * where the Web Font files of [Bravura](https://github.com/steinbergmedia/bravura) are. Normally alphaTab expects
      * them to be in a `font` subfolder beside the script file. If this is not the case, this setting must be used to configure the path.
      * Alternatively also a global variable `ALPHATAB_FONT` can be set on the page before initializing alphaTab.
+     * 
+     * Use {@link smuflFontSources} for more flexible font configuration.
      * @defaultValue `"${AlphaTabScriptFolder}/font/"`
      * @category Core - JavaScript Specific
      * @target web
      * @since 0.9.6
-     * @deprecated Use {@link smuflFontSources} for more flexible font configuration.
      */
     public fontDirectory: string | null = null;
 

--- a/src/CoreSettings.ts
+++ b/src/CoreSettings.ts
@@ -79,7 +79,9 @@ export class CoreSettings {
      * Defines the URLs from which to load the SMuFL compliant font files.
      * @remarks
      * These sources will be used to load and register the webfonts on the page so
-     * they are available for rendering the music sheet.
+     * they are available for rendering the music sheet. The sources can be set to any 
+     * CSS compatible URL which can be passed into `url()`.
+     * See https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src#url
      * @defaultValue Bravura files located at {@link fontDirectory} .
      * @category Core - JavaScript Specific
      * @target web

--- a/src/CoreSettings.ts
+++ b/src/CoreSettings.ts
@@ -71,7 +71,7 @@ export class CoreSettings {
      * @category Core - JavaScript Specific
      * @target web
      * @since 0.9.6
-     * @deprecated Use {@link smfulFontSources} for more flexible font configuration.
+     * @deprecated Use {@link smuflFontSources} for more flexible font configuration.
      */
     public fontDirectory: string | null = null;
 
@@ -85,11 +85,11 @@ export class CoreSettings {
      * @target web
      * @since 1.6.0
      */
-    public smfulFontSources: Map<FontFileFormat, string> | null = null;
+    public smuflFontSources: Map<FontFileFormat, string> | null = null;
 
     /**
      * Builds the default SMuFL font sources for the usage with alphaTab in cases
-     * where no custom {@link smfulFontSources} are provided.
+     * where no custom {@link smuflFontSources} are provided.
      * @param fontDirectory The {@link fontDirectory} configured.
      * @target web
      */

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -47,7 +47,6 @@ import type { ScoreLayout } from '@src/rendering/layout/ScoreLayout';
 import { ScoreBarRendererFactory } from '@src/rendering/ScoreBarRendererFactory';
 import type { ScoreRenderer } from '@src/rendering/ScoreRenderer';
 import { TabBarRendererFactory } from '@src/rendering/TabBarRendererFactory';
-import { FontLoadingChecker } from '@src/util/FontLoadingChecker';
 import { Logger } from '@src/Logger';
 import { LeftHandTapEffectInfo } from '@src/rendering/effects/LeftHandTapEffectInfo';
 import { CapellaImporter } from '@src/importer/CapellaImporter';
@@ -142,62 +141,6 @@ export class Environment {
 
     /**
      * @target web
-     * @internal
-     */
-    public static createStyleElement(elementDocument: HTMLDocument, fontDirectory: string | null) {
-        let styleElement: HTMLStyleElement = elementDocument.getElementById('alphaTabStyle') as HTMLStyleElement;
-        if (!styleElement) {
-            if (!fontDirectory) {
-                Logger.error('AlphaTab', 'Font directory could not be detected, cannot create style element');
-                return;
-            }
-
-            styleElement = elementDocument.createElement('style');
-            styleElement.id = 'alphaTabStyle';
-            const css: string = `
-            @font-face {
-                font-display: block;
-                font-family: 'alphaTab';
-                 src: url('${fontDirectory}Bravura.eot');
-                 src: url('${fontDirectory}Bravura.eot?#iefix') format('embedded-opentype')
-                      , url('${fontDirectory}Bravura.woff') format('woff')
-                      , url('${fontDirectory}Bravura.otf') format('opentype')
-                      , url('${fontDirectory}Bravura.svg#Bravura') format('svg');
-                 font-weight: normal;
-                 font-style: normal;
-            }
-            .at-surface * {
-                cursor: default;
-                vertical-align: top;
-                overflow: visible;
-            }
-            .at-surface-svg text {
-                dominant-baseline: central;
-                white-space:pre;
-            }
-            .at {
-                 font-family: 'alphaTab';
-                 speak: none;
-                 font-style: normal;
-                 font-weight: normal;
-                 font-variant: normal;
-                 text-transform: none;
-                 line-height: 1;
-                 line-height: 1;
-                 -webkit-font-smoothing: antialiased;
-                 -moz-osx-font-smoothing: grayscale;
-                 font-size: ${Environment.MusicFontSize}px;
-                 overflow: visible !important;
-            }`;
-
-            styleElement.innerHTML = css;
-            elementDocument.getElementsByTagName('head').item(0)!.appendChild(styleElement);
-            Environment.bravuraFontChecker.checkForFontAvailability();
-        }
-    }
-
-    /**
-     * @target web
      */
     private static _globalThis: any | undefined = undefined;
 
@@ -254,12 +197,6 @@ export class Environment {
      * @target web
      */
     public static readonly fontDirectory: string | null = Environment.detectFontDirectory();
-
-    /**
-     * @target web
-     * @internal
-     */
-    public static readonly bravuraFontChecker: FontLoadingChecker = new FontLoadingChecker(['alphaTab']);
 
     /**
      * @target web

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -264,8 +264,12 @@ export class Environment {
         }
 
         // normal browser include as <script>
-        if ('document' in Environment.globalThis && document.currentScript) {
-            return (document.currentScript as HTMLScriptElement).src;
+        if (
+            'document' in Environment.globalThis &&
+            document.currentScript &&
+            document.currentScript instanceof HTMLScriptElement
+        ) {
+            return document.currentScript.src;
         }
 
         return null;

--- a/src/RenderingResources.ts
+++ b/src/RenderingResources.ts
@@ -12,6 +12,17 @@ export class RenderingResources {
     private static serifFont: string = 'Georgia, serif';
 
     /**
+     * The SMuFL Font to use for rendering music symbols.
+     * @remarks
+     * This is only meant for internal passing of font family information between components.
+     * Setting this manually can lead to unexpected side effects.
+     * @defaultValue `alphaTab`
+     * @since 0.9.6
+     * @internal
+     */
+    public smuflFont?: Font;
+
+    /**
      * The font to use for displaying the songs copyright information in the header of the music sheet.
      * @defaultValue `bold 12px Arial, sans-serif`
      * @since 0.9.6

--- a/src/alphaTab.core.ts
+++ b/src/alphaTab.core.ts
@@ -1,6 +1,6 @@
 import '@src/alphaTab.polyfills';
 
-export { CoreSettings } from '@src/CoreSettings';
+export { CoreSettings, FontFileFormat } from '@src/CoreSettings';
 export { DisplaySettings, SystemsLayoutMode } from '@src/DisplaySettings';
 export { LayoutMode } from '@src/LayoutMode';
 export { StaveProfile } from '@src/StaveProfile';

--- a/src/generated/CoreSettingsJson.ts
+++ b/src/generated/CoreSettingsJson.ts
@@ -33,18 +33,21 @@ export interface CoreSettingsJson {
      * where the Web Font files of [Bravura](https://github.com/steinbergmedia/bravura) are. Normally alphaTab expects
      * them to be in a `font` subfolder beside the script file. If this is not the case, this setting must be used to configure the path.
      * Alternatively also a global variable `ALPHATAB_FONT` can be set on the page before initializing alphaTab.
+     *
+     * Use {@link smuflFontSources} for more flexible font configuration.
      * @defaultValue `"${AlphaTabScriptFolder}/font/"`
      * @category Core - JavaScript Specific
      * @target web
      * @since 0.9.6
-     * @deprecated Use {@link smuflFontSources} for more flexible font configuration.
      */
     fontDirectory?: string | null;
     /**
      * Defines the URLs from which to load the SMuFL compliant font files.
      * @remarks
      * These sources will be used to load and register the webfonts on the page so
-     * they are available for rendering the music sheet.
+     * they are available for rendering the music sheet. The sources can be set to any
+     * CSS compatible URL which can be passed into `url()`.
+     * See https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src#url
      * @defaultValue Bravura files located at {@link fontDirectory} .
      * @category Core - JavaScript Specific
      * @target web

--- a/src/generated/CoreSettingsJson.ts
+++ b/src/generated/CoreSettingsJson.ts
@@ -37,7 +37,7 @@ export interface CoreSettingsJson {
      * @category Core - JavaScript Specific
      * @target web
      * @since 0.9.6
-     * @deprecated Use {@link smfulFontSources} for more flexible font configuration.
+     * @deprecated Use {@link smuflFontSources} for more flexible font configuration.
      */
     fontDirectory?: string | null;
     /**
@@ -50,7 +50,7 @@ export interface CoreSettingsJson {
      * @target web
      * @since 1.6.0
      */
-    smfulFontSources?: Map<FontFileFormat | keyof typeof FontFileFormat | Lowercase<keyof typeof FontFileFormat>, string>;
+    smuflFontSources?: Map<FontFileFormat | keyof typeof FontFileFormat | Lowercase<keyof typeof FontFileFormat>, string>;
     /**
      * The full URL to the input file to be loaded.
      * @remarks

--- a/src/generated/CoreSettingsJson.ts
+++ b/src/generated/CoreSettingsJson.ts
@@ -3,6 +3,7 @@
 // Changes to this file may cause incorrect behavior and will be lost if
 // the code is regenerated.
 // </auto-generated>
+import { FontFileFormat } from "@src/CoreSettings";
 import { LogLevel } from "@src/LogLevel";
 /**
  * All main settings of alphaTab controlling rather general aspects of its behavior.
@@ -36,8 +37,20 @@ export interface CoreSettingsJson {
      * @category Core - JavaScript Specific
      * @target web
      * @since 0.9.6
+     * @deprecated Use {@link smfulFontSources} for more flexible font configuration.
      */
     fontDirectory?: string | null;
+    /**
+     * Defines the URLs from which to load the SMuFL compliant font files.
+     * @remarks
+     * These sources will be used to load and register the webfonts on the page so
+     * they are available for rendering the music sheet.
+     * @defaultValue Bravura files located at {@link fontDirectory} .
+     * @category Core - JavaScript Specific
+     * @target web
+     * @since 1.6.0
+     */
+    smfulFontSources?: Map<FontFileFormat | keyof typeof FontFileFormat | Lowercase<keyof typeof FontFileFormat>, string>;
     /**
      * The full URL to the input file to be loaded.
      * @remarks

--- a/src/generated/CoreSettingsSerializer.ts
+++ b/src/generated/CoreSettingsSerializer.ts
@@ -5,6 +5,7 @@
 // </auto-generated>
 import { CoreSettings } from "@src/CoreSettings";
 import { JsonHelper } from "@src/io/JsonHelper";
+import { FontFileFormat } from "@src/CoreSettings";
 import { LogLevel } from "@src/LogLevel";
 export class CoreSettingsSerializer {
     public static fromJson(obj: CoreSettings, m: unknown): void {
@@ -22,6 +23,14 @@ export class CoreSettingsSerializer {
         o.set("scriptfile", obj.scriptFile);
         /*@target web*/
         o.set("fontdirectory", obj.fontDirectory);
+        /*@target web*/
+        if (obj.smfulFontSources !== null) {
+            const m = new Map<string, unknown>();
+            o.set("smfulfontsources", m);
+            for (const [k, v] of obj.smfulFontSources!) {
+                m.set(k.toString(), v);
+            }
+        }
         /*@target web*/
         o.set("file", obj.file);
         /*@target web*/
@@ -44,6 +53,13 @@ export class CoreSettingsSerializer {
             /*@target web*/
             case "fontdirectory":
                 obj.fontDirectory = v as string | null;
+                return true;
+            /*@target web*/
+            case "smfulfontsources":
+                obj.smfulFontSources = new Map<FontFileFormat, string>();
+                JsonHelper.forEach(v, (v, k) => {
+                    obj.smfulFontSources!.set(JsonHelper.parseEnum<FontFileFormat>(k, FontFileFormat)!, v as string);
+                });
                 return true;
             /*@target web*/
             case "file":

--- a/src/generated/CoreSettingsSerializer.ts
+++ b/src/generated/CoreSettingsSerializer.ts
@@ -24,10 +24,10 @@ export class CoreSettingsSerializer {
         /*@target web*/
         o.set("fontdirectory", obj.fontDirectory);
         /*@target web*/
-        if (obj.smfulFontSources !== null) {
+        if (obj.smuflFontSources !== null) {
             const m = new Map<string, unknown>();
-            o.set("smfulfontsources", m);
-            for (const [k, v] of obj.smfulFontSources!) {
+            o.set("smuflfontsources", m);
+            for (const [k, v] of obj.smuflFontSources!) {
                 m.set(k.toString(), v);
             }
         }
@@ -55,10 +55,10 @@ export class CoreSettingsSerializer {
                 obj.fontDirectory = v as string | null;
                 return true;
             /*@target web*/
-            case "smfulfontsources":
-                obj.smfulFontSources = new Map<FontFileFormat, string>();
+            case "smuflfontsources":
+                obj.smuflFontSources = new Map<FontFileFormat, string>();
                 JsonHelper.forEach(v, (v, k) => {
-                    obj.smfulFontSources!.set(JsonHelper.parseEnum<FontFileFormat>(k, FontFileFormat)!, v as string);
+                    obj.smuflFontSources!.set(JsonHelper.parseEnum<FontFileFormat>(k, FontFileFormat)!, v as string);
                 });
                 return true;
             /*@target web*/

--- a/src/generated/RenderingResourcesJson.ts
+++ b/src/generated/RenderingResourcesJson.ts
@@ -13,6 +13,16 @@ import { ColorJson } from "@src/model/Color";
  */
 export interface RenderingResourcesJson {
     /**
+     * The SMuFL Font to use for rendering music symbols.
+     * @remarks
+     * This is only meant for internal passing of font family information between components.
+     * Setting this manually can lead to unexpected side effects.
+     * @defaultValue `alphaTab`
+     * @since 0.9.6
+     * @internal
+     */
+    smuflFont?: FontJson;
+    /**
      * The font to use for displaying the songs copyright information in the header of the music sheet.
      * @defaultValue `bold 12px Arial, sans-serif`
      * @since 0.9.6

--- a/src/generated/RenderingResourcesSerializer.ts
+++ b/src/generated/RenderingResourcesSerializer.ts
@@ -19,7 +19,7 @@ export class RenderingResourcesSerializer {
             return null;
         }
         const o = new Map<string, unknown>();
-        o.set("smuflfont", Font.toJson(obj.smuflFont)!);
+        o.set("smuflfont", Font.toJson(obj.smuflFont));
         o.set("copyrightfont", Font.toJson(obj.copyrightFont)!);
         o.set("titlefont", Font.toJson(obj.titleFont)!);
         o.set("subtitlefont", Font.toJson(obj.subTitleFont)!);
@@ -47,7 +47,7 @@ export class RenderingResourcesSerializer {
     public static setProperty(obj: RenderingResources, property: string, v: unknown): boolean {
         switch (property) {
             case "smuflfont":
-                obj.smuflFont = Font.fromJson(v)!;
+                obj.smuflFont = Font.fromJson(v);
                 return true;
             case "copyrightfont":
                 obj.copyrightFont = Font.fromJson(v)!;

--- a/src/generated/RenderingResourcesSerializer.ts
+++ b/src/generated/RenderingResourcesSerializer.ts
@@ -19,6 +19,7 @@ export class RenderingResourcesSerializer {
             return null;
         }
         const o = new Map<string, unknown>();
+        o.set("smuflfont", Font.toJson(obj.smuflFont)!);
         o.set("copyrightfont", Font.toJson(obj.copyrightFont)!);
         o.set("titlefont", Font.toJson(obj.titleFont)!);
         o.set("subtitlefont", Font.toJson(obj.subTitleFont)!);
@@ -45,6 +46,9 @@ export class RenderingResourcesSerializer {
     }
     public static setProperty(obj: RenderingResources, property: string, v: unknown): boolean {
         switch (property) {
+            case "smuflfont":
+                obj.smuflFont = Font.fromJson(v)!;
+                return true;
             case "copyrightfont":
                 obj.copyrightFont = Font.fromJson(v)!;
                 return true;

--- a/src/model/Font.ts
+++ b/src/model/Font.ts
@@ -489,14 +489,14 @@ export class Font {
         return this._css;
     }
 
-    public static fromJson(v: unknown): Font | null {
+    public static fromJson(v: unknown): Font | undefined {
         if (v instanceof Font) {
             return v;
         }
 
         switch (typeof v) {
             case 'undefined':
-                return null;
+                return undefined;
             case 'object': {
                 const m = v as Map<string, unknown>;
                 const families = m.get('families') as string[];
@@ -576,11 +576,14 @@ export class Font {
                 return Font.withFamilyList(families, fontSize, fontStyle, fontWeight);
             }
             default:
-                return null;
+                return undefined;
         }
     }
 
-    public static toJson(font: Font): Map<string, unknown> {
+    public static toJson(font: Font | undefined): Map<string, unknown> | undefined {
+        if(!font) {
+            return undefined;
+        }
         const o = new Map<string, unknown>();
         o.set('families', font.families);
         o.set('size', font.size);

--- a/src/platform/javascript/BrowserUiFacade.ts
+++ b/src/platform/javascript/BrowserUiFacade.ts
@@ -357,12 +357,12 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
 
         // SmuFl Font Specific style
 
-        const smfulFontSources =
-            settings.core.smfulFontSources ?? CoreSettings.buildDefaultSmuflFontSources(settings.core.fontDirectory);
+        const smuflFontSources =
+            settings.core.smuflFontSources ?? CoreSettings.buildDefaultSmuflFontSources(settings.core.fontDirectory);
 
         // create a simple unique hash for the font source definition
         // as data urls might be used we don't want to just use the plain strings.
-        const hash = BrowserUiFacade.cyrb53(smfulFontSources.values());
+        const hash = BrowserUiFacade.cyrb53(smuflFontSources.values());
 
         // reuse existing style if available
         const registeredWebFonts = BrowserUiFacade._registeredWebFonts;
@@ -377,7 +377,7 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
         const fontSuffix = registeredWebFonts.size === 0 ? '' : String(registeredWebFonts.size);
         const familyName = `alphaTab${fontSuffix}`;
 
-        const src = Array.from(smfulFontSources.entries())
+        const src = Array.from(smuflFontSources.entries())
             .map(e => `url(${JSON.stringify(e[1])}) format('${BrowserUiFacade.cssFormat(e[0])}')`)
             .join(',');
 

--- a/src/platform/javascript/Html5Canvas.ts
+++ b/src/platform/javascript/Html5Canvas.ts
@@ -16,21 +16,12 @@ export class Html5Canvas implements ICanvas {
     private _context!: CanvasRenderingContext2D;
     private _color: Color = new Color(0, 0, 0, 0xff);
     private _font: Font = new Font('Arial', 10, FontStyle.Plain);
-    private _musicFont: Font;
+    private _musicFont?: Font;
     private _lineWidth: number = 0;
 
     public settings!: Settings;
 
     public constructor() {
-        const fontElement: HTMLElement = document.createElement('span');
-        fontElement.classList.add('at');
-        document.body.appendChild(fontElement);
-        const style: CSSStyleDeclaration = window.getComputedStyle(fontElement);
-        let family: string = style.fontFamily;
-        if (family.startsWith('"') || family.startsWith("'")) {
-            family = family.substr(1, family.length - 2);
-        }
-        this._musicFont = new Font(family, Number.parseFloat(style.fontSize), FontStyle.Plain);
         this._measureCanvas = document.createElement('canvas');
         this._measureCanvas.width = 10;
         this._measureCanvas.height = 10;
@@ -47,6 +38,8 @@ export class Html5Canvas implements ICanvas {
     }
 
     public beginRender(width: number, height: number): void {
+        this._musicFont = this.settings.display.resources.smuflFont;
+
         const scale = this.settings.display.scale;
 
         this._canvas = document.createElement('canvas');
@@ -269,7 +262,7 @@ export class Html5Canvas implements ICanvas {
         const textAlign = this._context.textAlign;
         const baseLine = this._context.textBaseline;
         const font: string = this._context.font;
-        this._context.font = this._musicFont.toCssString(relativeScale);
+        this._context.font = this._musicFont!.toCssString(relativeScale);
         this._context.textBaseline = 'middle';
         if (centerAtPosition) {
             this._context.textAlign = 'center';

--- a/test/bundler/Vite.test.ts
+++ b/test/bundler/Vite.test.ts
@@ -63,18 +63,18 @@ describe('Vite', () => {
                     // ensure worklet bootstrapper script is references
                     expect(text).to.include('assets/alphaTab.worklet-');
                     // without custom chunking the app will bundle alphatab directly
-                    expect(text).to.include("font-family: 'alphaTab';");
+                    expect(text).to.include(".at-surface");
                     appValidated = true;
                 } else if (file.name.startsWith('alphaTab.worker-')) {
                     expect(text).to.include('initializeWorker()');
                     // without custom chunking the app will bundle alphatab directly
-                    expect(text).to.include("font-family: 'alphaTab';");
+                    expect(text).to.include(".at-surface");
 
                     workerValidated = true;
                 } else if (file.name.startsWith('alphaTab.worklet-')) {
                     expect(text).to.include('initializeAudioWorklet()');
                     // without custom chunking the app will bundle alphatab directly
-                    expect(text).to.include("font-family: 'alphaTab';");
+                    expect(text).to.include(".at-surface");
                     workletValidated = true;
                 }
             }

--- a/test/visualTests/VisualTestHelper.ts
+++ b/test/visualTests/VisualTestHelper.ts
@@ -235,8 +235,6 @@ export class VisualTestHelper {
     }
 
     static prepareSettingsForTest(settings: Settings) {
-        /**@target web*/
-        settings.core.fontDirectory = 'font/bravura/';
         settings.core.engine = 'skia';
         Environment.HighDpiFactor = 1; // test data is in scale 1
         settings.core.enableLazyLoading = false;


### PR DESCRIPTION
### Issues
Fixes #2113

### Proposed changes
Allows more flexible configuration of the SmuFL web font used in alphaTab. (e.g. loading bravura from a data url). 

Note: We do not support other SmuFL fonts other than bravura with this improvement. This is part of #1949 where we'll need to accept metadata to size and position things correctly. But the change is taking a small step towards this.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
