### PR TITLE
fix(android): interrupt handling and main looper usage

### DIFF
--- a/packages/kotlin/src/android/src/main/java/alphaTab/AlphaTabView.kt
+++ b/packages/kotlin/src/android/src/main/java/alphaTab/AlphaTabView.kt
@@ -78,8 +78,8 @@ class AlphaTabView : RelativeLayout {
     }
 
     override fun onDetachedFromWindow() {
-        super.onDetachedFromWindow()
         _api.destroy()
+        super.onDetachedFromWindow()
     }
 
     private fun init(context: Context) {

--- a/packages/kotlin/src/android/src/main/java/alphaTab/platform/android/AndroidAudioWorker.kt
+++ b/packages/kotlin/src/android/src/main/java/alphaTab/platform/android/AndroidAudioWorker.kt
@@ -56,23 +56,28 @@ internal class AndroidAudioWorker(
 
     private fun writeSamples() {
         while (!_stopped) {
-            if (_track.playState == AudioTrack.PLAYSTATE_PLAYING) {
-                val samplesFromBuffer = _output.read(_buffer, 0, _buffer.size)
-                if (_previousPosition == -1) {
-                    _previousPosition = _track.playbackHeadPosition
-                    _track.getTimestamp(_timestamp)
+            try {
+                if (_track.playState == AudioTrack.PLAYSTATE_PLAYING) {
+                    val samplesFromBuffer = _output.read(_buffer, 0, _buffer.size)
+                    if (_previousPosition == -1) {
+                        _previousPosition = _track.playbackHeadPosition
+                        _track.getTimestamp(_timestamp)
+                    }
+                    _track.write(_buffer, 0, samplesFromBuffer, AudioTrack.WRITE_BLOCKING)
+                } else {
+                    _playingSemaphore.acquire() // wait for playing to start
+                    _playingSemaphore.release() // release semaphore for others
                 }
-                _track.write(_buffer, 0, samplesFromBuffer, AudioTrack.WRITE_BLOCKING)
-            } else {
-                _playingSemaphore.acquire() // wait for playing to start
-                _playingSemaphore.release() // release semaphore for others
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+                break;
             }
         }
     }
 
     fun close() {
-        _playingSemaphore.release() // proceed thread
         _stopped = true
+        _playingSemaphore.release() // proceed thread
         _track.stop()
         _writeThread!!.interrupt()
         _writeThread!!.join()

--- a/packages/kotlin/src/android/src/main/java/alphaTab/platform/android/AndroidUiFacade.kt
+++ b/packages/kotlin/src/android/src/main/java/alphaTab/platform/android/AndroidUiFacade.kt
@@ -26,6 +26,7 @@ import alphaTab.synth.IAudioExporterWorker
 import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.os.Handler
+import android.os.Looper
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -54,6 +55,8 @@ internal class AndroidUiFacade : IUiFacade<AlphaTabView> {
     private val _renderSurface: AlphaTabRenderSurface
     private val _renderWrapper: RelativeLayout
 
+    private val _uiLooper:Handler;
+
     public constructor(
         outerScroll: SuspendableHorizontalScrollView,
         innerScroll: SuspendableScrollView,
@@ -64,6 +67,7 @@ internal class AndroidUiFacade : IUiFacade<AlphaTabView> {
         _innerScroll = innerScroll
         _renderSurface = renderSurface
         _renderWrapper = renderWrapper
+        _uiLooper = Handler(Looper.getMainLooper())
 
         rootContainer =
             AndroidRootViewContainer(outerScroll, innerScroll, renderSurface, this::beginInvoke)
@@ -163,7 +167,7 @@ internal class AndroidUiFacade : IUiFacade<AlphaTabView> {
     }
 
     private fun postToUIThread(action: () -> Unit) {
-        this._renderSurface.post(action)
+        _uiLooper.post(action)
     }
 
     private fun openDefaultSoundFont(): InputStream {


### PR DESCRIPTION
### Issues
Fixes #2629

### Proposed changes
* Handle interrupts in Android Audio Worker
* Use Looper to decouple UI thread (avoids races on destroys of controls)

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
