### PR TITLE
fix(webpack): Prevent worker chunks using global library settings

### DIFF
--- a/src/webpack/AlphaTabAudioWorklet.ts
+++ b/src/webpack/AlphaTabAudioWorklet.ts
@@ -50,7 +50,12 @@ export function configureAudioWorklet(
             entryOptions: {
                 chunkLoading: false,
                 wasmLoading: false,
-                runtime: runtime
+                runtime: runtime,
+                library: {
+                    // prevent any built-in/default library settings
+                    // to be active for this chunk
+                    type: 'at-worklet'
+                }
             }
         });
 

--- a/src/webpack/AlphaTabWebWorker.ts
+++ b/src/webpack/AlphaTabWebWorker.ts
@@ -52,7 +52,12 @@ export function configureWebWorker(
             entryOptions: {
                 chunkLoading: 'import-scripts',
                 wasmLoading: false,
-                runtime: runtime
+                runtime: runtime,
+                library: {
+                    // prevent any built-in/default library settings
+                    // to be active for this chunk
+                    type: 'at-worker'
+                }
             }
         });
 

--- a/test/bundler/WebPack.test.ts
+++ b/test/bundler/WebPack.test.ts
@@ -18,7 +18,14 @@ describe('WebPack', () => {
                 webpack(
                     {
                         entry: {
-                            app: './src/app.mjs'
+                            app: {
+                                import: './src/app.mjs',
+                                // see https://github.com/CoderLine/alphaTab/issues/2299
+                                library: {
+                                    type: 'assign',
+                                    name: 'alphaTabApp'
+                                }
+                            }
                         },
                         output: {
                             filename: '[name]-[contenthash:8].js',
@@ -99,16 +106,26 @@ describe('WebPack', () => {
                     expect(text).to.include('/* worklet bootstrap */ async function(__webpack_worklet__) {');
                     // without custom bundling the app will bundle alphatab directly
                     expect(text).to.include('class AlphaTabApiBase');
+                    // ensure the library mode is active as needed
+                    expect(text).to.include('alphaTabApp = __webpack_exports__');
 
                     appValidated = true;
                 } else if (file.name.endsWith('.js')) {
                     if (text.includes('class AlphaTabApiBase')) {
+                        // ensure the library mode is does not affect chunks
+                        expect(text).to.not.include('alphaTabApp = __webpack_exports__');
                         coreFileValidated = true; // found core file (imported by worker and worklet)
                     } else if (text.includes('initializeAudioWorklet()')) {
+                        // ensure the library mode is does not affect chunks
+                        expect(text).to.not.include('alphaTabApp = __webpack_exports__');
+
                         // ensure chunk installer is there
                         expect(text).to.include('webpack/runtime/alphaTab audio worker chunk loading');
                         workletValidated = true;
                     } else if (text.includes('initializeWorker()')) {
+                        // ensure the library mode is does not affect chunks
+                        expect(text).to.not.include('alphaTabApp = __webpack_exports__');
+
                         // ensure chunk loader is there
                         expect(text).to.include('webpack/runtime/importScripts chunk loading');
                         workerValidated = true;


### PR DESCRIPTION
### Issues
Fixes #2299

### Proposed changes
Set a library type for the chunk entry points (worker/worklet) to prevent global settings activating. 

e.g. in NextJS there might be a "Assign" library type causing errors on strict mode. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
