### PR TITLE
fix: ensure cleanup of workers on termination

### DIFF
--- a/packages/csharp/src/AlphaTab/Platform/CSharp/ManagedThreadAlphaSynthWorker.cs
+++ b/packages/csharp/src/AlphaTab/Platform/CSharp/ManagedThreadAlphaSynthWorker.cs
@@ -8,12 +8,13 @@ namespace AlphaTab.Platform.CSharp;
 internal abstract class ManagedThreadWorkerBase<T> : IAlphaTabWorker<T>
 {
     private readonly Action<Action> _postToMain;
-    private readonly Thread _workerThread;
     private readonly BlockingCollection<Action> _workerQueue;
     private readonly CancellationTokenSource _workerCancellationToken;
     private readonly ManualResetEventSlim? _threadStartedEvent;
     private readonly ConcurrentDictionary<Action<MessageEvent<T>>,Action<MessageEvent<T>>> _listenerInsideWorker = new();
     private readonly ConcurrentDictionary<Action<MessageEvent<T>>,Action<MessageEvent<T>>> _listenerOutsideWorker = new();
+
+    protected Thread WorkerThread { get; }
 
     protected ManagedThreadWorkerBase(Action<Action> postToMain)
     {
@@ -22,11 +23,11 @@ internal abstract class ManagedThreadWorkerBase<T> : IAlphaTabWorker<T>
         _workerQueue = new BlockingCollection<Action>();
         _workerCancellationToken = new CancellationTokenSource();
 
-        _workerThread = new Thread(DoWork)
+        WorkerThread = new Thread(DoWork)
         {
             IsBackground = true
         };
-        _workerThread.Start();
+        WorkerThread.Start();
 
         _threadStartedEvent.Wait();
         _threadStartedEvent.Dispose();
@@ -55,7 +56,7 @@ internal abstract class ManagedThreadWorkerBase<T> : IAlphaTabWorker<T>
     public void PostMessage(T message)
     {
         var ev = new MessageEvent<T>(message);
-        if (Thread.CurrentThread.ManagedThreadId == _workerThread.ManagedThreadId)
+        if (Thread.CurrentThread.ManagedThreadId == WorkerThread.ManagedThreadId)
         {
             // Inside Worker -> Post to main
             _postToMain(() =>
@@ -87,7 +88,7 @@ internal abstract class ManagedThreadWorkerBase<T> : IAlphaTabWorker<T>
     public void AddEventListener(string @event, Action<MessageEvent<T>> handler)
     {
         if (@event != "message") return;
-        var listeners = Thread.CurrentThread.ManagedThreadId == _workerThread.ManagedThreadId
+        var listeners = Thread.CurrentThread.ManagedThreadId == WorkerThread.ManagedThreadId
             ? _listenerInsideWorker
             : _listenerOutsideWorker;
         listeners[handler] = handler;
@@ -96,7 +97,7 @@ internal abstract class ManagedThreadWorkerBase<T> : IAlphaTabWorker<T>
     public void RemoveEventListener(string @event, Action<MessageEvent<T>> handler)
     {
         if (@event != "message") return;
-        var listeners = Thread.CurrentThread.ManagedThreadId == _workerThread.ManagedThreadId
+        var listeners = Thread.CurrentThread.ManagedThreadId == WorkerThread.ManagedThreadId
             ? _listenerInsideWorker
             : _listenerOutsideWorker;
         listeners.TryRemove(handler, out _);
@@ -105,7 +106,7 @@ internal abstract class ManagedThreadWorkerBase<T> : IAlphaTabWorker<T>
     public virtual void Terminate()
     {
         _workerCancellationToken.Cancel();
-        _workerThread.Join();
+        WorkerThread.Join();
         while (_workerQueue.Count > 0)
         {
             _workerQueue.Take();
@@ -133,6 +134,12 @@ internal class ManagedThreadAlphaTabRendererWorker :
         WorkerLookup[Thread.CurrentThread.ManagedThreadId] = this;
         AlphaTabWebWorker.Init();
     }
+
+    public override void Terminate()
+    {
+        base.Terminate();
+        WorkerLookup.TryRemove(WorkerThread.ManagedThreadId, out _);
+    }
 }
 
 internal class ManagedThreadAlphaSynthWorker :
@@ -154,5 +161,11 @@ internal class ManagedThreadAlphaSynthWorker :
     {
         WorkerLookup[Thread.CurrentThread.ManagedThreadId] = this;
         AlphaSynthWebWorker.Init();
+    }
+
+    public override void Terminate()
+    {
+        base.Terminate();
+        WorkerLookup.TryRemove(WorkerThread.ManagedThreadId, out _);
     }
 }

--- a/packages/kotlin/src/android/src/main/java/alphaTab/platform/android/JavaThreadWorkers.kt
+++ b/packages/kotlin/src/android/src/main/java/alphaTab/platform/android/JavaThreadWorkers.kt
@@ -17,7 +17,7 @@ import kotlin.contracts.ExperimentalContracts
 @OptIn(ExperimentalContracts::class, ExperimentalUnsignedTypes::class)
 internal abstract class JavaThreadWorkerBase<T> : IAlphaTabWorker<T>, Runnable {
     private val _postToMain: (action: () -> Unit) -> Unit
-    private val _workerThread: Thread
+    protected val workerThread: Thread
     private val _workerQueue = LinkedBlockingQueue<() -> Unit>()
     private var _isCancelled = false
     private val _threadStartedEvent = Semaphore(1)
@@ -29,9 +29,9 @@ internal abstract class JavaThreadWorkerBase<T> : IAlphaTabWorker<T>, Runnable {
     protected constructor(postToMain: (action: () -> Unit) -> Unit) {
         _postToMain = postToMain;
 
-        _workerThread = Thread(this)
-        _workerThread.isDaemon = true
-        _workerThread.start()
+        workerThread = Thread(this)
+        workerThread.isDaemon = true
+        workerThread.start()
 
         _threadStartedEvent.acquire()
     }
@@ -56,7 +56,7 @@ internal abstract class JavaThreadWorkerBase<T> : IAlphaTabWorker<T>, Runnable {
 
     override fun postMessage(message: T) {
         val ev = MessageEvent(message);
-        if (Thread.currentThread().id == _workerThread.id) {
+        if (Thread.currentThread().id == workerThread.id) {
             // Inside Worker -> Post to main
             _postToMain(
                 {
@@ -83,7 +83,7 @@ internal abstract class JavaThreadWorkerBase<T> : IAlphaTabWorker<T>, Runnable {
         if (event != "message") {
             return;
         }
-        val listeners = if (Thread.currentThread().id == _workerThread.id) {
+        val listeners = if (Thread.currentThread().id == workerThread.id) {
             _listenerInsideWorker
         } else {
             _listenerOutsideWorker
@@ -95,7 +95,7 @@ internal abstract class JavaThreadWorkerBase<T> : IAlphaTabWorker<T>, Runnable {
         if (event != "message") {
             return;
         }
-        val listeners = if (Thread.currentThread().id == _workerThread.id) {
+        val listeners = if (Thread.currentThread().id == workerThread.id) {
             _listenerInsideWorker
         } else {
             _listenerOutsideWorker
@@ -105,8 +105,8 @@ internal abstract class JavaThreadWorkerBase<T> : IAlphaTabWorker<T>, Runnable {
 
     override fun terminate() {
         _isCancelled = true
-        _workerThread.interrupt()
-        _workerThread.join()
+        workerThread.interrupt()
+        workerThread.join()
         _workerQueue.clear()
     }
 }
@@ -130,6 +130,11 @@ internal class JavaThreadAlphaTabRendererWorker(postToMain: (action: () -> Unit)
         workerLookup[Thread.currentThread().id] = this;
         AlphaTabWebWorker.init();
     }
+
+    override fun terminate() {
+        super.terminate()
+        workerLookup.remove(workerThread.id)
+    }
 }
 
 @OptIn(ExperimentalContracts::class, ExperimentalUnsignedTypes::class)
@@ -150,5 +155,10 @@ internal class JavaThreadAlphaSynthWorker(postToMain: (action: () -> Unit) -> Un
     override fun onStartInsideWorker() {
         workerLookup[Thread.currentThread().id] = this;
         AlphaSynthWebWorker.init();
+    }
+
+    override fun terminate() {
+        super.terminate()
+        workerLookup.remove(workerThread.id)
     }
 }


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Fixes #2621

### Proposed changes
Some new findings on leaking objects. After this change the profiler did not show any remaining objects on activity changes. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
