### PR TITLE
fix(model): skip tie-destination beats when applying lyrics

### DIFF
--- a/packages/alphatab/src/model/Track.ts
+++ b/packages/alphatab/src/model/Track.ts
@@ -173,6 +173,10 @@ export class Track {
         }
     }
 
+    private _isPureTieDestinationBeat(beat: Beat): boolean {
+        return beat.notes.length > 0 && beat.notes.every(n => n.isTieDestination);
+    }
+
     public applyLyrics(lyrics: Lyrics[]): void {
         for (const lyric of lyrics) {
             lyric.finish();
@@ -183,8 +187,8 @@ export class Track {
             if (lyric.startBar >= 0 && lyric.startBar < staff.bars.length) {
                 let beat: Beat | null = staff.bars[lyric.startBar].voices[0].beats[0];
                 for (let ci: number = 0; ci < lyric.chunks.length && beat; ci++) {
-                    // skip rests and empty beats
-                    while (beat && (beat.isEmpty || beat.isRest)) {
+                    // skip rests, empty beats, and pure tie-destination beats (no new syllable attack)
+                    while (beat && (beat.isEmpty || beat.isRest || this._isPureTieDestinationBeat(beat))) {
                         beat = beat.nextBeat;
                     }
                     // mismatch between chunks and beats might lead to missing beats

--- a/packages/alphatab/test/model/Lyrics.test.ts
+++ b/packages/alphatab/test/model/Lyrics.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { AlphaTexImporter } from '@coderline/alphatab/importer/AlphaTexImporter';
 import { GpxImporter } from '@coderline/alphatab/importer/GpxImporter';
 import { ByteBuffer } from '@coderline/alphatab/io/ByteBuffer';
 import { Lyrics } from '@coderline/alphatab/model/Lyrics';
@@ -133,5 +134,23 @@ describe('LyricsTests', () => {
         testLyrics('[AAA BBB\r\nCCC DDD]AAA BBB', ['AAA', 'BBB']);
         testLyrics('[AAA BBB\r\nCCC DDD] AAA BBB', ['', 'AAA', 'BBB']);
         testLyrics('[AAA] AAA [BBB] BBB [CCC] CCC [DDD] DDD', ['', 'AAA', '', 'BBB', '', 'CCC', '', 'DDD']);
+    });
+
+    it('skip-tie-destination-beat', () => {
+        const importer: AlphaTexImporter = new AlphaTexImporter();
+        importer.initFromString('\\track "V" 3.3.4 -.3.4 5.3.4 |', new Settings());
+        const score = importer.readScore();
+
+        const lyrics = new Lyrics();
+        lyrics.text = 'AAA BBB';
+        lyrics.startBar = 0;
+        score.tracks[0].applyLyrics([lyrics]);
+
+        const beats = score.tracks[0].staves[0].bars[0].voices[0].beats;
+        expect(beats[1].notes[0].isTieDestination).toBe(true);
+
+        expect(beats[0].lyrics![0]).toBe('AAA');
+        expect(beats[1].lyrics).not.toBeTruthy();
+        expect(beats[2].lyrics![0]).toBe('BBB');
     });
 });


### PR DESCRIPTION
### Issues

Related to #2728

### Proposed changes

This PR fixes lyric chunks being assigned to beats whose notes are all tie destinations.

Before this change, `Track.applyLyrics()` skipped empty and rest beats, but pure tie-destination beats were still treated as lyric-eligible. This could cause lyric syllables to appear on tied continuation notes / held-note destinations instead of the next fresh note attack.

Changes included:

- Added a private helper in `Track` to detect beats where all notes are tie destinations.
- Updated `Track.applyLyrics()` to skip those beats when distributing lyric chunks.
- Added a focused regression test using AlphaTex:

```alphatex
\track "V" 3.3.4 -.3.4 5.3.4 |

The Test Verifies:

* the first lyric lands on the first fresh note
* the tie-destination beat receives no lyrics
* the next lyric lands on the next fresh note

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [x] New tests were added 

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
