### PR TITLE
fix: avoid placeholder reuse on content change

### DIFF
--- a/packages/alphatab/src/platform/javascript/AlphaTabWebWorker.ts
+++ b/packages/alphatab/src/platform/javascript/AlphaTabWebWorker.ts
@@ -1,12 +1,13 @@
+import { Environment } from '@coderline/alphatab/Environment';
+import { SettingsSerializer } from '@coderline/alphatab/generated/SettingsSerializer';
+import { Logger } from '@coderline/alphatab/Logger';
 import { JsonConverter } from '@coderline/alphatab/model/JsonConverter';
 import type { Score } from '@coderline/alphatab/model/Score';
 import type { IWorkerScope } from '@coderline/alphatab/platform/javascript/IWorkerScope';
 import { type FontSizeDefinition, FontSizes } from '@coderline/alphatab/platform/svg/FontSizes';
+import type { RenderHints } from '@coderline/alphatab/rendering/IScoreRenderer';
 import { ScoreRenderer } from '@coderline/alphatab/rendering/ScoreRenderer';
 import type { Settings } from '@coderline/alphatab/Settings';
-import { Logger } from '@coderline/alphatab/Logger';
-import { Environment } from '@coderline/alphatab/Environment';
-import { SettingsSerializer } from '@coderline/alphatab/generated/SettingsSerializer';
 
 /**
  * @target web
@@ -67,8 +68,8 @@ export class AlphaTabWebWorker {
                 });
                 this._renderer.error.on(this._error.bind(this));
                 break;
-            case 'alphaTab.invalidate':
-                this._renderer.render();
+            case 'alphaTab.render':
+                this._renderer.render(data.renderHints);
                 break;
             case 'alphaTab.resizeRender':
                 this._renderer.resizeRender();
@@ -111,9 +112,9 @@ export class AlphaTabWebWorker {
         SettingsSerializer.fromJson(this._renderer.settings, json);
     }
 
-    private _renderMultiple(score: Score | null, trackIndexes: number[] | null): void {
+    private _renderMultiple(score: Score | null, trackIndexes: number[] | null, renderHints?: RenderHints): void {
         try {
-            this._renderer.renderScore(score, trackIndexes);
+            this._renderer.renderScore(score, trackIndexes, renderHints);
         } catch (e) {
             this._error(e as Error);
         }

--- a/packages/alphatab/src/platform/javascript/AlphaTabWorkerScoreRenderer.ts
+++ b/packages/alphatab/src/platform/javascript/AlphaTabWorkerScoreRenderer.ts
@@ -1,9 +1,14 @@
 import type { AlphaTabApiBase } from '@coderline/alphatab/AlphaTabApiBase';
-import { EventEmitter, type IEventEmitterOfT, type IEventEmitter, EventEmitterOfT } from '@coderline/alphatab/EventEmitter';
+import {
+    EventEmitter,
+    type IEventEmitterOfT,
+    type IEventEmitter,
+    EventEmitterOfT
+} from '@coderline/alphatab/EventEmitter';
 import { JsonConverter } from '@coderline/alphatab/model/JsonConverter';
 import type { Score } from '@coderline/alphatab/model/Score';
 import { FontSizes } from '@coderline/alphatab/platform/svg/FontSizes';
-import type { IScoreRenderer } from '@coderline/alphatab/rendering/IScoreRenderer';
+import type { IScoreRenderer, RenderHints } from '@coderline/alphatab/rendering/IScoreRenderer';
 import type { RenderFinishedEventArgs } from '@coderline/alphatab/rendering/RenderFinishedEventArgs';
 import { BoundsLookup } from '@coderline/alphatab/rendering/utils/BoundsLookup';
 import type { Settings } from '@coderline/alphatab/Settings';
@@ -55,9 +60,10 @@ export class AlphaTabWorkerScoreRenderer<T> implements IScoreRenderer {
         return jsObject;
     }
 
-    public render(): void {
+    public render(renderHints?: RenderHints): void {
         this._worker.postMessage({
-            cmd: 'alphaTab.render'
+            cmd: 'alphaTab.render',
+            renderHints: renderHints
         });
     }
 
@@ -113,13 +119,15 @@ export class AlphaTabWorkerScoreRenderer<T> implements IScoreRenderer {
         }
     }
 
-    public renderScore(score: Score | null, trackIndexes: number[] | null): void {
-        const jsObject: unknown = score == null ? null : JsonConverter.scoreToJsObject(Environment.prepareForPostMessage(score));
+    public renderScore(score: Score | null, trackIndexes: number[] | null, renderHints?: RenderHints): void {
+        const jsObject: unknown =
+            score == null ? null : JsonConverter.scoreToJsObject(Environment.prepareForPostMessage(score));
         this._worker.postMessage({
             cmd: 'alphaTab.renderScore',
             score: jsObject,
             trackIndexes: Environment.prepareForPostMessage(trackIndexes),
-            fontSizes: FontSizes.fontSizeLookupTables
+            fontSizes: FontSizes.fontSizeLookupTables,
+            renderHints
         });
     }
 
@@ -128,7 +136,8 @@ export class AlphaTabWorkerScoreRenderer<T> implements IScoreRenderer {
         new EventEmitterOfT<RenderFinishedEventArgs>();
     public readonly partialLayoutFinished: IEventEmitterOfT<RenderFinishedEventArgs> =
         new EventEmitterOfT<RenderFinishedEventArgs>();
-    public readonly renderFinished: IEventEmitterOfT<RenderFinishedEventArgs> = new EventEmitterOfT<RenderFinishedEventArgs>();
+    public readonly renderFinished: IEventEmitterOfT<RenderFinishedEventArgs> =
+        new EventEmitterOfT<RenderFinishedEventArgs>();
     public readonly postRenderFinished: IEventEmitter = new EventEmitter();
     public readonly error: IEventEmitterOfT<Error> = new EventEmitterOfT<Error>();
 }

--- a/packages/alphatab/src/platform/javascript/BrowserUiFacade.ts
+++ b/packages/alphatab/src/platform/javascript/BrowserUiFacade.ts
@@ -678,6 +678,9 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
             placeholder.renderedResultId = undefined;
             placeholder.renderedResult = undefined;
 
+            if (!renderResult.reuseViewport) {
+                placeholder.textContent = '';
+            }
             this._resultIdToElementLookup.set(renderResult.id, placeholder);
 
             // remember which bar is contained in which node for faster lookup

--- a/packages/alphatab/src/rendering/IScoreRenderer.ts
+++ b/packages/alphatab/src/rendering/IScoreRenderer.ts
@@ -6,6 +6,22 @@ import type { BoundsLookup } from '@coderline/alphatab/rendering/utils/BoundsLoo
 import type { Settings } from '@coderline/alphatab/Settings';
 
 /**
+ * Additional hints which should be respected during layout and rendering of the score.
+ * @public
+ */
+export interface RenderHints {
+    /**
+     * A value indicating whether the currently rendered viewport can be reused when rendering the score.
+     * @remarks
+     * Set this property to true in cases of live-editing where the rendered score changes from an object perspective,
+     * but remains the similar from a content perspective. This way the visual update will appear more smooth than a full clearing.
+     *
+     * internally it might still be decided to clear the viewport.
+     */
+    reuseViewport?: boolean;
+}
+
+/**
  * Represents the public interface of the component that can render scores.
  * @public
  */
