### PR TITLE
fix(exporter): add missing tags of percussion in gp exporter

### DIFF
--- a/packages/alphatab/src/exporter/GpifWriter.ts
+++ b/packages/alphatab/src/exporter/GpifWriter.ts
@@ -106,6 +106,32 @@ class GpifMidiProgramInfo {
 }
 
 /**
+ * @internal
+ */
+class GpifArticulationInfo  {
+    public inputMidiNumber: number
+    public elementName: string
+    public articulationName: string
+    public outputRSESound: string
+    public soundbankName: string
+
+    constructor(inputMidiNumber: number, elementName: string, outputRSESound: string, soundbankName: string) {
+        this.inputMidiNumber = inputMidiNumber;
+        this.elementName = elementName;
+        this.outputRSESound = outputRSESound;
+        this.soundbankName = soundbankName;
+
+        let articulationName = this.elementName
+        for (const [name, inputMidi] of PercussionMapper.instrumentArticulationNames) {
+            if (inputMidiNumber === inputMidi) {
+                articulationName = name;
+            }
+        }
+        this.articulationName = articulationName
+    }
+}
+
+/**
  * This class can write a score.gpif XML from a given score model.
  * @internal
  */
@@ -246,6 +272,102 @@ export class GpifWriter {
         [126, new GpifMidiProgramInfo(GpifIconIds.Fx, 'Recorder')],
         [127, new GpifMidiProgramInfo(GpifIconIds.Fx, 'Timpani')]
     ]);
