### PR TITLE
feat(bundlers): warn if plugins are not used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,6 @@
             "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
@@ -1738,7 +1737,6 @@
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -2736,7 +2734,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2770,7 +2767,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
             "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -2998,6 +2994,14 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.9.7",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.7.tgz",
+            "integrity": "sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg==",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.js"
+            }
+        },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3067,9 +3071,9 @@
             "license": "ISC"
         },
         "node_modules/browserslist": {
-            "version": "4.25.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
-            "integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -3084,13 +3088,12 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "caniuse-lite": "^1.0.30001737",
-                "electron-to-chromium": "^1.5.211",
-                "node-releases": "^2.0.19",
-                "update-browserslist-db": "^1.1.3"
+                "baseline-browser-mapping": "^2.9.0",
+                "caniuse-lite": "^1.0.30001759",
+                "electron-to-chromium": "^1.5.263",
+                "node-releases": "^2.0.27",
+                "update-browserslist-db": "^1.2.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -3316,9 +3319,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001739",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001739.tgz",
-            "integrity": "sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==",
+            "version": "1.0.30001760",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001760.tgz",
+            "integrity": "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -3332,8 +3335,7 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ],
-            "license": "CC-BY-4.0"
+            ]
         },
         "node_modules/chai": {
             "version": "6.2.1",
@@ -3933,10 +3935,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.214",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.214.tgz",
-            "integrity": "sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q==",
-            "license": "ISC"
+            "version": "1.5.267",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
+            "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
@@ -5704,12 +5705,15 @@
             }
         },
         "node_modules/loader-runner": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
-            "license": "MIT",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+            "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
             "engines": {
                 "node": ">=6.11.5"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/locate-path": {
@@ -6183,10 +6187,9 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-            "license": "MIT"
+            "version": "2.0.27",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+            "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -6959,7 +6962,6 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz",
             "integrity": "sha512-/Zl4D8zPifNmyGzJS+3kVoyXeDeT/GrsJM94sACNg9RtUE0hrHa1bNPtRSrfHTMH5HjRzce6K7rlTh3Khiw+pw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -7089,10 +7091,9 @@
             }
         },
         "node_modules/schema-utils": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-            "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
-            "license": "MIT",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
                 "ajv": "^8.9.0",
@@ -7675,10 +7676,9 @@
             }
         },
         "node_modules/tapable": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
-            "integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
-            "license": "MIT",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+            "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
             "engines": {
                 "node": ">=6"
             },
@@ -8413,7 +8413,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -8452,9 +8451,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.2.tgz",
+            "integrity": "sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -8469,7 +8468,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.1"
@@ -8536,7 +8534,6 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.6.tgz",
             "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.5.0",
@@ -8797,11 +8794,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.101.3",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.3.tgz",
-            "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
-            "license": "MIT",
-            "peer": true,
+            "version": "5.103.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.103.0.tgz",
+            "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -8811,7 +8806,7 @@
                 "@webassemblyjs/wasm-parser": "^1.14.1",
                 "acorn": "^8.15.0",
                 "acorn-import-phases": "^1.0.3",
-                "browserslist": "^4.24.0",
+                "browserslist": "^4.26.3",
                 "chrome-trace-event": "^1.0.2",
                 "enhanced-resolve": "^5.17.3",
                 "es-module-lexer": "^1.2.1",
@@ -8820,13 +8815,13 @@
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.11",
                 "json-parse-even-better-errors": "^2.3.1",
-                "loader-runner": "^4.2.0",
+                "loader-runner": "^4.3.1",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
-                "schema-utils": "^4.3.2",
-                "tapable": "^2.1.1",
+                "schema-utils": "^4.3.3",
+                "tapable": "^2.3.0",
                 "terser-webpack-plugin": "^5.3.11",
