### PR TITLE
fix(synth): buffer pending worklet messages

### DIFF
--- a/packages/alphatab/src/platform/javascript/AlphaSynthAudioWorkletOutput.ts
+++ b/packages/alphatab/src/platform/javascript/AlphaSynthAudioWorkletOutput.ts
@@ -203,6 +203,8 @@ export class AlphaSynthAudioWorkletOutput extends AlphaSynthWebAudioOutputBase {
     private readonly _settings: Settings;
     private _boundHandleMessage: (e: MessageEvent<IAlphaSynthWorkerMessage>) => void;
 
+    private _pendingEvents?: IAlphaSynthWorkerMessage[];
+
     public constructor(settings: Settings) {
         super();
         this._settings = settings;
@@ -234,6 +236,14 @@ export class AlphaSynthAudioWorkletOutput extends AlphaSynthWebAudioOutputBase {
                 this.source!.connect(this._worklet);
                 this.source!.start(0);
                 this._worklet.connect(ctx!.destination);
+
+                const pending = this._pendingEvents;
+                if (pending) {
+                    for (const e of pending) {
+                        this._worklet.port.postMessage(e);
+                    }
+                    this._pendingEvents = undefined;
+                }
             },
             (reason: any) => {
                 Logger.error('WebAudio', `Audio Worklet creation failed: reason=${reason}`);
@@ -264,17 +274,28 @@ export class AlphaSynthAudioWorkletOutput extends AlphaSynthWebAudioOutputBase {
             this._worklet.disconnect();
         }
         this._worklet = null;
+        this._pendingEvents = undefined;
+    }
+
+    private _postWorkerMessage(message: IAlphaSynthWorkerMessage) {
+        const worklet = this._worklet;
+        if (worklet) {
+            worklet.port.postMessage(message);
+        } else {
+            this._pendingEvents ??= [];
+            this._pendingEvents.push(message);
+        }
     }
 
     public addSamples(f: Float32Array): void {
-        this._worklet?.port.postMessage({
+        this._postWorkerMessage({
             cmd: 'alphaSynth.output.addSamples',
             samples: Environment.prepareForPostMessage(f)
         });
     }
 
     public resetSamples(): void {
-        this._worklet?.port.postMessage({
+        this._postWorkerMessage({
             cmd: 'alphaSynth.output.resetSamples'
         });
     }


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Fixes #2561

### Proposed changes
Buffer pending messages in the worklet output and send them when worklet is constructed and ready. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
