### PR TITLE
fix(alphatex): Clef names

### DIFF
--- a/src/importer/AlphaTexImporter.ts
+++ b/src/importer/AlphaTexImporter.ts
@@ -805,10 +805,10 @@ export class AlphaTexImporter extends ScoreImporter {
             case 'bass':
                 return Clef.F4;
             case 'c3':
-            case 'tenor':
+            case 'alto':
                 return Clef.C3;
             case 'c4':
-            case 'alto':
+            case 'tenor':
                 return Clef.C4;
             case 'n':
             case 'neutral':
@@ -826,6 +826,8 @@ export class AlphaTexImporter extends ScoreImporter {
      */
     private parseClefFromInt(i: number): Clef {
         switch (i) {
+            case 0:
+                return Clef.Neutral;
             case 43:
                 return Clef.G2;
             case 65:

--- a/test/importer/AlphaTexImporter.test.ts
+++ b/test/importer/AlphaTexImporter.test.ts
@@ -1965,12 +1965,27 @@ describe('AlphaTexImporterTest', () => {
 
     it('clefs', () => {
         const score = parseTex(`
-        \\clef C4 \\ottava 15ma C4 | C4
+        \\clef C4 \\ottava 15ma C4 | C4 |
+        \\clef 0 | \\clef 48 | \\clef 60 | \\clef 65 | \\clef 43 |
+        \\clef Neutral | \\clef C3 | \\clef C4 | \\clef F4 | \\clef G2 | 
+        \\clef "Neutral" | \\clef "C3" | \\clef "C4" | \\clef "F4" | \\clef "G2" | 
+        \\clef n | \\clef alto | \\clef tenor | \\clef bass | \\clef treble | 
+        \\clef "n" | \\clef "alto" | \\clef "tenor" | \\clef "bass" | \\clef "treble"
         `);
-        expect(score.tracks[0].staves[0].bars[0].clef).to.equal(Clef.C4);
-        expect(score.tracks[0].staves[0].bars[0].clefOttava).to.equal(Ottavia._15ma);
-        expect(score.tracks[0].staves[0].bars[1].clef).to.equal(Clef.C4);
-        expect(score.tracks[0].staves[0].bars[1].clefOttava).to.equal(Ottavia._15ma);
+        let barIndex = 0;
+        expect(score.tracks[0].staves[0].bars[barIndex].clef).to.equal(Clef.C4);
+        expect(score.tracks[0].staves[0].bars[barIndex++].clefOttava).to.equal(Ottavia._15ma);
+        expect(score.tracks[0].staves[0].bars[barIndex].clef).to.equal(Clef.C4);
+        expect(score.tracks[0].staves[0].bars[barIndex++].clefOttava).to.equal(Ottavia._15ma);
+
+        for (let i = 0; i < 5; i++) {
+            expect(score.tracks[0].staves[0].bars[barIndex++].clef).to.equal(Clef.Neutral, `Invalid clef at index ${barIndex - 1}`);
+            expect(score.tracks[0].staves[0].bars[barIndex++].clef).to.equal(Clef.C3, `Invalid clef at index ${barIndex - 1}`);
+            expect(score.tracks[0].staves[0].bars[barIndex++].clef).to.equal(Clef.C4, `Invalid clef at index ${barIndex - 1}`);
+            expect(score.tracks[0].staves[0].bars[barIndex++].clef).to.equal(Clef.F4, `Invalid clef at index ${barIndex - 1}`);
+            expect(score.tracks[0].staves[0].bars[barIndex++].clef).to.equal(Clef.G2, `Invalid clef at index ${barIndex - 1}`);
+        }
+
         testExportRoundtrip(score);
     });
 


### PR DESCRIPTION
### Issues
Fixes #2195

### Proposed changes
Fixes the wrong parsing of names to clefs in alphaTex. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