+    private static _articulationExtraInfoLookup: Map<number, GpifArticulationInfo> = new Map([
+        new GpifArticulationInfo(38, "Snare", "stick.hit.hit", "Master-Snare"),
+        new GpifArticulationInfo(37, "Snare", "stick.hit.sidestick", "Master-Snare"),
+        new GpifArticulationInfo(91, "Snare", "stick.hit.rimshot", "Master-Snare"),
+        new GpifArticulationInfo(42, "Charley", "stick.hit.closed", "Master-Hihat"),
+        new GpifArticulationInfo(92, "Charley", "stick.hit.half", "Master-Hihat"),
+        new GpifArticulationInfo(46, "Charley", "stick.hit.open", "Master-Hihat"),
+        new GpifArticulationInfo(44, "Charley", "pedal.hit.pedal", "Master-Hihat"),
+        new GpifArticulationInfo(35, "Acoustic Kick Drum", "pedal.hit.hit", "AcousticKick-Percu"),
+        new GpifArticulationInfo(36, "Kick Drum", "pedal.hit.hit", "Master-Kick"),
+        new GpifArticulationInfo(50, "Tom Very High", "stick.hit.hit", "Master-Tom05"),
+        new GpifArticulationInfo(48, "Tom High", "stick.hit.hit", "Master-Tom04"),
+        new GpifArticulationInfo(47, "Tom Medium", "stick.hit.hit", "Master-Tom03"),
+        new GpifArticulationInfo(45, "Tom Low", "stick.hit.hit", "Master-Tom02"),
+        new GpifArticulationInfo(43, "Tom Very Low", "stick.hit.hit", "Master-Tom01"),
+        new GpifArticulationInfo(93, "Ride", "stick.hit.edge", "Master-Ride"),
+        new GpifArticulationInfo(51, "Ride", "stick.hit.mid", "Master-Ride"),
+        new GpifArticulationInfo(53, "Ride", "stick.hit.bell", "Master-Ride"),
+        new GpifArticulationInfo(94, "Ride", "stick.hit.choke", "Master-Ride"),
+        new GpifArticulationInfo(55, "Splash", "stick.hit.hit", "Master-Splash"),
+        new GpifArticulationInfo(95, "Splash", "stick.hit.choke", "Master-Splash"),
+        new GpifArticulationInfo(52, "China", "stick.hit.hit", "Master-China"),
+        new GpifArticulationInfo(96, "China", "stick.hit.choke", "Master-China"),
+        new GpifArticulationInfo(49, "Crash High", "stick.hit.hit", "Master-Crash02"),
+        new GpifArticulationInfo(97, "Crash High", "stick.hit.choke", "Master-Crash02"),
+        new GpifArticulationInfo(57, "Crash Medium", "stick.hit.hit", "Master-Crash01"),
+        new GpifArticulationInfo(98, "Crash Medium", "stick.hit.choke", "Master-Crash01"),
+        new GpifArticulationInfo(99, "Cowbell Low", "stick.hit.hit", "CowbellBig-Percu"),
+        new GpifArticulationInfo(100, "Cowbell Low", "stick.hit.tip", "CowbellBig-Percu"),
+        new GpifArticulationInfo(56, "Cowbell Medium", "stick.hit.hit", "CowbellMid-Percu"),
+        new GpifArticulationInfo(101, "Cowbell Medium", "stick.hit.tip", "CowbellMid-Percu"),
+        new GpifArticulationInfo(102, "Cowbell High", "stick.hit.hit", "CowbellSmall-Percu"),
+        new GpifArticulationInfo(103, "Cowbell High", "stick.hit.tip", "CowbellSmall-Percu"),
+        new GpifArticulationInfo(77, "Woodblock Low", "stick.hit.hit", "WoodblockLow-Percu"),
+        new GpifArticulationInfo(76, "Woodblock High", "stick.hit.hit", "WoodblockHigh-Percu"),
+        new GpifArticulationInfo(60, "Bongo High", "hand.hit.hit", "BongoHigh-Percu"),
+        new GpifArticulationInfo(104, "Bongo High", "hand.hit.mute", "BongoHigh-Percu"),
+        new GpifArticulationInfo(105, "Bongo High", "hand.hit.slap", "BongoHigh-Percu"),
+        new GpifArticulationInfo(61, "Bongo Low", "hand.hit.hit", "BongoLow-Percu"),
+        new GpifArticulationInfo(106, "Bongo Low", "hand.hit.mute", "BongoLow-Percu"),
+        new GpifArticulationInfo(107, "Bongo Low", "hand.hit.slap", "BongoLow-Percu"),
+        new GpifArticulationInfo(66, "Timbale Low", "stick.hit.hit", "TimbaleLow-Percu"),
+        new GpifArticulationInfo(65, "Timbale High", "stick.hit.hit", "TimbaleHigh-Percu"),
+        new GpifArticulationInfo(68, "Agogo Low", "stick.hit.hit", "AgogoLow-Percu"),
+        new GpifArticulationInfo(67, "Agogo High", "stick.hit.hit", "AgogoHigh-Percu"),
+        new GpifArticulationInfo(64, "Conga Low", "hand.hit.hit", "CongaLow-Percu"),
+        new GpifArticulationInfo(108, "Conga Low", "hand.hit.slap", "CongaLow-Percu"),
+        new GpifArticulationInfo(109, "Conga Low", "hand.hit.mute", "CongaLow-Percu"),
+        new GpifArticulationInfo(63, "Conga High", "hand.hit.hit", "CongaHigh-Percu"),
+        new GpifArticulationInfo(110, "Conga High", "hand.hit.slap", "CongaHigh-Percu"),
+        new GpifArticulationInfo(62, "Conga High", "hand.hit.mute", "CongaHigh-Percu"),
+        new GpifArticulationInfo(72, "Whistle Low", "blow.hit.hit", "WhistleLow-Percu"),
+        new GpifArticulationInfo(71, "Whistle High", "blow.hit.hit", "WhistleHigh-Percu"),
+        new GpifArticulationInfo(73, "Guiro", "stick.hit.hit", "Guiro-Percu"),
+        new GpifArticulationInfo(74, "Guiro", "stick.scrape.return", "Guiro-Percu"),
+        new GpifArticulationInfo(86, "Surdo", "brush.hit.hit", "Surdo-Percu"),
+        new GpifArticulationInfo(87, "Surdo", "brush.hit.mute", "Surdo-Percu"),
+        new GpifArticulationInfo(54, "Tambourine", "hand.hit.hit", "Tambourine-Percu"),
+        new GpifArticulationInfo(111, "Tambourine", "hand.hit.return", "Tambourine-Percu"),
+        new GpifArticulationInfo(112, "Tambourine", "hand.hit.roll", "Tambourine-Percu"),
+        new GpifArticulationInfo(113, "Tambourine", "hand.hit.handhit", "Tambourine-Percu"),
+        new GpifArticulationInfo(79, "Cuica", "hand.hit.hit", "Cuica-Percu"),
+        new GpifArticulationInfo(78, "Cuica", "hand.hit.mute", "Cuica-Percu"),
+        new GpifArticulationInfo(58, "Vibraslap", "hand.hit.hit", "Vibraslap-Percu"),
+        new GpifArticulationInfo(81, "Triangle", "stick.hit.hit", "Triangle-Percu"),
+        new GpifArticulationInfo(80, "Triangle", "stick.hit.mute", "Triangle-Percu"),
+        new GpifArticulationInfo(114, "Grancassa", "mallet.hit.hit", "Grancassa-Percu"),
+        new GpifArticulationInfo(115, "Piatti", "hand.hit.hit", "Piatti-Percu"),
+        new GpifArticulationInfo(116, "Piatti", "hand.hit.hit", "Piatti-Percu"),
+        new GpifArticulationInfo(69, "Cabasa", "hand.hit.hit", "Cabasa-Percu"),
+        new GpifArticulationInfo(117, "Cabasa", "hand.hit.return", "Cabasa-Percu"),
+        new GpifArticulationInfo(85, "Castanets", "hand.hit.hit", "Castanets-Percu"),
+        new GpifArticulationInfo(75, "Claves", "stick.hit.hit", "Claves-Percu"),
+        new GpifArticulationInfo(70, "Left Maraca", "hand.hit.hit", "Maracas-Percu"),
+        new GpifArticulationInfo(118, "Left Maraca", "hand.hit.return", "Maracas-Percu"),
+        new GpifArticulationInfo(119, "Right Maraca", "hand.hit.hit", "Maracas-Percu"),
+        new GpifArticulationInfo(120, "Right Maraca", "hand.hit.return", "Maracas-Percu"),
+        new GpifArticulationInfo(82, "Shaker", "hand.hit.hit", "ShakerStudio-Percu"),
+        new GpifArticulationInfo(122, "Shaker", "hand.hit.return", "ShakerStudio-Percu"),
+        new GpifArticulationInfo(84, "Bell Tree", "stick.hit.hit", "BellTree-Percu"),
+        new GpifArticulationInfo(123, "Bell Tree", "stick.hit.return", "BellTree-Percu"),
+        new GpifArticulationInfo(83, "Jingle Bell", "stick.hit.hit", "JingleBell-Percu"),
+        new GpifArticulationInfo(124, "Golpe", "thumb.hit.body", "Golpe-Percu"),
+        new GpifArticulationInfo(125, "Golpe", "finger4.hit.body", "Golpe-Percu"),
+        new GpifArticulationInfo(39, "Hand Clap", "hand.hit.hit", "GroupHandClap-Percu"),
+        new GpifArticulationInfo(40, "Electric Snare", "stick.hit.hit", "ElectricSnare-Percu"),
+        new GpifArticulationInfo(31, "Sticks", "stick.hit.sidestick", "Stick-Percu"),
+        new GpifArticulationInfo(41, "Very Low Floor Tom", "stick.hit.hit", "LowFloorTom-Percu"),
+        new GpifArticulationInfo(59, "Ride Cymbal 2", "stick.hit.edge", "Ride-Percu"),
+        new GpifArticulationInfo(126, "Ride Cymbal 2", "stick.hit.mid", "Ride-Percu"),
+        new GpifArticulationInfo(127, "Ride Cymbal 2", "stick.hit.bell", "Ride-Percu"),
+        new GpifArticulationInfo(29, "Ride Cymbal 2", "stick.hit.choke", "Ride-Percu"),
+        new GpifArticulationInfo(30, "Reverse Cymbal", "stick.hit.hit", "Reverse-Cymbal"),
+        new GpifArticulationInfo(33, "Metronome", "stick.hit.sidestick", "Metronome-Percu"),
+        new GpifArticulationInfo(34, "Metronome", "stick.hit.hit", "Metronome-Percu"),
+    ].map(info=> [info.inputMidiNumber, info]))
 
     private static _drumKitProgramInfo: GpifMidiProgramInfo = new GpifMidiProgramInfo(
         GpifIconIds.PercussionKit,
@@ -1739,34 +1861,33 @@ export class GpifWriter {
 
             instrumentSet.addElement('Name').innerText = GpifWriter._drumKitProgramInfo.instrumentSetName;
             instrumentSet.addElement('Type').innerText = GpifWriter._drumKitProgramInfo.instrumentSetType;
-            const currentElementType: string = '';
             let currentElementName: string = '';
+            let currentElement: XmlNode | null = null;
             let currentArticulations: XmlNode = new XmlNode();
-            const counterPerType = new Map<string, number>();
             const elements = instrumentSet.addElement('Elements');
             for (const articulation of articulations) {
-                if (!currentElementType || currentElementType !== articulation.elementType) {
-                    const currentElement = elements.addElement('Element');
+                const extraArticulationInfo = GpifWriter._articulationExtraInfoLookup.get(articulation.inputMidiNumber);
 
-                    let name = articulation.elementType;
-                    if (counterPerType.has(name)) {
-                        const counter = counterPerType.get(name)!;
-                        name += ` ${counter}`;
-                        counterPerType.set(name, counter + 1);
-                    } else {
-                        counterPerType.set(name, 1);
-                    }
-
-                    currentElementName = name;
-                    currentElement.addElement('Name').innerText = name;
+                // Group by elementName (e.g., 'Snare', 'Charley', 'Kick Drum')
+                // If elementName is not set, fall back to elementType
+                const elementNameToUse = extraArticulationInfo?.elementName 
+                    || articulation.elementType;
+                
+                if (!currentElementName || currentElementName !== elementNameToUse) {
+                    currentElement = elements.addElement('Element');
+                    currentElementName = elementNameToUse;
+                    
+                    currentElement.addElement('Name').innerText = elementNameToUse;
                     currentElement.addElement('Type').innerText = articulation.elementType;
+                    currentElement.addElement('SoundbankName').innerText = extraArticulationInfo?.soundbankName || '';
 
                     currentArticulations = currentElement.addElement('Articulations');
                 }
 
                 const articulationNode = currentArticulations.addElement('Articulation');
-                articulationNode.addElement('Name').innerText =
-                    `${currentElementName} ${currentArticulations.childNodes.length}`;
+                // Use articulationName if available, otherwise generate a name
+
+                articulationNode.addElement('Name').innerText = extraArticulationInfo?.articulationName || '';
                 articulationNode.addElement('StaffLine').innerText = articulation.staffLine.toString();
                 articulationNode.addElement('Noteheads').innerText = [
                     this._mapMusicSymbol(articulation.noteHeadDefault),
@@ -1791,10 +1912,14 @@ export class GpifWriter {
                 articulationNode.addElement('TechniqueSymbol').innerText = this._mapMusicSymbol(
                     articulation.techniqueSymbol
                 );
-                articulationNode.addElement('InputMidiNumbers').innerText = '';
+                // Write InputMidiNumbers using the inputMidiNumber field
+                articulationNode.addElement('InputMidiNumbers').innerText = 
+                    articulation.inputMidiNumber > 0 ? articulation.inputMidiNumber.toString() : '';
+                // Write OutputRSESound
+                articulationNode.addElement('OutputRSESound').innerText = extraArticulationInfo?.outputRSESound || '';
                 articulationNode.addElement('OutputMidiNumber').innerText = articulation.outputMidiNumber.toString();
             }
-        } else {
+        }  else {
             const programInfo = GpifWriter._midiProgramInfoLookup.has(track.playbackInfo.program)
                 ? GpifWriter._midiProgramInfoLookup.get(track.playbackInfo.program)!
                 : GpifWriter._midiProgramInfoLookup.get(0)!;

--- a/packages/alphatab/src/generated/DisplaySettingsJson.ts
+++ b/packages/alphatab/src/generated/DisplaySettingsJson.ts
@@ -354,6 +354,7 @@ export interface DisplaySettingsJson {
      *
      * * Comparing files against each other (top/bottom comparison)
      * * Aligning the playback of multiple files on one screen assuming the same tempo (e.g. one file per track).
+     * @deprecated Use the {@link LayoutMode.Parchment} to display a music sheet respecting the systems layout.
      */
     systemsLayoutMode?: SystemsLayoutMode | keyof typeof SystemsLayoutMode | Lowercase<keyof typeof SystemsLayoutMode>;
 }

--- a/packages/alphatab/src/generated/model/InstrumentArticulationSerializer.ts
+++ b/packages/alphatab/src/generated/model/InstrumentArticulationSerializer.ts
@@ -29,6 +29,7 @@ export class InstrumentArticulationSerializer {
         o.set("noteheadwhole", obj.noteHeadWhole as number);
         o.set("techniquesymbol", obj.techniqueSymbol as number);
         o.set("techniquesymbolplacement", obj.techniqueSymbolPlacement as number);
+        o.set("inputmidinumber", obj.inputMidiNumber);
         o.set("outputmidinumber", obj.outputMidiNumber);
         return o;
     }
@@ -54,6 +55,9 @@ export class InstrumentArticulationSerializer {
                 return true;
             case "techniquesymbolplacement":
                 obj.techniqueSymbolPlacement = JsonHelper.parseEnum<TechniqueSymbolPlacement>(v, TechniqueSymbolPlacement)!;
+                return true;
+            case "inputmidinumber":
+                obj.inputMidiNumber = v! as number;
                 return true;
             case "outputmidinumber":
                 obj.outputMidiNumber = v! as number;

--- a/packages/alphatab/src/importer/MusicXmlImporter.ts
+++ b/packages/alphatab/src/importer/MusicXmlImporter.ts
@@ -130,6 +130,7 @@ class TrackInfo {
         'Default',
         0,
         0,
+        0,
         MusicFontSymbol.NoteheadBlack,
         MusicFontSymbol.NoteheadHalf,
         MusicFontSymbol.NoteheadWhole
@@ -171,6 +172,7 @@ class TrackInfo {
         const newArticulation = new InstrumentArticulation(
             articulation.elementType,
             staffLine,
+            articulation.inputMidiNumber,
             articulation.outputMidiNumber,
             articulation.noteHeadDefault,
             articulation.noteHeadHalf,

--- a/packages/alphatab/src/model/InstrumentArticulation.ts
+++ b/packages/alphatab/src/model/InstrumentArticulation.ts
@@ -70,11 +70,16 @@ export class InstrumentArticulation {
     /**
      * Gets or sets which midi key to use when playing the note.
      */
+    public inputMidiNumber: number;
+    /**
+     * Gets or sets which midi key to use when playing the note.
+     */
     public outputMidiNumber: number;
 
     public constructor(
         elementType: string = '',
         staffLine: number = 0,
+        inputMidiNumber: number = 0,
         outputMidiNumber: number = 0,
         noteHeadDefault: MusicFontSymbol = MusicFontSymbol.None,
         noteHeadHalf: MusicFontSymbol = MusicFontSymbol.None,
@@ -83,6 +88,7 @@ export class InstrumentArticulation {
         techniqueSymbolPlacement: TechniqueSymbolPlacement = TechniqueSymbolPlacement.Inside
     ) {
         this.elementType = elementType;
+        this.inputMidiNumber = inputMidiNumber;
         this.outputMidiNumber = outputMidiNumber;
         this.staffLine = staffLine;
         this.noteHeadDefault = noteHeadDefault;

--- a/packages/alphatab/src/model/PercussionMapper.ts
+++ b/packages/alphatab/src/model/PercussionMapper.ts
@@ -64,10 +64,10 @@ export class PercussionMapper {
      * 		const noteHeads = articulation.getElementsByTagName('Noteheads')[0].textContent.split(' ').map(n=>n = 'MusicFontSymbol.' + n);
      * 		if(!existingArticulations.has(midi)) {
      *        if(techniqueSymbol) {
-     * 		    s += `['${elementType}', ${midi}, new InstrumentArticulation(${staffLine}, ${outputMidiNumber}, ${noteHeads[0]}, ${noteHeads[1]}, ${noteHeads[2]}, ${techniqueSymbol}, ${techniquePlacement})],\r\n`;
+     * 		    s += `new InstrumentArticulation(${staffLine}, ${midi}, ${outputMidiNumber}, ${noteHeads[0]}, ${noteHeads[1]}, ${noteHeads[2]}, ${techniqueSymbol}, ${techniquePlacement}),\r\n`;
      *        }
      *        else {
-     * 		    s += `['${elementType}', ${midi}, new InstrumentArticulation(${staffLine}, ${outputMidiNumber}, ${noteHeads[0]}, ${noteHeads[1]}, ${noteHeads[2]})],\r\n`;
+     * 		    s += `new InstrumentArticulation(${staffLine}, ${midi}, ${outputMidiNumber}, ${noteHeads[0]}, ${noteHeads[1]}, ${noteHeads[2]}),\r\n`;
      *        }
      * 		  existingArticulations.set(midi, true);
      * 		}
@@ -76,1085 +76,897 @@ export class PercussionMapper {
      * copy(s)
      */
     public static instrumentArticulations: Map<number, InstrumentArticulation> = new Map([
-        [
-            38,
             new InstrumentArticulation(
                 'snare',
                 3,
                 38,
+                38,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            37,
+            ),
             new InstrumentArticulation(
                 'snare',
                 3,
                 37,
+                37,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack
-            )
-        ],
-        [
-            91,
+            ),
             new InstrumentArticulation(
                 'snare',
                 3,
+                91,
                 38,
                 MusicFontSymbol.NoteheadDiamondWhite,
                 MusicFontSymbol.NoteheadDiamondWhite,
                 MusicFontSymbol.NoteheadDiamondWhite
-            )
-        ],
-        [
-            42,
+            ),
             new InstrumentArticulation(
                 'hiHat',
                 -1,
                 42,
+                42,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack
-            )
-        ],
-        [
-            92,
+            ),
             new InstrumentArticulation(
                 'hiHat',
                 -1,
+                92,
                 46,
                 MusicFontSymbol.NoteheadCircleSlash,
                 MusicFontSymbol.NoteheadCircleSlash,
                 MusicFontSymbol.NoteheadCircleSlash
-            )
-        ],
-        [
-            46,
+            ),
             new InstrumentArticulation(
                 'hiHat',
                 -1,
                 46,
+                46,
                 MusicFontSymbol.NoteheadCircleX,
                 MusicFontSymbol.NoteheadCircleX,
                 MusicFontSymbol.NoteheadCircleX
-            )
-        ],
-        [
-            44,
+            ),
             new InstrumentArticulation(
                 'hiHat',
                 9,
                 44,
+                44,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack
-            )
-        ],
-        [
-            35,
+            ),
             new InstrumentArticulation(
                 'kickDrum',
                 8,
                 35,
+                35,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            36,
+            ),
             new InstrumentArticulation(
                 'kickDrum',
                 7,
                 36,
+                36,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            50,
+            ),
             new InstrumentArticulation(
                 'tom',
                 1,
                 50,
+                50,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            48,
+            ),
             new InstrumentArticulation(
                 'tom',
                 2,
                 48,
+                48,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            47,
+            ),
             new InstrumentArticulation(
                 'tom',
                 4,
                 47,
+                47,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            45,
+            ),
             new InstrumentArticulation(
                 'tom',
                 5,
                 45,
+                45,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            43,
+            ),
             new InstrumentArticulation(
                 'tom',
                 6,
                 43,
+                43,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            93,
+            ),
             new InstrumentArticulation(
                 'ride',
                 0,
+                93,
                 51,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.PictEdgeOfCymbal,
                 TechniqueSymbolPlacement.Below
-            )
-        ],
-        [
-            51,
+            ),
             new InstrumentArticulation(
                 'ride',
                 0,
                 51,
+                51,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack
-            )
-        ],
-        [
-            53,
+            ),
             new InstrumentArticulation(
                 'ride',
                 0,
                 53,
+                53,
                 MusicFontSymbol.NoteheadDiamondWhite,
                 MusicFontSymbol.NoteheadDiamondWhite,
                 MusicFontSymbol.NoteheadDiamondWhite
-            )
-        ],
-        [
-            94,
+            ),
             new InstrumentArticulation(
                 'ride',
                 0,
+                94,
                 51,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.ArticStaccatoAbove,
                 TechniqueSymbolPlacement.Above
-            )
-        ],
-        [
-            55,
+            ),
             new InstrumentArticulation(
                 'splash',
                 -2,
+                55,
                 55,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack
-            )
-        ],
-        [
-            95,
+            ),
             new InstrumentArticulation(
                 'splash',
                 -2,
+                95,
                 55,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.ArticStaccatoAbove,
                 TechniqueSymbolPlacement.Below
-            )
-        ],
-        [
-            52,
+            ),
             new InstrumentArticulation(
                 'china',
                 -3,
                 52,
-                MusicFontSymbol.NoteheadHeavyXHat,
-                MusicFontSymbol.NoteheadHeavyXHat,
-                MusicFontSymbol.NoteheadHeavyXHat
-            )
-        ],
-        [
-            96,
-            new InstrumentArticulation(
-                'china',
-                -3,
                 52,
                 MusicFontSymbol.NoteheadHeavyXHat,
                 MusicFontSymbol.NoteheadHeavyXHat,
                 MusicFontSymbol.NoteheadHeavyXHat
-            )
-        ],
-        [
-            49,
+            ),
+            new InstrumentArticulation(
+                'china',
+                -3,
+                96,
+                52,
+                MusicFontSymbol.NoteheadHeavyXHat,
+                MusicFontSymbol.NoteheadHeavyXHat,
+                MusicFontSymbol.NoteheadHeavyXHat
+            ),
             new InstrumentArticulation(
                 'crash',
                 -2,
                 49,
+                49,
                 MusicFontSymbol.NoteheadHeavyX,
                 MusicFontSymbol.NoteheadHeavyX,
                 MusicFontSymbol.NoteheadHeavyX
-            )
-        ],
-        [
-            97,
+            ),
             new InstrumentArticulation(
                 'crash',
                 -2,
+                97,
                 49,
                 MusicFontSymbol.NoteheadHeavyX,
                 MusicFontSymbol.NoteheadHeavyX,
                 MusicFontSymbol.NoteheadHeavyX,
                 MusicFontSymbol.ArticStaccatoAbove,
                 TechniqueSymbolPlacement.Below
-            )
-        ],
-        [
-            57,
+            ),
             new InstrumentArticulation(
                 'crash',
                 -1,
                 57,
+                57,
                 MusicFontSymbol.NoteheadHeavyX,
                 MusicFontSymbol.NoteheadHeavyX,
                 MusicFontSymbol.NoteheadHeavyX
-            )
-        ],
-        [
-            98,
+            ),
             new InstrumentArticulation(
                 'crash',
                 -1,
+                98,
                 57,
                 MusicFontSymbol.NoteheadHeavyX,
                 MusicFontSymbol.NoteheadHeavyX,
                 MusicFontSymbol.NoteheadHeavyX,
                 MusicFontSymbol.ArticStaccatoAbove,
                 TechniqueSymbolPlacement.Below
-            )
-        ],
-        [
-            99,
+            ),
             new InstrumentArticulation(
                 'cowbell',
                 1,
+                99,
                 56,
                 MusicFontSymbol.NoteheadTriangleUpBlack,
                 MusicFontSymbol.NoteheadTriangleUpHalf,
                 MusicFontSymbol.NoteheadTriangleUpWhole
-            )
-        ],
-        [
-            100,
+            ),
             new InstrumentArticulation(
                 'cowbell',
                 1,
+                 100,
                 56,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXHalf,
                 MusicFontSymbol.NoteheadXWhole
-            )
-        ],
-        [
-            56,
+            ),
             new InstrumentArticulation(
                 'cowbell',
                 0,
                 56,
+                56,
                 MusicFontSymbol.NoteheadTriangleUpBlack,
                 MusicFontSymbol.NoteheadTriangleUpHalf,
                 MusicFontSymbol.NoteheadTriangleUpWhole
-            )
-        ],
-        [
-            101,
+            ),
             new InstrumentArticulation(
                 'cowbell',
                 0,
+                 101,
                 56,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXHalf,
                 MusicFontSymbol.NoteheadXWhole
-            )
-        ],
-        [
-            102,
+            ),
             new InstrumentArticulation(
                 'cowbell',
                 -1,
+                 102,
                 56,
                 MusicFontSymbol.NoteheadTriangleUpBlack,
                 MusicFontSymbol.NoteheadTriangleUpHalf,
                 MusicFontSymbol.NoteheadTriangleUpWhole
-            )
-        ],
-        [
-            103,
+            ),
             new InstrumentArticulation(
                 'cowbell',
                 -1,
+                 103,
                 56,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXHalf,
                 MusicFontSymbol.NoteheadXWhole
-            )
-        ],
-        [
-            77,
+            ),
             new InstrumentArticulation(
                 'woodblock',
                 -9,
                 77,
+                77,
                 MusicFontSymbol.NoteheadTriangleUpBlack,
                 MusicFontSymbol.NoteheadTriangleUpBlack,
                 MusicFontSymbol.NoteheadTriangleUpBlack
-            )
-        ],
-        [
-            76,
+            ),
             new InstrumentArticulation(
                 'woodblock',
                 -10,
                 76,
+                76,
                 MusicFontSymbol.NoteheadTriangleUpBlack,
                 MusicFontSymbol.NoteheadTriangleUpBlack,
                 MusicFontSymbol.NoteheadTriangleUpBlack
-            )
-        ],
-        [
-            60,
+            ),
             new InstrumentArticulation(
                 'bongo',
                 -4,
                 60,
+                60,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            104,
+            ),
             new InstrumentArticulation(
                 'bongo',
                 -5,
+                 104,
                 60,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole,
                 MusicFontSymbol.NoteheadParenthesis,
                 TechniqueSymbolPlacement.Inside
-            )
-        ],
-        [
-            105,
+            ),
             new InstrumentArticulation(
                 'bongo',
                 -6,
+                 105,
                 60,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack
-            )
-        ],
-        [
-            61,
+            ),
             new InstrumentArticulation(
                 'bongo',
                 -7,
                 61,
+                61,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            106,
+            ),
             new InstrumentArticulation(
                 'bongo',
                 -8,
+                 106,
                 61,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole,
                 MusicFontSymbol.NoteheadParenthesis,
                 TechniqueSymbolPlacement.Inside
-            )
-        ],
-        [
-            107,
+            ),
             new InstrumentArticulation(
                 'bongo',
                 -16,
+                 107,
                 61,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack
-            )
-        ],
-        [
-            66,
+            ),
             new InstrumentArticulation(
                 'timbale',
                 10,
                 66,
+                66,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            65,
+            ),
             new InstrumentArticulation(
                 'timbale',
                 9,
                 65,
+                65,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            68,
+            ),
             new InstrumentArticulation(
                 'agogo',
                 12,
                 68,
+                68,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            67,
+            ),
             new InstrumentArticulation(
                 'agogo',
                 11,
                 67,
+                67,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            64,
+            ),
             new InstrumentArticulation(
                 'conga',
                 17,
                 64,
+                64,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            108,
+            ),
             new InstrumentArticulation(
                 'conga',
                 16,
+                 108,
                 64,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack
-            )
-        ],
-        [
-            109,
+            ),
             new InstrumentArticulation(
                 'conga',
                 15,
+                 109,
                 64,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole,
                 MusicFontSymbol.NoteheadParenthesis,
                 TechniqueSymbolPlacement.Inside
-            )
-        ],
-        [
-            63,
+            ),
             new InstrumentArticulation(
                 'conga',
                 14,
                 63,
+                63,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            110,
+            ),
             new InstrumentArticulation(
                 'conga',
                 13,
+                 110,
                 63,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack
-            )
-        ],
-        [
-            62,
+            ),
             new InstrumentArticulation(
                 'conga',
                 19,
+                62,
                 62,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole,
                 MusicFontSymbol.NoteheadParenthesis,
                 TechniqueSymbolPlacement.Inside
-            )
-        ],
-        [
-            72,
+            ),
             new InstrumentArticulation(
                 'whistle',
                 -11,
                 72,
+                72,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            71,
+            ),
             new InstrumentArticulation(
                 'whistle',
                 -17,
                 71,
+                71,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            73,
+            ),
             new InstrumentArticulation(
                 'guiro',
                 38,
                 73,
+                73,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            74,
+            ),
             new InstrumentArticulation(
                 'guiro',
                 37,
                 74,
+                74,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            86,
+            ),
             new InstrumentArticulation(
                 'surdo',
                 36,
                 86,
+                86,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            87,
+            ),
             new InstrumentArticulation(
                 'surdo',
                 35,
+                87,
                 87,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadParenthesis,
                 TechniqueSymbolPlacement.Inside
-            )
-        ],
-        [
-            54,
+            ),
             new InstrumentArticulation(
                 'tambourine',
                 3,
                 54,
+                54,
                 MusicFontSymbol.NoteheadTriangleUpBlack,
                 MusicFontSymbol.NoteheadTriangleUpBlack,
                 MusicFontSymbol.NoteheadTriangleUpBlack
-            )
-        ],
-        [
-            111,
+            ),
             new InstrumentArticulation(
                 'tambourine',
                 2,
+                 111,
                 54,
                 MusicFontSymbol.NoteheadTriangleUpBlack,
                 MusicFontSymbol.NoteheadTriangleUpBlack,
                 MusicFontSymbol.NoteheadTriangleUpBlack,
                 MusicFontSymbol.StringsUpBow,
                 TechniqueSymbolPlacement.Below
-            )
-        ],
-        [
-            112,
+            ),
             new InstrumentArticulation(
                 'tambourine',
                 1,
+                 112,
                 54,
                 MusicFontSymbol.NoteheadTriangleUpBlack,
                 MusicFontSymbol.NoteheadTriangleUpBlack,
                 MusicFontSymbol.NoteheadTriangleUpBlack,
                 MusicFontSymbol.StringsDownBow,
                 TechniqueSymbolPlacement.Below
-            )
-        ],
-        [
-            113,
+            ),
             new InstrumentArticulation(
                 'tambourine',
                 -7,
+                 113,
                 54,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack
-            )
-        ],
-        [
-            79,
+            ),
             new InstrumentArticulation(
                 'cuica',
                 30,
                 79,
+                79,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            78,
+            ),
             new InstrumentArticulation(
                 'cuica',
                 29,
                 78,
+                78,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack
-            )
-        ],
-        [
-            58,
+            ),
             new InstrumentArticulation(
                 'vibraslap',
                 28,
                 58,
+                58,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            81,
+            ),
             new InstrumentArticulation(
                 'triangle',
                 27,
                 81,
+                81,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            80,
+            ),
             new InstrumentArticulation(
                 'triangle',
                 26,
+                80,
                 80,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadParenthesis,
                 TechniqueSymbolPlacement.Inside
-            )
-        ],
-        [
-            114,
+            ),
             new InstrumentArticulation(
                 'grancassa',
                 25,
+                 114,
                 43,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            115,
+            ),
             new InstrumentArticulation(
                 'piatti',
                 18,
+                 115,
                 49,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            116,
+            ),
             new InstrumentArticulation(
                 'piatti',
                 24,
+                 116,
                 49,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack
-            )
-        ],
-        [
-            69,
+            ),
             new InstrumentArticulation(
                 'cabasa',
                 23,
                 69,
+                69,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            117,
+            ),
             new InstrumentArticulation(
                 'cabasa',
                 22,
+                 117,
                 69,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole,
                 MusicFontSymbol.StringsUpBow,
                 TechniqueSymbolPlacement.Below
-            )
-        ],
-        [
-            85,
+            ),
             new InstrumentArticulation(
                 'castanets',
                 21,
                 85,
+                85,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            75,
+            ),
             new InstrumentArticulation(
                 'claves',
                 20,
                 75,
+                75,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            70,
+            ),
             new InstrumentArticulation(
                 'maraca',
                 -12,
                 70,
+                70,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            118,
+            ),
             new InstrumentArticulation(
                 'maraca',
                 -13,
+                 118,
                 70,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole,
                 MusicFontSymbol.StringsUpBow,
                 TechniqueSymbolPlacement.Below
-            )
-        ],
-        [
-            119,
+            ),
             new InstrumentArticulation(
                 'maraca',
                 -14,
+                 119,
                 70,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            120,
+            ),
             new InstrumentArticulation(
                 'maraca',
                 -15,
+                 120,
                 70,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole,
                 MusicFontSymbol.StringsUpBow,
                 TechniqueSymbolPlacement.Below
-            )
-        ],
-        [
-            82,
+            ),
             new InstrumentArticulation(
                 'shaker',
                 -23,
+                82,
                 54,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            122,
+            ),
             new InstrumentArticulation(
                 'shaker',
                 -24,
+                 122,
                 54,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole,
                 MusicFontSymbol.StringsUpBow,
                 TechniqueSymbolPlacement.Below
-            )
-        ],
-        [
-            84,
+            ),
             new InstrumentArticulation(
                 'bellTree',
                 -18,
+                84,
                 53,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            123,
+            ),
             new InstrumentArticulation(
                 'bellTree',
                 -19,
+                 123,
                 53,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole,
                 MusicFontSymbol.StringsUpBow,
                 TechniqueSymbolPlacement.Below
-            )
-        ],
-        [
-            83,
+            ),
             new InstrumentArticulation(
                 'jingleBell',
                 -20,
+                83,
                 53,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            124,
+            ),
             new InstrumentArticulation(
                 'unpitched',
                 -21,
+                 124,
                 62,
                 MusicFontSymbol.NoteheadNull,
                 MusicFontSymbol.NoteheadNull,
                 MusicFontSymbol.NoteheadNull,
                 MusicFontSymbol.GuitarGolpe,
                 TechniqueSymbolPlacement.Above
-            )
-        ],
-        [
-            125,
+            ),
             new InstrumentArticulation(
                 'unpitched',
                 -22,
+                 125,
                 62,
                 MusicFontSymbol.NoteheadNull,
                 MusicFontSymbol.NoteheadNull,
                 MusicFontSymbol.NoteheadNull,
                 MusicFontSymbol.GuitarGolpe,
                 TechniqueSymbolPlacement.Below
-            )
-        ],
-        [
-            39,
+            ),
             new InstrumentArticulation(
                 'handClap',
                 3,
                 39,
+                39,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            40,
+            ),
             new InstrumentArticulation(
                 'snare',
                 3,
                 40,
+                40,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            31,
+            ),
             new InstrumentArticulation(
                 'snare',
                 3,
+                31,
                 40,
                 MusicFontSymbol.NoteheadSlashedBlack2,
                 MusicFontSymbol.NoteheadSlashedBlack2,
                 MusicFontSymbol.NoteheadSlashedBlack2
-            )
-        ],
-        [
-            41,
+            ),
             new InstrumentArticulation(
                 'tom',
                 5,
                 41,
+                41,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadHalf,
                 MusicFontSymbol.NoteheadWhole
-            )
-        ],
-        [
-            59,
+            ),
             new InstrumentArticulation(
                 'ride',
                 2,
+                59,
                 59,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.PictEdgeOfCymbal,
                 TechniqueSymbolPlacement.Below
-            )
-        ],
-        [
-            126,
+            ),
             new InstrumentArticulation(
                 'ride',
                 2,
+                 126,
                 59,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack
-            )
-        ],
-        [
-            127,
+            ),
             new InstrumentArticulation(
                 'ride',
                 2,
+                 127,
                 59,
                 MusicFontSymbol.NoteheadDiamondWhite,
                 MusicFontSymbol.NoteheadDiamondWhite,
                 MusicFontSymbol.NoteheadDiamondWhite
-            )
-        ],
-        [
-            29,
+            ),
             new InstrumentArticulation(
                 'ride',
                 2,
+                29,
                 59,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.ArticStaccatoAbove,
                 TechniqueSymbolPlacement.Above
-            )
-        ],
-        [
-            30,
+            ),
             new InstrumentArticulation(
                 'crash',
                 -3,
+                30,
                 49,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack
-            )
-        ],
-        [
-            33,
+            ),
             new InstrumentArticulation(
                 'snare',
                 3,
+                33,
                 37,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack,
                 MusicFontSymbol.NoteheadXBlack
-            )
-        ],
-        [
-            34,
+            ),
             new InstrumentArticulation(
                 'snare',
                 3,
+                34,
                 38,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadBlack,
                 MusicFontSymbol.NoteheadBlack
             )
-        ]
-    ]);
+    ].map(articulation => [articulation.inputMidiNumber, articulation]));
 
     // these are manually defined names/identifiers for the articulation list above.
     // they are currently only used in the AlphaTex importer when using default articulations


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Fixes #2467

### Proposed changes
This PR fixes missing percussion articulation data in the GP exporter that prevented RSE (Realistic Sound Engine) from working properly in Guitar Pro 8 for exported drum tracks.

**Changes made:**
- Added missing `OutputRSESound` tag to percussion articulations, which is essential for RSE sound mapping in Guitar Pro
- Added `InputMidiNumbers` tag with proper values (was previously empty)
- Added `SoundbankName` tag to percussion elements
- Improved percussion element grouping logic to use `elementName` (falling back to `elementType` when not available)
- Used `articulationName` when available instead of generating generic names
- Refactored `PercussionMapper` to include the new articulation properties needed for proper GP export
- Added serialization support for the new `InstrumentArticulation` fields

These changes ensure that exported GP files contain all the necessary metadata for Guitar Pro 8's RSE to properly map and play drum sounds.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website