### PR TITLE
fix: ensure smuflFontFamily is filled for multiple instances

### DIFF
--- a/packages/alphatab/src/platform/javascript/BrowserUiFacade.ts
+++ b/packages/alphatab/src/platform/javascript/BrowserUiFacade.ts
@@ -65,6 +65,7 @@ interface ResultPlaceholder extends HTMLElement {
  */
 interface RegisteredWebFont {
     hash: number;
+    familyName: string;
     cssSource: string;
     elements: Map<
         HTMLDocument,
@@ -213,6 +214,7 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
             element.element.innerText = '';
         }
         this._createStyleElements(settings);
+        settings.display.resources.smuflFontFamilyName = this._webFont.familyName;
         this._file = settings.core.file;
     }
 
@@ -444,10 +446,9 @@ export class BrowserUiFacade implements IUiFacade<unknown> {
         this._fontCheckers.set(familyName, checker);
         checker.checkForFontAvailability();
 
-        settings.display.resources.smuflFontFamilyName = familyName;
-
         const webFont: RegisteredWebFont = {
             hash,
+            familyName,
             elements: new Map(),
             fontSuffix,
             checker,


### PR DESCRIPTION
### Issues
Fixes #2551

### Proposed changes
The `smuflFontFamily` needs to be filled or it leads to runtime problems.  

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
