### PR TITLE
feat: Sync Points for alphaTex

### DIFF
--- a/src.compiler/csharp/CSharpAstTransformer.ts
+++ b/src.compiler/csharp/CSharpAstTransformer.ts
@@ -3647,7 +3647,16 @@ export default class CSharpAstTransformer {
                     newObject.arguments.push(assignment);
                 } else if (ts.isShorthandPropertyAssignment(p)) {
                     assignment.label = p.name.getText();
-                    assignment.expression = this.visitExpression(assignment, p.objectAssignmentInitializer!)!;
+                    if(p.objectAssignmentInitializer) {
+                        assignment.expression = this.visitExpression(assignment, p.objectAssignmentInitializer)!;
+                    } else {
+                        assignment.expression = {
+                            nodeType: cs.SyntaxKind.Identifier,
+                            parent: assignment,
+                            tsNode: p.name,
+                            text: p.name.getText()
+                        } as cs.Identifier
+                    }
                     newObject.arguments.push(assignment);
                 } else if (ts.isSpreadAssignment(p)) {
                     this._context.addTsNodeDiagnostics(p, 'Spread operator not supported', ts.DiagnosticCategory.Error);

--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -274,7 +274,7 @@ export class AlphaTexImporter extends ScoreImporter {
         // \sync BarIndex Occurence MillisecondOffset
         // \sync BarIndex Occurence MillisecondOffset RatioPosition
 
-        if (this._sy !== AlphaTexSymbols.MetaCommand || this._syData !== 'sync') {
+        if (this._sy !== AlphaTexSymbols.MetaCommand || (this._syData as string) !== 'sync') {
             this.error('syncPoint', AlphaTexSymbols.MetaCommand, true);
         }
 

--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -245,6 +245,7 @@ export class AlphaTexImporter extends ScoreImporter {
 
             ModelUtils.consolidate(this._score);
             this._score.finish(this.settings);
+            ModelUtils.trimEmptyBarsAtEnd(this._score);
             this._score.rebuildRepeatGroups();
             this._score.applyFlatSyncPoints(this._syncPoints);
             for (const [track, lyrics] of this._lyrics) {

--- a/src/importer/ScoreLoader.ts
+++ b/src/importer/ScoreLoader.ts
@@ -9,12 +9,26 @@ import type { Score } from '@src/model/Score';
 import { Settings } from '@src/Settings';
 
 import { Logger } from '@src/Logger';
+import { AlphaTexImporter } from '@src/importer/AlphaTexImporter';
 
 /**
  * The ScoreLoader enables you easy loading of Scores using all
  * available importers
  */
 export class ScoreLoader {
+    /**
+     * Loads the given alphaTex string.
+     * @param tex The alphaTex string.
+     * @param settings The settings to use for parsing.
+     * @returns The parsed {@see Score}.
+     */
+    public static loadAlphaTex(tex: string, settings?: Settings): Score {
+        const parser = new AlphaTexImporter();
+        parser.logErrors = true;
+        parser.initFromString(tex, settings ?? new Settings());
+        return parser.readScore();
+    }
+
     /**
      * Loads a score asynchronously from the given datasource
      * @param path the source path to load the binary file from

--- a/src/importer/_barrel.ts
+++ b/src/importer/_barrel.ts
@@ -1,3 +1,4 @@
 export { ScoreImporter } from '@src/importer/ScoreImporter';
 export { ScoreLoader } from '@src/importer/ScoreLoader';
 export { UnsupportedFormatError } from '@src/importer/UnsupportedFormatError';
+export { AlphaTexImporter } from '@src/importer/AlphaTexImporter';

--- a/src/model/Bar.ts
+++ b/src/model/Bar.ts
@@ -319,6 +319,31 @@ export class Bar {
     }
 
     /**
+     * Whether this bar has any changes applied which are not related to the voices in it.
+     * (e.g. new key signatures)
+     */
+    public get hasChanges(): boolean {
+        if (this.index === 0) {
+            return true;
+        }
+        const hasChangesToPrevious =
+            this.keySignature !== this.previousBar!.keySignature ||
+            this.keySignatureType !== this.previousBar!.keySignatureType ||
+            this.clef !== this.previousBar!.clef ||
+            this.clefOttava !== this.previousBar!.clefOttava;
+        if (hasChangesToPrevious) {
+            return true;
+        }
+
+        return (
+            this.simileMark !== SimileMark.None ||
+            this.sustainPedals.length > 0 ||
+            this.barLineLeft !== BarLineStyle.Automatic ||
+            this.barLineRight !== BarLineStyle.Automatic
+        );
+    }
+
+    /**
      * Whether this bar is empty or has only rests.
      */
     public get isRestOnly(): boolean {

--- a/src/model/MasterBar.ts
+++ b/src/model/MasterBar.ts
@@ -45,6 +45,39 @@ export class MasterBar {
     public index: number = 0;
 
     /**
+     * Whether the masterbar is has any changes applied to it (e.g. tempo changes, time signature changes etc)
+     * The first bar is always considered changed due to initial setup of values. It does not consider
+     * elements like whether the tempo really changes to the previous bar.
+     */
+    public get hasChanges() {
+        if (this.index === 0) {
+            return false;
+        }
+
+        const hasChangesToPrevious =
+            this.timeSignatureCommon !== this.previousMasterBar!.timeSignatureCommon ||
+            this.timeSignatureNumerator !== this.previousMasterBar!.timeSignatureNumerator ||
+            this.timeSignatureDenominator !== this.previousMasterBar!.timeSignatureDenominator ||
+            this.tripletFeel !== this.previousMasterBar!.tripletFeel;
+        if (hasChangesToPrevious) {
+            return true;
+        }
+
+        return (
+            this.alternateEndings !== 0 ||
+            this.isRepeatStart ||
+            this.isRepeatEnd ||
+            this.isFreeTime ||
+            this.isSectionStart ||
+            this.tempoAutomations.length > 0 ||
+            this.syncPoints && this.syncPoints!.length > 0 ||
+            (this.fermata !== null && this.fermata!.size > 0) ||
+            (this.directions !== null && this.directions!.size > 0) ||
+            this.isAnacrusis
+        );
+    }
+
+    /**
      * The key signature used on all bars.
      * @deprecated Use key signatures on bar level
      */

--- a/src/model/ModelUtils.ts
+++ b/src/model/ModelUtils.ts
@@ -411,8 +411,8 @@ export class ModelUtils {
                 const masterBar = score.masterBars[currentIndex];
 
                 let hasTempoChange = false;
-                for(const a of masterBar.tempoAutomations) {
-                    if(a.value !== tempo) {
+                for (const a of masterBar.tempoAutomations) {
+                    if (a.value !== tempo) {
                         hasTempoChange = true;
                     }
                     tempo = a.value;
@@ -630,6 +630,44 @@ export class ModelUtils {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Trims any empty bars at the end of the song.
+     * @param score
+     */
+    public static trimEmptyBarsAtEnd(score: Score) {
+        while (score.masterBars.length > 1) {
+            const barIndex = score.masterBars.length - 1;
+            const masterBar = score.masterBars[barIndex];
+
+            for (const track of score.tracks) {
+                for (const staff of track.staves) {
+                    if (barIndex < staff.bars.length) {
+                        const bar = staff.bars[barIndex];
+                        if (!bar.isEmpty) {
+                            // found a non-empty bar, stop whole cleanup
+                            return;
+                        }
+                    }
+                }
+            }
+
+            // if we reach here, all found bars are empty, remove the bar
+            for (const track of score.tracks) {
+                for (const staff of track.staves) {
+                    if (barIndex < staff.bars.length) {
+                        const bar = staff.bars[barIndex];
+                        staff.bars.pop();
+                        // unlink
+                        bar.previousBar!.nextBar = null;
+                    }
+                }
+            }
+
+            score.masterBars.pop();
+            masterBar.previousMasterBar!.nextMasterBar = null;
         }
     }
 }

--- a/src/model/ModelUtils.ts
+++ b/src/model/ModelUtils.ts
@@ -419,8 +419,7 @@ export class ModelUtils {
                 }
 
                 // check if masterbar breaks multibar rests, it must be fully empty with no annotations
-                if (
-                    masterBar.alternateEndings ||
+                if (masterBar.alternateEndings ||
                     (masterBar.isRepeatStart && masterBar.index !== currentGroupStartIndex) ||
                     masterBar.isFreeTime ||
                     masterBar.isAnacrusis ||
@@ -642,11 +641,15 @@ export class ModelUtils {
             const barIndex = score.masterBars.length - 1;
             const masterBar = score.masterBars[barIndex];
 
+            if (masterBar.hasChanges) {
+                return;
+            }
+            
             for (const track of score.tracks) {
                 for (const staff of track.staves) {
                     if (barIndex < staff.bars.length) {
                         const bar = staff.bars[barIndex];
-                        if (!bar.isEmpty) {
+                        if (!bar.isEmpty || bar.hasChanges) {
                             // found a non-empty bar, stop whole cleanup
                             return;
                         }

--- a/test/audio/MidiPlaybackController.test.ts
+++ b/test/audio/MidiPlaybackController.test.ts
@@ -163,7 +163,7 @@ describe('MidiPlaybackControllerTest', () => {
         const tex: string = `
         \\tempo 175
         .
-        \\ro :1 r | \\ae 1 r | \\ae 2 \\rc 2 r | \\ro r | \\ae 1 r | \\ae (2 3 4) \\rc 4 r |       
+        \\ro :1 r | \\ae 1 r | \\ae 2 \\rc 2 r | \\ro r | \\ae 1 r | \\ae (2 3 4) \\rc 4 r | r
         `;
         const expectedBars: number[] = [0, 1, 0, 2, 3, 4, 3, 5, 3, 5, 3, 5, 6];
         testAlphaTexRepeat(tex, expectedBars, 50);

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -781,7 +781,7 @@ describe('AlphaTexImporterTest', () => {
             [KeySignature.B, KeySignatureType.Major],
             [KeySignature.FSharp, KeySignatureType.Minor]
         ];
-        
+
         for (let i = 0; i < expected.length; i++) {
             expect(bars[i].keySignature).to.equal(expected[i][0]);
             expect(bars[i].keySignatureType).to.equal(expected[i][1]);
@@ -1972,6 +1972,28 @@ describe('AlphaTexImporterTest', () => {
                     \\barlineleft heavylight
                     \\barlineright dashed
             `);
+        expect(score).toMatchSnapshot();
+    });
+
+    it('sync', () => {
+        const score = parseTex(`
+            \\tempo 90
+            .
+            3.4.4*4 | 3.4.4*4 |
+            \\ro 3.4.4*4 | 3.4.4*4 | \\rc 2 3.4.4*4 |
+            3.4.4*4 | 3.4.4*4
+            .
+            \\sync 0 0 0 
+            \\sync 0 0 1000 0.5
+            \\sync 1 0 2000
+            \\sync 3 0 3000
+            \\sync 3 1 4000
+            \\sync 6 1 5000
+            `);
+
+        // simplify snapshot
+        score.tracks = [];
+
         expect(score).toMatchSnapshot();
     });
 });

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -1996,4 +1996,30 @@ describe('AlphaTexImporterTest', () => {
 
         expect(score).toMatchSnapshot();
     });
+
+    it('sync-expect-dot', () => {
+        const score = parseTex(`
+            \\title "Prelude in D Minor"
+            \\artist "J.S. Bach (1685-1750)"
+            \\copyright "Public Domain"
+            \\tempo 80
+            .
+            \\ts 3 4
+            0.4.16 (3.2 -.4) (1.1 -.4) (5.1 -.4) 1.1 3.2 1.1 3.2 2.3.8 (3.2 3.4) |
+            (3.2 0.4).16 (3.2 -.4) (1.1 -.4) (5.1 -.4) 1.1 3.2 1.1 3.2 2.3.8 (3.2 3.4) | 
+            (3.2 0.4).16 (3.2 -.4) (3.1 -.4) (6.1 -.4) 3.1 3.2 3.1 3.2 3.3.8 (3.2 0.3) | 
+            (3.2 0.4).16 (3.2 -.4) (3.1 -.4) (6.1 -.4) 3.1 3.2 3.1 3.2 3.3.8 (3.2 0.3) |
+            .
+            \\sync 0 0 0
+            \\sync 0 0 1500 0.666
+            \\sync 1 0 4075 0.666
+            \\sync 2 0 6475 0.333
+            \\sync 3 0 10223 1
+        `);
+
+        // simplify snapshot
+        score.tracks = [];
+
+        expect(score).toMatchSnapshot();
+    });
 });

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -881,7 +881,7 @@ describe('AlphaTexImporterTest', () => {
     });
 
     it('triplet-feel-multi-bar', () => {
-        const tex: string = '\\tf t16 | | | \\tf t8 | | | \\tf no | | ';
+        const tex: string = '\\tf t16 C4 | C4  | C4  | \\tf t8 C4 | C4 | C4 | \\tf no | C4  | C4 ';
         const score: Score = parseTex(tex);
         expect(score.masterBars[0].tripletFeel).to.equal(TripletFeel.Triplet16th);
         expect(score.masterBars[1].tripletFeel).to.equal(TripletFeel.Triplet16th);
@@ -1480,9 +1480,9 @@ describe('AlphaTexImporterTest', () => {
 
         expect(score.masterBars).to.have.length(2);
 
-        expect(score.tracks[0].staves[0].bars).to.have.length(2);
-        expect(score.tracks[0].staves[0].bars[0].voices).to.have.length(2);
-        expect(score.tracks[0].staves[0].bars[1].voices).to.have.length(2);
+        expect(score.tracks[0].staves[0].bars.length).to.equal(2);
+        expect(score.tracks[0].staves[0].bars[0].voices.length).to.equal(2);
+        expect(score.tracks[0].staves[0].bars[1].voices.length).to.equal(2);
     });
 
     it('multi-voice-simple-all-voices', () => {

--- a/test/importer/__snapshots__/AlphaTexImporter.test.ts.snap
+++ b/test/importer/__snapshots__/AlphaTexImporter.test.ts.snap
@@ -138,3 +138,124 @@ Map {
   ],
 }
 `;
+
+exports[`AlphaTexImporterTest sync 1`] = `
+Map {
+  "__kind" => "Score",
+  "tempo" => 90,
+  "masterbars" => Array [
+    Map {
+      "__kind" => "MasterBar",
+      "tempoautomations" => Array [
+        Map {
+          "islinear" => false,
+          "type" => 0,
+          "value" => 90,
+          "ratioposition" => 0,
+          "text" => "",
+        },
+      ],
+      "syncpoints" => Array [
+        Map {
+          "islinear" => false,
+          "type" => 4,
+          "value" => 0,
+          "syncpointvalue" => Map {
+            "baroccurence" => 0,
+            "millisecondoffset" => 0,
+          },
+          "ratioposition" => 0,
+          "text" => "",
+        },
+        Map {
+          "islinear" => false,
+          "type" => 4,
+          "value" => 0,
+          "syncpointvalue" => Map {
+            "baroccurence" => 0,
+            "millisecondoffset" => 1000,
+          },
+          "ratioposition" => 0.5,
+          "text" => "",
+        },
+      ],
+    },
+    Map {
+      "__kind" => "MasterBar",
+      "syncpoints" => Array [
+        Map {
+          "islinear" => false,
+          "type" => 4,
+          "value" => 0,
+          "syncpointvalue" => Map {
+            "baroccurence" => 0,
+            "millisecondoffset" => 2000,
+          },
+          "ratioposition" => 0,
+          "text" => "",
+        },
+      ],
+      "start" => 3840,
+    },
+    Map {
+      "__kind" => "MasterBar",
+      "isrepeatstart" => true,
+      "start" => 7680,
+    },
+    Map {
+      "__kind" => "MasterBar",
+      "syncpoints" => Array [
+        Map {
+          "islinear" => false,
+          "type" => 4,
+          "value" => 0,
+          "syncpointvalue" => Map {
+            "baroccurence" => 0,
+            "millisecondoffset" => 3000,
+          },
+          "ratioposition" => 0,
+          "text" => "",
+        },
+        Map {
+          "islinear" => false,
+          "type" => 4,
+          "value" => 0,
+          "syncpointvalue" => Map {
+            "baroccurence" => 1,
+            "millisecondoffset" => 4000,
+          },
+          "ratioposition" => 0,
+          "text" => "",
+        },
+      ],
+      "start" => 11520,
+    },
+    Map {
+      "__kind" => "MasterBar",
+      "repeatcount" => 2,
+      "start" => 15360,
+    },
+    Map {
+      "__kind" => "MasterBar",
+      "start" => 19200,
+    },
+    Map {
+      "__kind" => "MasterBar",
+      "syncpoints" => Array [
+        Map {
+          "islinear" => false,
+          "type" => 4,
+          "value" => 0,
+          "syncpointvalue" => Map {
+            "baroccurence" => 1,
+            "millisecondoffset" => 5000,
+          },
+          "ratioposition" => 0,
+          "text" => "",
+        },
+      ],
+      "start" => 23040,
+    },
+  ],
+}
+`;

--- a/test/importer/__snapshots__/AlphaTexImporter.test.ts.snap
+++ b/test/importer/__snapshots__/AlphaTexImporter.test.ts.snap
@@ -259,3 +259,126 @@ Map {
   ],
 }
 `;
+
+exports[`AlphaTexImporterTest sync-expect-dot 1`] = `
+Map {
+  "__kind" => "Score",
+  "artist" => "J.S. Bach (1685-1750)",
+  "copyright" => "Public Domain",
+  "title" => "Prelude in D Minor",
+  "tempo" => 80,
+  "masterbars" => Array [
+    Map {
+      "__kind" => "MasterBar",
+      "timesignaturenumerator" => 3,
+      "tempoautomations" => Array [
+        Map {
+          "islinear" => false,
+          "type" => 0,
+          "value" => 80,
+          "ratioposition" => 0,
+          "text" => "",
+        },
+      ],
+      "syncpoints" => Array [
+        Map {
+          "islinear" => false,
+          "type" => 4,
+          "value" => 0,
+          "syncpointvalue" => Map {
+            "baroccurence" => 0,
+            "millisecondoffset" => 0,
+          },
+          "ratioposition" => 0,
+          "text" => "",
+        },
+        Map {
+          "islinear" => false,
+          "type" => 4,
+          "value" => 0,
+          "syncpointvalue" => Map {
+            "baroccurence" => 0,
+            "millisecondoffset" => 1500,
+          },
+          "ratioposition" => 0.666,
+          "text" => "",
+        },
+      ],
+    },
+    Map {
+      "__kind" => "MasterBar",
+      "timesignaturenumerator" => 3,
+      "syncpoints" => Array [
+        Map {
+          "islinear" => false,
+          "type" => 4,
+          "value" => 0,
+          "syncpointvalue" => Map {
+            "baroccurence" => 0,
+            "millisecondoffset" => 4075,
+          },
+          "ratioposition" => 0.666,
+          "text" => "",
+        },
+      ],
+      "start" => 2880,
+    },
+    Map {
+      "__kind" => "MasterBar",
+      "timesignaturenumerator" => 3,
+      "syncpoints" => Array [
+        Map {
+          "islinear" => false,
+          "type" => 4,
+          "value" => 0,
+          "syncpointvalue" => Map {
+            "baroccurence" => 0,
+            "millisecondoffset" => 6475,
+          },
+          "ratioposition" => 0.333,
+          "text" => "",
+        },
+      ],
+      "start" => 5760,
+    },
+    Map {
+      "__kind" => "MasterBar",
+      "timesignaturenumerator" => 3,
+      "syncpoints" => Array [
+        Map {
+          "islinear" => false,
+          "type" => 4,
+          "value" => 0,
+          "syncpointvalue" => Map {
+            "baroccurence" => 0,
+            "millisecondoffset" => 10223,
+          },
+          "ratioposition" => 1,
+          "text" => "",
+        },
+      ],
+      "start" => 8640,
+    },
+  ],
+  "style" => Map {
+    "headerandfooter" => Map {
+      "0" => Map {
+        "template" => "%TITLE%",
+        "isvisible" => true,
+        "textalign" => 1,
+      },
+      "2" => Map {
+        "template" => "%ARTIST%",
+        "isvisible" => true,
+        "textalign" => 1,
+      },
+      "8" => Map {
+        "template" => "%COPYRIGHT%",
+        "isvisible" => true,
+        "textalign" => 1,
+      },
+    },
+    "colors" => Map {},
+  },
+}
+`;


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Fixes #2126

### Proposed changes
Adds alphaTex support for sync points. Also it exposes the alphaTex importer for easier external use. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website
