### PR TITLE
Clamp negative cursor animation duration in AndroidViewContainer

### DIFF
--- a/packages/kotlin/src/android/src/main/java/alphaTab/platform/android/AndroidViewContainer.kt
+++ b/packages/kotlin/src/android/src/main/java/alphaTab/platform/android/AndroidViewContainer.kt
@@ -179,7 +179,7 @@ internal class AndroidViewContainer : GestureDetector.SimpleOnGestureListener, I
                 }
             }
             a.interpolator = LinearInterpolator()
-            a.duration = duration.toLong()
+            a.duration = maxOf(0L, duration.toLong()) // prevent negative duration
             view.startAnimation(a)
         }
     }


### PR DESCRIPTION
### Issues

Fixes #2616

### Proposed changes
In `AndroidViewContainer.transitionToX`, clamp the animation duration with positive values before calling Animation.setDuration, so Android never throws `IllegalArgumentException: Animation duration cannot be negative` when playback, autoscroll, and user scrolling interact (e.g. off-screen).
This is a defensive platform fix.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added

No new automated tests: the failure depends on Android animation APIs and a manual playback and scroll scenario. Verified manually with real devices.

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
