### PR TITLE
Issue 2617

### DIFF
--- a/packages/kotlin/src/android/src/main/java/alphaTab/EnvironmentPartials.kt
+++ b/packages/kotlin/src/android/src/main/java/alphaTab/EnvironmentPartials.kt
@@ -39,7 +39,7 @@ internal class EnvironmentPartials {
             print("Screen Size: ${AndroidEnvironment.screenWidth}x${AndroidEnvironment.screenHeight}");
         }
 
-        private val throttleScope = CoroutineScope(Dispatchers.Default)
+        private val throttleScope = CoroutineScope(Dispatchers.Main)
         internal fun throttle(toThrottle: () -> Unit, delay: Double): () -> Unit {
             var job: Job? = null
             return {

--- a/packages/kotlin/src/android/src/main/java/alphaTab/platform/android/AlphaTabRenderSurface.kt
+++ b/packages/kotlin/src/android/src/main/java/alphaTab/platform/android/AlphaTabRenderSurface.kt
@@ -12,6 +12,7 @@ import android.widget.ScrollView
 import java.io.Closeable
 import java.lang.RuntimeException
 import kotlin.contracts.ExperimentalContracts
+import java.util.concurrent.CopyOnWriteArrayList
 
 @ExperimentalUnsignedTypes
 @ExperimentalContracts
@@ -44,7 +45,7 @@ internal class RenderPlaceholder(public var result: RenderFinishedEventArgs) : C
 @ExperimentalContracts
 internal class AlphaTabRenderSurface(context: Context, attributeSet: AttributeSet) :
     View(context, attributeSet), View.OnScrollChangeListener {
-    private val _placeholders: ArrayList<RenderPlaceholder> = arrayListOf()
+    private val _placeholders: CopyOnWriteArrayList<RenderPlaceholder> = CopyOnWriteArrayList()
     private val _resultIdToIndex: ObjectDoubleMap<String> = ObjectDoubleMap()
 
     private var _totalWidth: Int = 0
@@ -65,11 +66,10 @@ internal class AlphaTabRenderSurface(context: Context, attributeSet: AttributeSe
 
     public fun clearPlaceholders() {
         _resultIdToIndex.clear()
-        val placeholder = _placeholders
-        for (p in placeholder) {
+        for (p in _placeholders) {
             p.close();
         }
-        placeholder.clear()
+        _placeholders.clear()
     }
 
     override fun onAttachedToWindow() {


### PR DESCRIPTION
### Issues

Fixes #2617

### Proposed changes
* AlphaTabRenderSurface — store render placeholders in a CopyOnWriteArrayList instead of ArrayList, so iterating during onLayout / updates cannot throw ConcurrentModificationException when partials are added or cleared during layout (e.g. rotation, scroll, resize).
* EnvironmentPartials (Android) — run the coroutine scope used by throttle() on Dispatchers.Main instead of Dispatchers.Default, so throttled resize work runs on the UI thread and avoids concurrent use of layout/bounds data from a background dispatcher (related ConcurrentModificationException seen around BoundsLookup during resize).

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added

No new automated tests: failures depend on Android layout timing and real-device interactions (rotation, scrolling). Verified manually on real devices.

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
