### PR TITLE
fix: External Cursor API related problems

### DIFF
--- a/src/AlphaTabApiBase.ts
+++ b/src/AlphaTabApiBase.ts
@@ -2212,8 +2212,9 @@ export class AlphaTabApiBase<TSettings> {
                         // it can happen that the cursor reaches the target position slightly too early (especially on backing tracks)
                         // to avoid the cursor stopping, causing a wierd look, we animate the cursor to the double position in double time.
                         // beatCursor!.transitionToX((duration / cursorSpeed), nextBeatX);
-                        const doubleEndBeatX = startBeatX + (nextBeatX - startBeatX) * 2;
-                        beatCursor!.transitionToX((duration / cursorSpeed) * 2, doubleEndBeatX);
+                        const factor = cursorMode === MidiTickLookupFindBeatResultCursorMode.ToNextBext ? 2 : 1;
+                        const doubleEndBeatX = startBeatX + (nextBeatX - startBeatX) * factor;
+                        beatCursor!.transitionToX((duration / cursorSpeed) * factor, doubleEndBeatX);
                     });
                 } else {
                     beatCursor.transitionToX(0, startBeatX);

--- a/src/midi/MidiFileGenerator.ts
+++ b/src/midi/MidiFileGenerator.ts
@@ -363,16 +363,6 @@ export class MidiFileGenerator {
             masterBarLookup.tempoChanges.push(new MasterBarTickLookupTempoChange(currentTick, currentTempo));
         }
 
-        const syncPoints = masterBar.syncPoints;
-        if (syncPoints) {
-            for (const syncPoint of syncPoints) {
-                if (syncPoint.syncPointValue!.barOccurence === barOccurence) {
-                    const tick = currentTick + masterBarDuration * syncPoint.ratioPosition;
-                    this.syncPoints.push(new BackingTrackSyncPoint(tick, syncPoint.syncPointValue!));
-                }
-            }
-        }
-
         masterBarLookup.masterBar = masterBar;
         masterBarLookup.start = currentTick;
         masterBarLookup.end = masterBarLookup.start + masterBarDuration;

--- a/src/synth/MidiFileSequencer.ts
+++ b/src/synth/MidiFileSequencer.ts
@@ -486,7 +486,9 @@ export class MidiFileSequencer {
             state.tempoChangeIndex = tempoChangeIndex;
             state.currentTempo = state.tempoChanges[state.tempoChangeIndex].bpm;
         }
+    }
 
+    private updateSyncPoints(state: MidiSequencerState, timePosition:number) {
         const syncPoints = state.syncPoints;
         if (syncPoints.length > 0) {
             let syncPointIndex = Math.min(state.syncPointIndex, syncPoints.length - 1);
@@ -516,7 +518,7 @@ export class MidiFileSequencer {
             return timePosition;
         }
 
-        this.updateCurrentTempo(this._mainState, timePosition);
+        this.updateSyncPoints(this._mainState, timePosition);
 
         const syncPointIndex = Math.min(mainState.syncPointIndex, syncPoints.length - 1);
 


### PR DESCRIPTION
### Issues
Relates to #1961 

### Proposed changes
Fixes some more findings around the external cursor api changes:

* The beat cursor was animating too far in some cases. We now respect the animation hint whether animation should only go to the end of the bar (e.g. on repeats or song ends). 
* Sync points were generated double after the refactoring
* The double update of sync points in the midi sequencer was wrong as it mixed the backing track and alphatab time axis. 

### Checklist
- [ ] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [ ] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
