### PR TITLE
fix: Update alphaSkia to 3.4.135

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
             "license": "MPL-2.0",
             "devDependencies": {
                 "@biomejs/biome": "^1.9.4",
-                "@coderline/alphaskia": "^3.3.135",
-                "@coderline/alphaskia-linux": "^3.3.135",
-                "@coderline/alphaskia-windows": "^3.3.135",
+                "@coderline/alphaskia": "^3.4.135",
+                "@coderline/alphaskia-linux": "^3.4.135",
+                "@coderline/alphaskia-windows": "^3.4.135",
                 "@fontsource/noto-sans": "^5.1.1",
                 "@fontsource/noto-serif": "^5.1.1",
                 "@fortawesome/fontawesome-free": "^6.7.2",
@@ -724,9 +724,9 @@
             }
         },
         "node_modules/@coderline/alphaskia": {
-            "version": "3.3.135",
-            "resolved": "https://registry.npmjs.org/@coderline/alphaskia/-/alphaskia-3.3.135.tgz",
-            "integrity": "sha512-Dkm9OdhY/CvVXips3feBzbW0oB2m8dzCI/oA9ZW3GQWW1rpD0GqfE6qSukDCcEgYf/3fdHMSCpPr5JBCdEofFw==",
+            "version": "3.4.135",
+            "resolved": "https://registry.npmjs.org/@coderline/alphaskia/-/alphaskia-3.4.135.tgz",
+            "integrity": "sha512-vKDE9cyC0BhFuMAPaQUryPD+rnbcP4J43bp69mxd3kM0hnpaDubpDcP5lwSlhfkEzkTQDD+a8kk5letJ4Jeu1g==",
             "dev": true,
             "engines": {
                 "node": ">=18.0.0"
@@ -738,9 +738,9 @@
             }
         },
         "node_modules/@coderline/alphaskia-linux": {
-            "version": "3.3.135",
-            "resolved": "https://registry.npmjs.org/@coderline/alphaskia-linux/-/alphaskia-linux-3.3.135.tgz",
-            "integrity": "sha512-mWFgEGS+8leKJrLg1KQiQ7oittw1kdE2St1JvA2V2zQeOMpOCsyTcsj2Eid3v7UTNtRsPl1CeUleWWUobznYxQ==",
+            "version": "3.4.135",
+            "resolved": "https://registry.npmjs.org/@coderline/alphaskia-linux/-/alphaskia-linux-3.4.135.tgz",
+            "integrity": "sha512-vApv3lijxD034eKUwR1QwUJOWFh3ztmdKk40JQ3iOyAcHqrKQqgLhJXFSrPH4EcZkaxFklhbezWDbrDz2DYAtw==",
             "dev": true,
             "engines": {
                 "node": ">=18.0.0"
@@ -757,9 +757,9 @@
             }
         },
         "node_modules/@coderline/alphaskia-windows": {
-            "version": "3.3.135",
-            "resolved": "https://registry.npmjs.org/@coderline/alphaskia-windows/-/alphaskia-windows-3.3.135.tgz",
-            "integrity": "sha512-k3JTzUGmYvz7XrDLsL4HTKeJIGbRQlncCizbYjZR1IDGlliTQSx6ueBX+cRfcw8qRBkstumllYGVxTtfAv4daw==",
+            "version": "3.4.135",
+            "resolved": "https://registry.npmjs.org/@coderline/alphaskia-windows/-/alphaskia-windows-3.4.135.tgz",
+            "integrity": "sha512-6LqOcHcGo5Jo3eSg3rRYFNzNV2MExyypPPrfigz15UxCAejb7lvIaqgTeIejYWtHSiZiyOLCjG/bxkFpN1uoeA==",
             "dev": true,
             "engines": {
                 "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -72,9 +72,9 @@
     },
     "devDependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@coderline/alphaskia": "^3.3.135",
-        "@coderline/alphaskia-linux": "^3.3.135",
-        "@coderline/alphaskia-windows": "^3.3.135",
+        "@coderline/alphaskia": "^3.4.135",
+        "@coderline/alphaskia-linux": "^3.4.135",
+        "@coderline/alphaskia-windows": "^3.4.135",
         "@fontsource/noto-sans": "^5.1.1",
         "@fontsource/noto-serif": "^5.1.1",
         "@fortawesome/fontawesome-free": "^6.7.2",

--- a/src.csharp/AlphaTab.Test/AlphaTab.Test.csproj
+++ b/src.csharp/AlphaTab.Test/AlphaTab.Test.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
         <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
-        <PackageReference Include="AlphaSkia" Version="3.3.135" />
-        <PackageReference Include="AlphaSkia.Native.Windows" Version="3.3.135" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
-        <PackageReference Include="AlphaSkia.Native.Linux" Version="3.3.135" Condition="$([MSBuild]::IsOsPlatform('Linux'))" />
-        <PackageReference Include="AlphaSkia.Native.MacOs" Version="3.3.135" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
+        <PackageReference Include="AlphaSkia" Version="3.4.135" />
+        <PackageReference Include="AlphaSkia.Native.Windows" Version="3.4.135" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
+        <PackageReference Include="AlphaSkia.Native.Linux" Version="3.4.135" Condition="$([MSBuild]::IsOsPlatform('Linux'))" />
+        <PackageReference Include="AlphaSkia.Native.MacOs" Version="3.4.135" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
 
     </ItemGroup>
 

--- a/src.csharp/AlphaTab.Windows/AlphaTab.Windows.csproj
+++ b/src.csharp/AlphaTab.Windows/AlphaTab.Windows.csproj
@@ -27,7 +27,7 @@
 
     <ItemGroup>
       <PackageReference Include="NAudio" Version="2.2.1" />
-      <PackageReference Include="AlphaSkia.Native.Windows" Version="3.3.135" />
+      <PackageReference Include="AlphaSkia.Native.Windows" Version="3.4.135" />
     </ItemGroup>
 
 </Project>

--- a/src.csharp/AlphaTab/AlphaTab.csproj
+++ b/src.csharp/AlphaTab/AlphaTab.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AlphaSkia" Version="3.3.135"/>
+        <PackageReference Include="AlphaSkia" Version="3.4.135"/>
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
         <PackageReference Include="System.Drawing.Common" Version="9.0.7"/>
     </ItemGroup>

--- a/src.kotlin/alphaTab/gradle/libs.versions.toml
+++ b/src.kotlin/alphaTab/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ appcompat = "1.7.1"
 coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
-alphaskia = "3.3.135"
+alphaskia = "3.4.135"
 mavenPublish = "0.33.0"
 
 


### PR DESCRIPTION
### Issues
Fixes #2205

### Proposed changes
Updates alphaSkia to the version which has the required fix for the rendering issues on Android. Basically Android is not guaranteeing a zero-terminator on strings and alphaSkia needs to use the explicitly provided string length. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
