### PR TITLE
feat: Add option to create fresh sync points

### DIFF
--- a/test/audio/SyncPoint.test.ts
+++ b/test/audio/SyncPoint.test.ts
@@ -124,6 +124,19 @@ describe('SyncPointTests', () => {
         }
     });
 
+    it('sync-point-generation-new', async () => {
+        const score = await syncPointTestScore();
+
+        const update = MidiFileGenerator.generateSyncPoints(score, true);
+        expect(
+            update.map(
+                p =>
+                    `${p.masterBarIndex},${p.masterBarOccurence},${p.synthBpm},${p.syncBpm},${p.synthTime},${p.syncTime}`
+            )
+        ).toMatchSnapshot();
+
+    });
+
     it('modified-tempo-lookup', async () => {
         const score = await syncPointTestScore();
 

--- a/test/audio/__snapshots__/SyncPoint.test.ts.snap
+++ b/test/audio/__snapshots__/SyncPoint.test.ts.snap
@@ -403,6 +403,15 @@ Array [
 ]
 `;
 
+exports[`SyncPointTests sync-point-generation-new 1`] = `
+Array [
+  "0,0,120,120,0,0",
+  "4,0,60,60,8000,8000",
+  "8,0,80,80,24000,24000",
+  "11,0,80,80,48000,48000",
+]
+`;
+
 exports[`SyncPointTests sync-point-update 1`] = `
 Array [
   "0,0,120,120,0,0",


### PR DESCRIPTION
### Proposed changes
Needed for the media sync editor to avoid code duplication. Adds a parameter which allows creation of a fresh set of sync points based on the synth timing and the song tempo changes. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
