### PR TITLE
Fix null currentBeat crash in AlphaTabApiBase internalCursorUpdateBeat

### DIFF
--- a/packages/alphatab/src/AlphaTabApiBase.ts
+++ b/packages/alphatab/src/AlphaTabApiBase.ts
@@ -2416,11 +2416,12 @@ export class AlphaTabApiBase<TSettings> {
         }
 
         let startBeatX = beatBoundings.onNotesX;
-        if (beatCursor) {
+        const currentBeat = this._currentBeat;
+        if (beatCursor && currentBeat) {
             const animationWidth = nextBeatX - beatBoundings.onNotesX;
-            const relativePosition = this._previousTick - this._currentBeat!.start;
+            const relativePosition = this._previousTick - currentBeat.start;
             const ratioPosition =
-                this._currentBeat!.tickDuration > 0 ? relativePosition / this._currentBeat!.tickDuration : 0;
+                currentBeat.tickDuration > 0 ? relativePosition / currentBeat.tickDuration : 0;
             startBeatX = beatBoundings.onNotesX + animationWidth * ratioPosition;
             duration -= duration * ratioPosition;
 


### PR DESCRIPTION
### Issues

Fixes #2615 

### Proposed changes
Guard `_internalCursorUpdateBeat` when `_currentBeat` is `null` after the deferred `beginInvoke` callback runs (e.g. Android `Handler.post`), so tapping the score during playback no longer crashes with a null on `currentBeat.start`.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added

No new automated tests: reproducing the race requires Android UI/async scheduling. Verified manually with real devices.

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
