### PR TITLE
fix(web): use Pointer Events API for touch support in HtmlElementContainer

### DIFF
--- a/packages/alphatab/src/platform/javascript/BrowserMouseEventArgs.ts
+++ b/packages/alphatab/src/platform/javascript/BrowserMouseEventArgs.ts
@@ -7,7 +7,7 @@ import type { HtmlElementContainer } from '@coderline/alphatab/platform/javascri
  * @internal
  */
 export class BrowserMouseEventArgs implements IMouseEventArgs {
-    public readonly mouseEvent: MouseEvent;
+    public readonly mouseEvent: PointerEvent;
 
     public get isLeftMouseButton(): boolean {
         return this.mouseEvent.button === 0;
@@ -31,7 +31,7 @@ export class BrowserMouseEventArgs implements IMouseEventArgs {
         this.mouseEvent.preventDefault();
     }
 
-    public constructor(e: MouseEvent) {
+    public constructor(e: PointerEvent) {
         this.mouseEvent = e;
     }
 }

--- a/packages/alphatab/src/platform/javascript/HtmlElementContainer.ts
+++ b/packages/alphatab/src/platform/javascript/HtmlElementContainer.ts
@@ -83,12 +83,12 @@ export class HtmlElementContainer implements IHtmlElementContainer {
 
         this.mouseDown = {
             on: (value: any) => {
-                const nativeListener: (e: MouseEvent) => void = e => {
+                const nativeListener: (e: PointerEvent) => void = e => {
                     value(new BrowserMouseEventArgs(e));
                 };
-                this.element.addEventListener('mousedown', nativeListener, true);
+                this.element.addEventListener('pointerdown', nativeListener, true);
                 return () => {
-                    this.element.removeEventListener('mousedown', nativeListener, true);
+                    this.element.removeEventListener('pointerdown', nativeListener, true);
                 };
             },
             off: (_value: any) => {
@@ -98,14 +98,14 @@ export class HtmlElementContainer implements IHtmlElementContainer {
 
         this.mouseUp = {
             on: (value: any) => {
-                const nativeListener: (e: MouseEvent) => void = e => {
+                const nativeListener: (e: PointerEvent) => void = e => {
                     value(new BrowserMouseEventArgs(e));
                 };
 
-                this.element.addEventListener('mouseup', nativeListener, true);
+                this.element.addEventListener('pointerup', nativeListener, true);
 
                 return () => {
-                    this.element.removeEventListener('mouseup', nativeListener, true);
+                    this.element.removeEventListener('pointerup', nativeListener, true);
                 };
             },
             off: (_value: any) => {
@@ -115,13 +115,13 @@ export class HtmlElementContainer implements IHtmlElementContainer {
 
         this.mouseMove = {
             on: (value: any) => {
-                const nativeListener: (e: MouseEvent) => void = e => {
+                const nativeListener: (e: PointerEvent) => void = e => {
                     value(new BrowserMouseEventArgs(e));
                 };
-                this.element.addEventListener('mousemove', nativeListener, true);
+                this.element.addEventListener('pointermove', nativeListener, true);
 
                 return () => {
-                    this.element.removeEventListener('mousemove', nativeListener, true);
+                    this.element.removeEventListener('pointermove', nativeListener, true);
                 };
             },
             off: (_: any) => {


### PR DESCRIPTION
### Issues
Fixes #2634

### Proposed changes

Replace `mousedown/mousemove/mouseup` DOM event listeners with the [Pointer Events API](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events) (`pointerdown/pointermove/pointerup`) in `HtmlElementContainer.ts`.

`PointerEvent` extends `MouseEvent`, so `BrowserMouseEventArgs` remains fully compatible — `pageX`, `pageY`, `button`, and `preventDefault()` all work identically. The change is backward compatible for existing mouse-based users.

**Files changed:**
- `packages/alphatab/src/platform/javascript/HtmlElementContainer.ts` — swap event names
- `packages/alphatab/src/platform/javascript/BrowserMouseEventArgs.ts` — update type annotation from `MouseEvent` → `PointerEvent`

**Tested on:**
- Desktop mouse (existing behavior unchanged)
- iPhone Safari — `beatMouseDown`, `beatMouseMove`, `beatMouseUp` all confirmed firing on touch
- Lenovo Android tablet, Firefox 149 — all three events confirmed firing on touch

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added — no browser event testing infrastructure exists in the current test suite; this is a DOM event wiring change that requires a real browser environment to test. All 1448 existing tests pass.

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website