@@ -31,9 +47,10 @@ export interface IScoreRenderer {
 
     /**
      * Initiates a re-rendering of the current setup.
+     * @param renderHints Additional hints to respect during layouting and rendering.
      * @since 0.9.6
      */
-    render(): void;
+    render(renderHints?: RenderHints): void;
 
     /**
      * Initiates a resize-optimized re-rendering of the score using the current settings.
@@ -53,9 +70,10 @@ export interface IScoreRenderer {
      * Initiates the rendering of the specified tracks of the given score.
      * @param score The score defining the tracks.
      * @param trackIndexes The indexes of the tracks to draw.
+     * @param renderHints Additional hints to respect during layouting and rendering.
      * @since 0.9.6
      */
-    renderScore(score: Score | null, trackIndexes: number[] | null): void;
+    renderScore(score: Score | null, trackIndexes: number[] | null, renderHints?: RenderHints): void;
 
     /**
      * Requests the rendering of a chunk which was layed out before.

--- a/packages/alphatab/src/rendering/LineBarRenderer.ts
+++ b/packages/alphatab/src/rendering/LineBarRenderer.ts
@@ -714,11 +714,7 @@ export abstract class LineBarRenderer extends BarRendererBase {
                 stemY2 = y1;
             }
 
-            if (y1 < y2) {
-                this.paintBeamingStem(beat, cy + this.y, cx + this.x + stemX, stemY1, stemY2, canvas);
-            } else {
-                this.paintBeamingStem(beat, cy + this.y, cx + this.x + stemX, stemY2, stemY1, canvas);
-            }
+            this.paintBeamingStem(beat, cy + this.y, cx + this.x + stemX, stemY1, stemY2, canvas);
 
             using _ = ElementStyleHelper.beat(canvas, beamsElement, beat);
 

--- a/packages/alphatab/src/rendering/RenderFinishedEventArgs.ts
+++ b/packages/alphatab/src/rendering/RenderFinishedEventArgs.ts
@@ -10,6 +10,20 @@ export class RenderFinishedEventArgs {
      * Gets or sets the unique id of this event args.
      */
     public id: string = ModelUtils.newGuid();
+
+    /**
+     * A value indicating whether the currently rendered viewport can be reused.
+     * @remarks
+     * If set to true, the viewport does NOT need to be cleared as a similar
+     * content will be rendered.
+     * If set to false, the viewport and any visual partials should be cleared
+     * as it could lead to UI disturbances otherwise.
+     *
+     * The viewport can be typically used on resize renders or if the user supplied
+     * a rendering hint that the new score is "similar" to the old one (e.g. in case of live-editing).
+     */
+    public reuseViewport: boolean = true;
+
     /**
      * Gets or sets the x position of the current rendering result.
      */

--- a/packages/alphatab/src/rendering/ScoreRenderer.ts
+++ b/packages/alphatab/src/rendering/ScoreRenderer.ts
@@ -1,10 +1,15 @@
 import { LayoutMode } from '@coderline/alphatab/LayoutMode';
 import { Environment } from '@coderline/alphatab/Environment';
-import { EventEmitter, type IEventEmitter, type IEventEmitterOfT, EventEmitterOfT } from '@coderline/alphatab/EventEmitter';
+import {
+    EventEmitter,
+    type IEventEmitter,
+    type IEventEmitterOfT,
+    EventEmitterOfT
+} from '@coderline/alphatab/EventEmitter';
 import type { Score } from '@coderline/alphatab/model/Score';
 import type { Track } from '@coderline/alphatab/model/Track';
 import type { ICanvas } from '@coderline/alphatab/platform/ICanvas';
-import type { IScoreRenderer } from '@coderline/alphatab/rendering/IScoreRenderer';
+import type { IScoreRenderer, RenderHints } from '@coderline/alphatab/rendering/IScoreRenderer';
 import type { ScoreLayout } from '@coderline/alphatab/rendering/layout/ScoreLayout';
 import { RenderFinishedEventArgs } from '@coderline/alphatab/rendering/RenderFinishedEventArgs';
 import { BoundsLookup } from '@coderline/alphatab/rendering/utils/BoundsLookup';
@@ -70,7 +75,7 @@ export class ScoreRenderer implements IScoreRenderer {
         return false;
     }
 
-    public renderScore(score: Score | null, trackIndexes: number[] | null): void {
+    public renderScore(score: Score | null, trackIndexes: number[] | null, renderHints?: RenderHints): void {
         try {
             this.score = score;
             let tracks: Track[] | null = null;
@@ -92,7 +97,7 @@ export class ScoreRenderer implements IScoreRenderer {
             }
 
             this.tracks = tracks;
-            this.render();
+            this.render(renderHints);
         } catch (e) {
             (this.error as EventEmitterOfT<Error>).trigger(e as Error);
         }
@@ -130,7 +135,7 @@ export class ScoreRenderer implements IScoreRenderer {
         }
     }
 
-    public render(): void {
+    public render(renderHints?: RenderHints): void {
         if (this.width === 0) {
             Logger.warning('Rendering', 'AlphaTab skipped rendering because of width=0 (element invisible)', null);
             return;
@@ -155,7 +160,7 @@ export class ScoreRenderer implements IScoreRenderer {
             }
             (this.preRender as EventEmitterOfT<boolean>).trigger(false);
             this._recreateLayout();
-            this._layoutAndRender();
+            this._layoutAndRender(renderHints);
             Logger.debug('Rendering', 'Rendering finished');
         }
     }
@@ -178,13 +183,13 @@ export class ScoreRenderer implements IScoreRenderer {
         Logger.debug('Rendering', 'Resize finished');
     }
 
-    private _layoutAndRender(): void {
+    private _layoutAndRender(renderHints?: RenderHints): void {
         Logger.debug(
             'Rendering',
             `Rendering at scale ${this.settings.display.scale} with layout ${this.layout!.name}`,
             null
         );
-        this.layout!.layoutAndRender();
+        this.layout!.layoutAndRender(renderHints);
         this._renderedTracks = this.tracks;
         this._onRenderFinished();
         (this.postRenderFinished as EventEmitter).trigger();

--- a/packages/alphatab/src/rendering/ScoreRendererWrapper.ts
+++ b/packages/alphatab/src/rendering/ScoreRendererWrapper.ts
@@ -1,6 +1,11 @@
-import { EventEmitter, EventEmitterOfT, type IEventEmitter, type IEventEmitterOfT } from '@coderline/alphatab/EventEmitter';
+import {
+    EventEmitter,
+    EventEmitterOfT,
+    type IEventEmitter,
+    type IEventEmitterOfT
+} from '@coderline/alphatab/EventEmitter';
 import type { Score } from '@coderline/alphatab/model/Score';
-import type { IScoreRenderer } from '@coderline/alphatab/rendering/IScoreRenderer';
+import type { IScoreRenderer, RenderHints } from '@coderline/alphatab/rendering/IScoreRenderer';
 import type { RenderFinishedEventArgs } from '@coderline/alphatab/rendering/RenderFinishedEventArgs';
 import type { BoundsLookup } from '@coderline/alphatab/rendering/utils/BoundsLookup';
 import type { Settings } from '@coderline/alphatab/Settings';
@@ -85,18 +90,18 @@ export class ScoreRendererWrapper implements IScoreRenderer {
         }
     }
 
-    public render(): void {
-        this._instance?.render();
+    public render(renderHints?: RenderHints): void {
+        this._instance?.render(renderHints);
     }
 
     public resizeRender(): void {
         this._instance?.resizeRender();
     }
 
-    public renderScore(score: Score | null, trackIndexes: number[] | null): void {
+    public renderScore(score: Score | null, trackIndexes: number[] | null, renderHints?: RenderHints): void {
         this._score = score;
         this._trackIndexes = trackIndexes;
-        this._instance?.renderScore(score, trackIndexes);
+        this._instance?.renderScore(score, trackIndexes, renderHints);
     }
 
     public renderResult(resultId: string): void {

--- a/packages/alphatab/src/rendering/layout/HorizontalScreenLayout.ts
+++ b/packages/alphatab/src/rendering/layout/HorizontalScreenLayout.ts
@@ -2,6 +2,7 @@ import { Logger } from '@coderline/alphatab/Logger';
 import type { MasterBar } from '@coderline/alphatab/model/MasterBar';
 import type { Score } from '@coderline/alphatab/model/Score';
 import { TextAlign } from '@coderline/alphatab/platform/ICanvas';
+import type { RenderHints } from '@coderline/alphatab/rendering/IScoreRenderer';
 import { ScoreLayout } from '@coderline/alphatab/rendering/layout/ScoreLayout';
 import { RenderFinishedEventArgs } from '@coderline/alphatab/rendering/RenderFinishedEventArgs';
 import type { MasterBarsRenderers } from '@coderline/alphatab/rendering/staves/MasterBarsRenderers';
@@ -44,7 +45,7 @@ export class HorizontalScreenLayout extends ScoreLayout {
         // not supported
     }
 
-    protected doLayoutAndRender(): void {
+    protected doLayoutAndRender(renderHints: RenderHints | undefined): void {
         const score: Score = this.renderer.score!;
 
         let startIndex: number = this.renderer.settings.display.startBar;
@@ -107,6 +108,7 @@ export class HorizontalScreenLayout extends ScoreLayout {
             const partial: HorizontalScreenLayoutPartialInfo = partials[i];
 
             const e = new RenderFinishedEventArgs();
+            e.reuseViewport = renderHints?.reuseViewport ?? false;
             e.x = x;
             e.y = 0;
             e.totalWidth = this.width;

--- a/packages/alphatab/src/rendering/layout/ScoreLayout.ts
+++ b/packages/alphatab/src/rendering/layout/ScoreLayout.ts
@@ -9,12 +9,14 @@ import type { Staff } from '@coderline/alphatab/model/Staff';
 import { type Track, TrackSubElement } from '@coderline/alphatab/model/Track';
 import { NotationElement } from '@coderline/alphatab/NotationSettings';
 import { type ICanvas, TextAlign, TextBaseline } from '@coderline/alphatab/platform/ICanvas';
+import type { RenderingResources } from '@coderline/alphatab/RenderingResources';
 import { BarRendererBase } from '@coderline/alphatab/rendering/BarRendererBase';
 import { type EffectBandInfo, EffectBandMode } from '@coderline/alphatab/rendering/BarRendererFactory';
 import { ChordDiagramContainerGlyph } from '@coderline/alphatab/rendering/glyphs/ChordDiagramContainerGlyph';
 import { TextGlyph } from '@coderline/alphatab/rendering/glyphs/TextGlyph';
 import { TuningContainerGlyph } from '@coderline/alphatab/rendering/glyphs/TuningContainerGlyph';
 import { TuningGlyph } from '@coderline/alphatab/rendering/glyphs/TuningGlyph';
+import type { RenderHints } from '@coderline/alphatab/rendering/IScoreRenderer';
 import { SlurRegistry } from '@coderline/alphatab/rendering/layout/SlurRegistry';
 import { RenderFinishedEventArgs } from '@coderline/alphatab/rendering/RenderFinishedEventArgs';
 import type { ScoreRenderer } from '@coderline/alphatab/rendering/ScoreRenderer';
@@ -22,7 +24,6 @@ import { RenderStaff } from '@coderline/alphatab/rendering/staves/RenderStaff';
 import { StaffSystem } from '@coderline/alphatab/rendering/staves/StaffSystem';
 import type { BeamingRuleLookup } from '@coderline/alphatab/rendering/utils/BeamingRuleLookup';
 import { ElementStyleHelper } from '@coderline/alphatab/rendering/utils/ElementStyleHelper';
-import type { RenderingResources } from '@coderline/alphatab/RenderingResources';
 import type { Settings } from '@coderline/alphatab/Settings';
 import { Lazy } from '@coderline/alphatab/util/Lazy';
 
@@ -83,7 +84,7 @@ export abstract class ScoreLayout {
     }
     public abstract doResize(): void;
 
-    public layoutAndRender(): void {
+    public layoutAndRender(renderHints?: RenderHints): void {
         this._lazyPartials.clear();
         this.slurRegistry.clear();
         this.beamingRuleLookups.clear();
@@ -112,7 +113,7 @@ export abstract class ScoreLayout {
         }
 
         this._createScoreInfoGlyphs();
-        this.doLayoutAndRender();
+        this.doLayoutAndRender(renderHints);
     }
 
     private _lazyPartials: Map<string, LazyPartial> = new Map<string, LazyPartial>();
@@ -156,7 +157,7 @@ export abstract class ScoreLayout {
         }
     }
 
-    protected abstract doLayoutAndRender(): void;
+    protected abstract doLayoutAndRender(renderHints: RenderHints | undefined): void;
 
     protected static readonly headerElements: Lazy<Map<ScoreSubElement, NotationElement | undefined>> = new Lazy(
         () =>

--- a/packages/csharp/src/AlphaTab/Platform/CSharp/ManagedThreadScoreRenderer.cs
+++ b/packages/csharp/src/AlphaTab/Platform/CSharp/ManagedThreadScoreRenderer.cs
@@ -101,15 +101,15 @@ internal class ManagedThreadScoreRenderer : IScoreRenderer
         return Thread.CurrentThread == _workerThread;
     }
 
-    public void Render()
+    public void Render(RenderHints? renderHints = null)
     {
         if (CheckAccess())
         {
-            _renderer.Render();
+            _renderer.Render(renderHints);
         }
         else
         {
-            _workerQueue.Add(Render);
+            _workerQueue.Add(() => Render(renderHints));
         }
     }
 
@@ -154,17 +154,17 @@ internal class ManagedThreadScoreRenderer : IScoreRenderer
         }
     }
 
-    public void RenderScore(Score? score, IList<double>? trackIndexes)
+    public void RenderScore(Score? score, IList<double>? trackIndexes, RenderHints? renderHints = null)
     {
         if (CheckAccess())
         {
-            _renderer.RenderScore(score, trackIndexes);
+            _renderer.RenderScore(score, trackIndexes, renderHints);
         }
         else
         {
             _workerQueue.Add(() =>
                 RenderScore(score,
-                    trackIndexes));
+                    trackIndexes, renderHints));
         }
     }
 

--- a/packages/kotlin/src/android/src/main/java/alphaTab/platform/android/AndroidThreadScoreRenderer.kt
+++ b/packages/kotlin/src/android/src/main/java/alphaTab/platform/android/AndroidThreadScoreRenderer.kt
@@ -6,6 +6,7 @@ import alphaTab.core.ecmaScript.Error
 import alphaTab.model.Score
 import alphaTab.rendering.IScoreRenderer
 import alphaTab.rendering.RenderFinishedEventArgs
+import alphaTab.rendering.RenderHints
 import alphaTab.rendering.ScoreRenderer
 import alphaTab.rendering.utils.BoundsLookup
 import java.util.concurrent.BlockingQueue
@@ -95,11 +96,11 @@ internal class AndroidThreadScoreRenderer : IScoreRenderer, Runnable {
             }
         }
 
-    override fun render() {
+    override fun render(renderHints: RenderHints?) {
         if (checkAccess()) {
-            renderer.render()
+            renderer.render(renderHints)
         } else {
-            _workerQueue.add { render() }
+            _workerQueue.add { render(renderHints) }
         }
     }
 
@@ -119,14 +120,15 @@ internal class AndroidThreadScoreRenderer : IScoreRenderer, Runnable {
         }
     }
 
-    override fun renderScore(score: Score?, trackIndexes: DoubleList?) {
+    override fun renderScore(score: Score?, trackIndexes: DoubleList?, renderHints: RenderHints?) {
         if (checkAccess()) {
-            renderer.renderScore(score, trackIndexes)
+            renderer.renderScore(score, trackIndexes, renderHints)
         } else {
             _workerQueue.add {
                 renderScore(
                     score,
-                    trackIndexes
+                    trackIndexes,
+                    renderHints
                 )
             }
         }

--- a/packages/playground/alphatex-editor.ts
+++ b/packages/playground/alphatex-editor.ts
@@ -118,7 +118,9 @@ async function setupEditor(api: alphaTab.AlphaTabApi, element: HTMLElement) {
 
         sessionStorage.setItem('alphatex-editor.code', tex);
         fromTex = true;
-        api.renderTracks(score.tracks);
+        api.renderTracks(score.tracks, {
+            reuseViewport: true
+        });
         fromTex = false;
     }
 


### PR DESCRIPTION
### Issues
Fixes #2488

### Proposed changes
We now avoid reusing the viewport in cases where we detect that the content has changed significantly. This avoids partials keeping their content causing weird/wrong notation being shown when having a larger re-rendering. 

e.g. when switching between layouts the content of the partials has to be cleared. Same when the whole rendered score changes. 

In cases where the developer knows the score should be same/similar, a new `RenderingHints` object specifying that the viewport should be reused. This provides a better experience when doing live-editing.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
