### PR TITLE
fix(player): only buffer output events received between play and worklet creation

### DIFF
--- a/packages/alphatab/src/platform/javascript/AlphaSynthAudioWorkletOutput.ts
+++ b/packages/alphatab/src/platform/javascript/AlphaSynthAudioWorkletOutput.ts
@@ -220,6 +220,13 @@ export class AlphaSynthAudioWorkletOutput extends AlphaSynthWebAudioOutputBase {
     public override play(): void {
         super.play();
         const ctx = this.context!;
+
+        // clear any pending events buffered from previous playback rounds
+        // we just want the events which come in after the play call until the worklet is created
+        if (this._pendingEvents) {
+            this._pendingEvents = undefined;
+        }
+
         // create a script processor node which will replace the silence with the generated audio
         BrowserUiFacade.createAlphaSynthAudioWorklet(ctx, this._settings).then(
             () => {


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Fixes #2561
Fixes #2763

### Proposed changes
Follow up from the previous fix. We need to ensure we do not send worklet message from the previous worklet instance to the new one. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