-                "watchpack": "^2.4.1",
+                "watchpack": "^2.4.4",
                 "webpack-sources": "^3.3.3"
             },
             "bin": {
@@ -8851,7 +8846,6 @@
             "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.6.1",
                 "@webpack-cli/configtest": "^3.0.1",
@@ -9459,7 +9453,7 @@
             "version": "1.8.0",
             "license": "MPL-2.0",
             "dependencies": {
-                "webpack": "^5.101.3"
+                "webpack": "^5.103.0"
             },
             "devDependencies": {
                 "@biomejs/biome": "^2.2.6",

--- a/packages/alphatab/src/Environment.ts
+++ b/packages/alphatab/src/Environment.ts
@@ -697,6 +697,15 @@ export class Environment {
         try {
             // @ts-expect-error
             if (typeof __webpack_require__ === 'function') {
+                // check if webpack plugin was used
+                // @ts-expect-error
+                if (typeof __ALPHATAB_WEBPACK__ !== 'boolean') {
+                    Logger.warning(
+                        'WebPack',
+                        `Detected bundling with WebPack but @coderline/alphatab-webpcak was not used! To ensure alphaTab works as expected use our bundler plugins. Learn more at https://www.alphatab.net/docs/getting-started/installation-webpack`
+                    );
+                }
+
                 return true;
             }
         } catch {
@@ -712,6 +721,15 @@ export class Environment {
         try {
             // @ts-expect-error
             if (typeof __BASE__ === 'string') {
+                // check if vite plugin was used
+                // @ts-expect-error
+                if (typeof __ALPHATAB_VITE__ !== 'boolean') {
+                    Logger.warning(
+                        'Vite',
+                        `Detected bundling with Vite but @coderline/alphatab-vite was not used! To ensure alphaTab works as expected use our bundler plugins. Learn more at https://www.alphatab.net/docs/getting-started/installation-vite`
+                    );
+                }
+
                 return true;
             }
         } catch {

--- a/packages/vite/src/alphaTabVitePlugin.ts
+++ b/packages/vite/src/alphaTabVitePlugin.ts
@@ -1,3 +1,4 @@
+import { detectionGlobalPlugin } from '@coderline/alphatab-vite/detectionGlobalPlugin';
 import type { AlphaTabVitePluginOptions } from './AlphaTabVitePluginOptions';
 import type { Plugin } from './bridge';
 import { copyAssetsPlugin } from './copyAssetsPlugin';
@@ -12,6 +13,7 @@ export function alphaTab(options?: AlphaTabVitePluginOptions) {
 
     options ??= {};
 
+    plugins.push(detectionGlobalPlugin());
     plugins.push(importMetaUrlPlugin(options));
     plugins.push(workerPlugin(options));
     plugins.push(copyAssetsPlugin(options));

--- a/packages/vite/src/detectionGlobalPlugin.ts
+++ b/packages/vite/src/detectionGlobalPlugin.ts
@@ -1,0 +1,38 @@
+import MagicString from 'magic-string';
+import type { Plugin, ResolvedConfig } from './bridge';
+
+const marker = '__ALPHATAB_VITE__';
+
+/**
+ * @public
+ */
+export function detectionGlobalPlugin(): Plugin {
+    let resolvedConfig: ResolvedConfig;
+    return {
+        name: 'vite-plugin-alphatab-global',
+
+        configResolved(config) {
+            resolvedConfig = config as ResolvedConfig;
+        },
+
+        shouldTransformCachedModule({ code }) {
+            return code.includes(marker);
+        },
+
+        async transform(code, id) {
+            if (!code.includes(marker)) {
+                return;
+            }
+
+            const s = new MagicString(code);
+            s.replaceAll(marker, JSON.stringify(true));
+            return {
+                code: s.toString(),
+                map:
+                    resolvedConfig.command === 'build' && resolvedConfig.build.sourcemap
+                        ? s.generateMap({ hires: 'boundary', source: id })
+                        : null
+            };
+        }
+    };
+}

--- a/packages/vite/test/Vite.test.ts
+++ b/packages/vite/test/Vite.test.ts
@@ -62,6 +62,8 @@ describe('Vite', () => {
                     expect(text).to.include('assets/alphaTab.worklet-');
                     // without custom chunking the app will bundle alphatab directly
                     expect(text).to.include(".at-surface");
+                    // ensure __ALPHATAB_VITE__ got replaced
+                    expect(text).to.not.include("__ALPHATAB_VITE__");
                     appValidated = true;
                 } else if (file.name.startsWith('alphaTab.worker-')) {
                     expect(text).to.include('initializeWorker()');

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -42,7 +42,7 @@
         "test": "mocha"
     },
     "dependencies": {
-        "webpack": "^5.101.3"
+        "webpack": "^5.103.0"
     },
     "engines": {
         "node": ">=20.19.0"

--- a/packages/webpack/src/AlphaTabWebPackPlugin.ts
+++ b/packages/webpack/src/AlphaTabWebPackPlugin.ts
@@ -14,6 +14,7 @@ import type { webPackWithAlphaTab, webpackTypes } from './Utils';
 import { injectWebWorkerDependency } from './AlphaTabWebWorkerDependency';
 import { injectWorkletRuntimeModule } from './AlphaTabWorkletStartRuntimeModule';
 import { injectWorkletDependency } from './AlphaTabWorkletDependency';
+import { configureDetectionGlobal } from '@coderline/alphatab-webpack/DetectionGlobal';
 
 const WINDOWS_ABS_PATH_REGEXP = /^[a-zA-Z]:[\\/]/;
 const WINDOWS_PATH_SEPARATOR_REGEXP = /\\/g;
@@ -219,6 +220,7 @@ export class AlphaTabWebPackPlugin {
                 cachedContextify
             );
             this._configureAssetCopy(this._webPackWithAlphaTab, pluginName, compiler, compilation);
+            configureDetectionGlobal(pluginName, normalModuleFactory);
         });
     }
 

--- a/packages/webpack/src/AlphaTabWebWorkerDependency.ts
+++ b/packages/webpack/src/AlphaTabWebWorkerDependency.ts
@@ -81,8 +81,8 @@ export function injectWebWorkerDependency(webPackWithAlphaTab: webPackWithAlphaT
             runtimeRequirements.add(webPackWithAlphaTab.webpack.RuntimeGlobals.getChunkScriptFilename);
 
             source.replace(
-                dep.range[0],
-                dep.range[1] - 1,
+                dep.range![0],
+                dep.range![1] - 1,
                 `/* worker import */ ${workerImportBaseUrl} + ${
                     webPackWithAlphaTab.webpack.RuntimeGlobals.getChunkScriptFilename
                 }(${JSON.stringify(chunk.id)}), ${webPackWithAlphaTab.webpack.RuntimeGlobals.baseURI}`

--- a/packages/webpack/src/AlphaTabWorkletDependency.ts
+++ b/packages/webpack/src/AlphaTabWorkletDependency.ts
@@ -99,8 +99,8 @@ export function injectWorkletDependency(webPackWithAlphaTab: webPackWithAlphaTab
             runtimeRequirements.add(webPackWithAlphaTab.alphaTab.RuntimeGlobalWorkletGetStartupChunks);
 
             source.replace(
-                dep.range[0],
-                dep.range[1] - 1,
+                dep.range![0],
+                dep.range![1] - 1,
                 webPackWithAlphaTab.webpack.Template.asString([
                     '(/* worklet bootstrap */ async function(__webpack_worklet__) {',
                     webPackWithAlphaTab.webpack.Template.indent([

--- a/packages/webpack/src/DetectionGlobal.ts
+++ b/packages/webpack/src/DetectionGlobal.ts
@@ -1,0 +1,17 @@
+import type { Expression } from 'estree';
+import { tapJavaScript } from './Utils';
+
+/**
+ * @internal
+ */
+export function configureDetectionGlobal(pluginName: string, normalModuleFactory: any) {
+    const parserPlugin = (parser: any) => {
+        parser.hooks.evaluateIdentifier.for('__ALPHATAB_WEBPACK__').tap(pluginName, (expr: Expression) => {
+            const res = parser.evaluate('true');
+            res.setRange(expr.range);
+            return res;
+        });
+    };
+
+    tapJavaScript(normalModuleFactory, pluginName, parserPlugin);
+}

--- a/packages/webpack/test/WebPack.test.ts
+++ b/packages/webpack/test/WebPack.test.ts
@@ -30,10 +30,7 @@ describe('WebPack', () => {
                             filename: '[name]-[contenthash:8].js',
                             path: path.resolve('./out')
                         },
-                        plugins: [
-                            new AlphaTabWebPackPlugin(),
-                            new HtmlWebpackPlugin()
-                        ],
+                        plugins: [new AlphaTabWebPackPlugin(), new HtmlWebpackPlugin()],
                         optimization: {
                             minimize: false,
                             splitChunks: {
@@ -105,7 +102,8 @@ describe('WebPack', () => {
                     expect(text).to.include('class AlphaTabApiBase');
                     // ensure the library mode is active as needed
                     expect(text).to.include('alphaTabApp = __webpack_exports__');
-
+                    // ensure __ALPHATAB_WEBPACK__ got replaced
+                    expect(text).to.not.include('__ALPHATAB_WEBPACK__');
                     appValidated = true;
                 } else if (file.name.endsWith('.js')) {
                     if (text.includes('class AlphaTabApiBase')) {


### PR DESCRIPTION
### Issues
Fixes #2314

### Proposed changes
Replace a special placeholder during build time to detect vite or webpack is used, but not with our plugins. If the plugin is used, the DCE will remove the warning. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
