### PR TITLE
fix: update selection highlight on re-render

### DIFF
--- a/packages/alphatab/src/AlphaTabApiBase.ts
+++ b/packages/alphatab/src/AlphaTabApiBase.ts
@@ -3621,6 +3621,9 @@ export class AlphaTabApiBase<TSettings> {
 
         this._currentBeat = null;
         this._cursorUpdateTick(this._previousTick, false, 1, true, true);
+        if(this._selectionStart) {
+            this.highlightPlaybackRange(this._selectionStart.beat, this._selectionEnd!.beat);
+        }
 
         (this.postRenderFinished as EventEmitter).trigger();
         this.uiFacade.triggerEvent(this.container, 'postRenderFinished', null);


### PR DESCRIPTION
### Issues
Fixes #2567

### Proposed changes
Ensures that the selection highlights are recreated when we re-render (e.g. on resize).

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
