### PR TITLE
fix(exporter): no sound in guitar 8 pro RSE

### DIFF
--- a/packages/alphatab/src/exporter/GpifWriter.ts
+++ b/packages/alphatab/src/exporter/GpifWriter.ts
@@ -1806,7 +1806,7 @@ export class GpifWriter {
             const elements = instrumentSet.addElement('Elements');
             const element = elements.addElement('Element');
 
-            element.addElement('Pitched').innerText = 'Pitched';
+            element.addElement('Name').innerText = 'Pitched';
             element.addElement('Type').innerText = 'pitched';
             element.addElement('SoundbankName').innerText = '';
 


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Fixes #2455

### Proposed changes
<!-- Describe the proposed changes -->
Fixed GP file export to correctly generate RSE audio configuration. GP files exported from alphaTab were missing the `<Name>` element and incorrectly using `<Pitched>` element, causing no sound when playing with RSE audio in Guitar Pro.

**Root cause:**
Exported GP files had `<Pitched>Pitched</Pitched>` instead of `<Name>Pitched</Name>` in the RSE audio configuration, which prevented Guitar Pro from properly loading the RSE sound bank.

**Change:**
```ts
// Before
element.addElement('Pitched').innerText = 'Pitched';
// After
element.addElement('Name').innerText = 'Pitched';
```


**Testing/Debugging process:**
1. Exported a GP file from alphaTab and reduced it to one measure with one track
2. Created a new track in Guitar Pro 8 and copied the notes from the original track
3. Configured both tracks to use RSE audio
4. Observed that the new track had sound but the original track (exported from alphaTab) did not
5. Unpacked both GP files and compared the `score.gpif` XML structure
6. Found that the working track had `<Name>Pitched</Name>` while the non-working track had `<Pitched>Pitched</Pitched>`

After applying this fix, exported GP files now play correctly with RSE audio in Guitar Pro.

### Checklist
- [x] I consent that this change becomes part of alphaTab under its current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- Manual testing performed: exported GP files now play correctly with RSE audio in Guitar Pro 8 -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website