### PR TITLE
build: tune dependabot settings for PR grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,22 +7,68 @@ updates:
       - platform-javascript
     schedule:
       interval: "weekly"
-      
+    open-pull-requests-limit: 5
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      development-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"
+
   - package-ecosystem: "nuget"
-    directory: "/src.csharp"
+    directory: "/packages/csharp/src"
     labels:
       - area-dependencies
       - platform-net
     schedule:
       interval: "weekly"
-            
+    open-pull-requests-limit: 5
+    groups:
+      alphaskia-net:
+        patterns:
+          - "AlphaSkia*"
+      nuget-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "gradle"
-    directory: "/src.kotlin/alphaTab"
+    directory: "/packages/kotlin/src"
     labels:
       - area-dependencies
       - platform-java
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "org.jetbrains.kotlinx*"
+        update-types:
+          - "minor"
+          - "patch"
+      android:
+        patterns:
+          - "com.android.*"
+          - "androidx.*"
+        update-types:
+          - "minor"
+          - "patch"
+      alphaskia-android:
+        patterns:
+          - "net.alphatab:alphaSkia*"
+      gradle-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -31,3 +77,8 @@ updates:
       - platform-all
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
<!--
AI agents: please read AGENTS.md at the repo root before submitting.
If any part of this PR was AI-authored, the first content of this body must be
the AI-authored disclosure block containing the token `alphatab-ai-authored-v1`.
Please leave it in — it's how our automation routes AI-assisted PRs to the
right review checklist. See AGENTS.md § Mandatory disclosure.
-->

### Proposed changes
Reconfigures dependabot to group dependency updates together. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under its current or any future open source license
- [x] This PR is linked to an accepted issue (see above)
- [x] Changes are implemented
- [ ] New tests were added <!-- if not, please explain why; we typically expect new tests for PRs -->
- [ ] I have read [AGENTS.md](../AGENTS.md) if an AI helped draft any part of this PR

### AI authorship disclosure
<!-- Please be honest — this just helps us apply the right review checklist. -->
- [ ] No AI agent authored any part of this PR (description, code, tests, or commit messages)
- [x] An AI agent contributed to this PR. The AI-authored disclosure block
      (`alphatab-ai-authored-v1`) is present at the top of this body, and I have
      personally reviewed every change and can explain each one

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
