### PR TITLE
fix: skip piano notes on the tab staff

### DIFF
--- a/packages/alphatab/src/rendering/glyphs/TabBeatGlyph.ts
+++ b/packages/alphatab/src/rendering/glyphs/TabBeatGlyph.ts
@@ -88,7 +88,15 @@ export class TabBeatGlyph extends BeatOnNoteGlyphBase {
         const tabRenderer: TabBarRenderer = this.renderer as TabBarRenderer;
 
         const centeredEffectGlyphs: Glyph[] = [];
-        if (!this.container.beat.isRest) {
+        // A beat on a stringed staff that contains ONLY piano notes has
+        // nothing to draw in tab form. Drop through to the rest path so
+        // TabNoteChordGlyph.doLayout doesn't call getNoteY(null) via
+        // minStringNote — it stays null because every loop below would
+        // skip the piano notes.
+        const hasStringedNoteForTab = this.container.beat.notes.some(
+            n => n.isVisible && !n.isPiano
+        );
+        if (!this.container.beat.isRest && hasStringedNoteForTab) {
             //
             // Note numbers
             const isGrace: boolean =
@@ -111,7 +119,15 @@ export class TabBeatGlyph extends BeatOnNoteGlyphBase {
                 this.noteNumbers = tabNoteNumbers;
                 tabNoteNumbers.beat = this.container.beat;
                 for (const note of this.container.beat.notes) {
-                    if (note.isVisible) {
+                    // Piano notes (string = -1) have no fret/string to place
+                    // on the tab staff. `getNoteLine(note)` returns
+                    // `tuning.length - note.string` = `tuning.length + 1`,
+                    // and `collectSpaces` then indexes past the end of the
+                    // `spaces` array and crashes when painting staff lines.
+                    // Piano notes render fine via `ScoreBeatGlyph` on the
+                    // standard-notation staff; skip them here so stringed
+                    // and piano notes can coexist in a single beat.
+                    if (note.isVisible && !note.isPiano) {
                         this._createNoteGlyph(note);
                     }
                 }

--- a/packages/alphatab/test/visualTests/issues/BrokenRenders.test.ts
+++ b/packages/alphatab/test/visualTests/issues/BrokenRenders.test.ts
@@ -4,6 +4,7 @@ import { Settings } from '@coderline/alphatab/Settings';
 import { XmlDocument } from '@coderline/alphatab/xml/XmlDocument';
 import { expect } from 'chai';
 import { ScoreLoader } from '@coderline/alphatab/importer/ScoreLoader';
+import { Note } from '@coderline/alphatab/model/Note';
 import type { RenderFinishedEventArgs } from '@coderline/alphatab/rendering/RenderFinishedEventArgs';
 import { ScoreRenderer } from '@coderline/alphatab/rendering/ScoreRenderer';
 
@@ -127,5 +128,78 @@ describe('BrokenRendersTests', () => {
                 }
             );
         });
+    });
+
+    it('piano-note-on-stringed-beat', () => {
+        // A beat on a stringed (tab + score) staff that also carries a
+        // piano note must render cleanly. Previously the TabBeatGlyph
+        // iterated every visible note and called getNoteLine(n) which
+        // returns tuning.length - n.string — for n.string === -1 (piano)
+        // that indexes past the end of collectSpaces' `spaces` array and
+        // crashed while painting the tab staff lines. AlphaTex rejects
+        // mixed notes on one staff at import time, but the runtime data
+        // model allows it and downstream tools (step-time editors) rely
+        // on that flexibility.
+        const settings = new Settings();
+        settings.core.engine = 'svg';
+        settings.core.enableLazyLoading = false;
+
+        const score = ScoreLoader.loadAlphaTex('3.3.4', settings);
+
+        // Add a piano note to the first beat alongside the stringed note.
+        // C7 = MIDI 96: octave 8, tone 0 (AlphaTab convention).
+        const beat = score.tracks[0].staves[0].bars[0].voices[0].beats[0];
+        const pianoNote = new Note();
+        pianoNote.octave = 8;
+        pianoNote.tone = 0;
+        beat.addNote(pianoNote);
+        expect(pianoNote.isPiano).to.equal(true);
+
+        let error: Error | null = null;
+        const api = new ScoreRenderer(settings);
+        api.error.on(e => {
+            error = e;
+        });
+        api.width = 1300;
+        api.renderScore(score, [0]);
+
+        error = error as Error | null;
+        if (error != null) {
+            throw error;
+        }
+    });
+
+    it('piano-only-beat-on-stringed-staff', () => {
+        // A beat with ONLY piano notes (no stringed notes) on a stringed
+        // staff: the tab renderer has nothing to draw there. Previously
+        // TabNoteChordGlyph.doLayout called getNoteY(this.minStringNote)
+        // and crashed on `note.string` because minStringNote stays null
+        // when every note is filtered as piano.
+        const settings = new Settings();
+        settings.core.engine = 'svg';
+        settings.core.enableLazyLoading = false;
+
+        const score = ScoreLoader.loadAlphaTex('3.3.4', settings);
+
+        // Replace the stringed note with a piano-only one.
+        const beat = score.tracks[0].staves[0].bars[0].voices[0].beats[0];
+        beat.notes.splice(0, beat.notes.length);
+        const pianoNote = new Note();
+        pianoNote.octave = 8;
+        pianoNote.tone = 0;
+        beat.addNote(pianoNote);
+
+        let error: Error | null = null;
+        const api = new ScoreRenderer(settings);
+        api.error.on(e => {
+            error = e;
+        });
+        api.width = 1300;
+        api.renderScore(score, [0]);
+
+        error = error as Error | null;
+        if (error != null) {
+            throw error;
+        }
     });
 });


