### PR TITLE
fix(synth): prevent audio thread spin loops and GC storms on playback end

### DIFF
--- a/packages/alphatab/src/synth/AlphaSynth.ts
+++ b/packages/alphatab/src/synth/AlphaSynth.ts
@@ -308,7 +308,8 @@ export class AlphaSynthBase implements IAlphaSynth {
             }
         } else {
             // Tell output that there is no data left for it.
-            const samples: Float32Array = new Float32Array(0);
+            // Send silence instead of 0-length array to prevent audio track underrun.
+            const samples: Float32Array = new Float32Array(SynthConstants.MicroBufferSize * SynthConstants.MicroBufferCount * SynthConstants.AudioChannels);
             this.output.addSamples(samples);
         }
     }


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Fixes N/A (Discovered this bug while integrating AlphaTab on Android where it caused infinite GC storms).

### Proposed changes
<!-- Describe the proposed changes -->
**Root Cause**
When AlphaSynth finishes generating all audio chunks, it previously sent a 0-length Float32Array to the output to signal the end of data. However, on platforms like Android, writing 0 samples to the `AudioTrack` is non-blocking and returns immediately. 
This causes the audio playback head to freeze (underrun), which in turn makes the native worker report `playedSamples = 0`. 
Since `_onSamplesPlayed(0)` short-circuits and ignores the update, the `_notPlayedSamples` counter never reaches 0. As a result, AlphaSynth never calls `stop()`, never emits the `playerFinished` event, and the native audio thread falls into an infinite 100% CPU spin loop (allocating massive arrays per second and triggering a severe GC storm).

**Solution**
Instead of sending a 0-length array when no data is left, we now send an array of silence matching the normal micro-buffer size. This allows the output device to block and consume data naturally, preventing the underrun. Consequently, `_notPlayedSamples` accurately drains to 0, allowing AlphaSynth to properly shut down and emit the `playerFinished` event.

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->
*(No tests were added because this is a fix for a platform-specific AudioTrack underrun deadlock that occurs asynchronously between the TS state machine and the Android native UI thread, making it difficult to cover in standard headless unit tests.)*

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website