### PR TITLE
fix: do not use relative time position for tick cursor

### DIFF
--- a/packages/alphatab/src/CursorHandler.ts
+++ b/packages/alphatab/src/CursorHandler.ts
@@ -118,11 +118,11 @@ export class NonAnimatingCursorHandler implements ICursorHandler {
         // nothing to do
     }
 
-    public placeBeatCursor(beatCursor: IContainer, beatBounds: BeatBounds, startBeatX: number): void {
+    public placeBeatCursor(beatCursor: IContainer, beatBounds: BeatBounds, _startBeatX: number): void {
         const barBoundings = beatBounds.barBounds.masterBarBounds;
         const barBounds = barBoundings.visualBounds;
-        beatCursor.transitionToX(0, startBeatX);
-        beatCursor.setBounds(startBeatX, barBounds.y, 1, barBounds.h);
+        beatCursor.transitionToX(0, beatBounds.onNotesX);
+        beatCursor.setBounds(beatBounds.onNotesX, barBounds.y, 1, barBounds.h);
     }
 
     public placeBarCursor(barCursor: IContainer, beatBounds: BeatBounds): void {


### PR DESCRIPTION
### Issues
Fixes #2546

### Proposed changes
Use the fixed position of the note and not the time-relative adjusted position for tick cursor.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