### PR DESCRIPTION
## Summary

Two related crashes in `TabBeatGlyph.doLayout` when a beat contains a piano note on a stringed-track staff:

**1. Mixed stringed + piano note on one beat.**
The note-glyph loop unconditionally calls `_createNoteGlyph(n)` → `TabBarRenderer.getNoteLine(n) = tuning.length - n.string`. Piano notes (`string === -1`) yield `tuning.length + 1`, past the end of the fret-line space array. `TabBarRenderer.collectSpaces` then pushes into `spaces[tuning.length - (-1)]` — `undefined` — and rendering crashes.

**2. Piano-only beat.**
After filtering piano notes out of the note-glyph loop (fix above), a beat with NO stringed notes leaves `TabNoteChordGlyph.minStringNote = null`. `doLayout` then calls `getNoteY(this.minStringNote, NoteYPosition.Center)` which dereferences `note.string` on null.

## Fix

- Skip notes where `isPiano === true` in the tab note-glyph loop — they render correctly via `ScoreBeatGlyph` on the standard-notation staff.
- When a beat has no stringed notes at all, fall through to the tab-rest path instead of building a `TabNoteChordGlyph` that can't be laid out.

## Why mixed notes can occur

The alphaTex importer explicitly forbids mixing fretted and piano notes on a single staff (AT218), which is a reasonable user-facing restriction. But the runtime data model allows it via the public `Beat`/`Note` API, and downstream tools that build scores programmatically — step-time editors, custom importers, MusicXML/MIDI adapters — rely on that flexibility for cases like:

- Writing on-score pitches that fall outside the current tuning's playable range (a 10-note piano chord on a 6-string-guitar track).
- Half-step dyads where only one note fits on the physical guitar (e.g. E + F on standard tuning both want string 1; one must render as a score-only piano note).
- Non-guitar-playable lines written on a guitar track for convenience.

The tab renderer currently crashes on these configurations instead of rendering the tab portion and leaving the piano notes to the score renderer.

## Repro

```ts
import { Note, ScoreLoader, ScoreRenderer, Settings } from '@coderline/alphatab';

const settings = new Settings();
settings.core.engine = 'svg';
settings.core.enableLazyLoading = false;

// Case 1: stringed + piano on the same beat.
const score1 = ScoreLoader.loadAlphaTex('3.3.4', settings);
const beat1 = score1.tracks[0].staves[0].bars[0].voices[0].beats[0];
const piano = new Note();
piano.octave = 8; piano.tone = 0;
beat1.addNote(piano);
new ScoreRenderer(settings).renderScore(score1, [0]);
// Before: crashes in TabBarRenderer.collectSpaces.
// After:  renders tab with only the stringed note; score shows both.

// Case 2: piano-only beat.
const score2 = ScoreLoader.loadAlphaTex('3.3.4', settings);
const beat2 = score2.tracks[0].staves[0].bars[0].voices[0].beats[0];
beat2.notes.splice(0, beat2.notes.length);
const pianoOnly = new Note();
pianoOnly.octave = 8; pianoOnly.tone = 0;
beat2.addNote(pianoOnly);
new ScoreRenderer(settings).renderScore(score2, [0]);
// Before: crashes in TabNoteChordGlyph.doLayout.
// After:  tab shows a rest; score shows the piano note.
```

## Tests

Adds two tests to `BrokenRenders.test.ts`:
- `piano-note-on-stringed-beat` — case 1 above
- `piano-only-beat-on-stringed-staff` — case 2 above

Both construct scores via the runtime API (alphaTex forbids the input), render via `ScoreRenderer`, and assert no error fires.

Did not attempt visual-reference tests — the SVG output for these cases is just the tab staff with the stringed notes (or rest), which matches rendering the same beats with the piano notes removed entirely. The regression worth pinning down is "doesn't crash," which the functional tests cover.

### Author note

Full disclosure, this was diagnosed/implemented with AI.

### Checklist
- [x] I consent that this change becomes part of alphaTab under its current or any future open source license
- [x] Changes are implemented
- [x] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website