### PR TITLE
fix(rendering): clear drawing infos instead of modifying and clearing together

### DIFF
--- a/packages/alphatab/src/rendering/utils/BeamingHelper.ts
+++ b/packages/alphatab/src/rendering/utils/BeamingHelper.ts
@@ -8,7 +8,6 @@ import type { Note } from '@coderline/alphatab/model/Note';
 import type { Staff } from '@coderline/alphatab/model/Staff';
 import type { Voice } from '@coderline/alphatab/model/Voice';
 import type { BarRendererBase } from '@coderline/alphatab/rendering/BarRendererBase';
-import { BeatXPosition } from '@coderline/alphatab/rendering/BeatXPosition';
 import { AccidentalHelper } from '@coderline/alphatab/rendering/utils/AccidentalHelper';
 import type { BeamDirection } from '@coderline/alphatab/rendering/utils/BeamDirection';
 import type { BeamingRuleLookup } from '@coderline/alphatab/rendering/utils/BeamingRuleLookup';
@@ -107,11 +106,7 @@ export class BeamingHelper {
     }
 
     public alignWithBeats() {
-        for (const v of this.drawingInfos.values()) {
-            v.startX = this._renderer.getBeatX(v.startBeat!, BeatXPosition.Stem);
-            v.endX = this._renderer.getBeatX(v.endBeat!, BeatXPosition.Stem);
-            this.drawingInfos.clear();
-        }
+        this.drawingInfos.clear();
     }
 
     public finish(): void {


### PR DESCRIPTION
### Issues
<!-- Each pull request needs to be related to an issue, mention it here below -->
Fixes #2748

### Proposed changes
Fixes the concurrent modification of the `drawingInfos` when clearing it the same time. Looks like this was some sort of merge conflict as the code didn't really make sense. Modifying the coordinates and then clearing the whole map doesn't make sense. Kept the clearing for 1.8.x, In 1.9.x the code is already removed and reworked. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under it's current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- if not test were added explain why, we typically expect new tests for PRs -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
