### PR TITLE
fix: use innerText when loading alphaTex from dom

### DIFF
--- a/packages/alphatab/src/platform/javascript/BrowserUiFacade.ts
+++ b/packages/alphatab/src/platform/javascript/BrowserUiFacade.ts
@@ -203,8 +203,8 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
         this._contents = '';
         const element: HtmlElementContainer = api.container as HtmlElementContainer;
         if (settings.core.tex) {
-            this._contents = element.element.innerHTML;
-            element.element.innerHTML = '';
+            this._contents = element.element.innerText;
+            element.element.innerText = '';
         }
         this._createStyleElements(settings);
         this._file = settings.core.file;

--- a/packages/alphatab/src/platform/javascript/HtmlElementContainer.ts
+++ b/packages/alphatab/src/platform/javascript/HtmlElementContainer.ts
@@ -196,6 +196,6 @@ export class HtmlElementContainer implements IContainer {
     }
 
     public clear(): void {
-        this.element.innerHTML = '';
+        this.element.innerText = '';
     }
 }

--- a/packages/playground/alphatex-editor.ts
+++ b/packages/playground/alphatex-editor.ts
@@ -82,8 +82,8 @@ async function load<T>(url: URL, type: XMLHttpRequest['responseType']): Promise<
 async function setupEditor(api: alphaTab.AlphaTabApi, element: HTMLElement) {
     Split(['#editor-wrap', '#alphatab-wrap']);
 
-    const initialCode = sessionStorage.getItem('alphatex-editor.code') ?? trimCode(element.innerHTML);
-    element.innerHTML = '';
+    const initialCode = sessionStorage.getItem('alphatex-editor.code') ?? trimCode(element.innerText);
+    element.innerText = '';
 
     await setupMonaco();
 


### PR DESCRIPTION
### Issues
Fixes #2330

### Proposed changes
As the title says. I don't expect any major negative impact here. Rather currently we get some escaped entities. 

In case of problems users can still opt to load the code via `.tex()`

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
