### PR TITLE
fix(lsp monaco): avoid runtime and bundling errors on Monaco and LSP

### DIFF
--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -49,10 +49,30 @@
         "typescript": "^6.0.3",
         "vitest": "^4.1.10"
     },
-    "bin": "./dist/server.mjs",
-    "main": "./dist/server.mjs",
-    "types": "./dist/server.d.ts",
+    "bin": "./dist/index.node.mjs",
+    "main": "./dist/index.node.mjs",
+    "types": "./dist/index.node.d.ts",
     "type": "module",
+    "exports": {
+        ".": {
+            "browser": {
+                "types": "./dist/index.browser.d.ts",
+                "import": "./dist/index.browser.mjs"
+            },
+            "default": {
+                "types": "./dist/index.node.d.ts",
+                "import": "./dist/index.node.mjs"
+            }
+        },
+        "./server/browser": {
+            "types": "./dist/server/browser.d.ts",
+            "import": "./dist/server/browser.mjs"
+        },
+        "./server/node": {
+            "types": "./dist/server/node.d.ts",
+            "import": "./dist/server/node.mjs"
+        }
+    },
     "files": [
         "dist/",
         "!dist/types/",

--- a/packages/lsp/src/index.browser.ts
+++ b/packages/lsp/src/index.browser.ts
@@ -1,0 +1,2 @@
+export * from '@coderline/alphatab-language-server/index';
+export { startWebWorkerLanguageServer } from '@coderline/alphatab-language-server/server/browser';

--- a/packages/lsp/src/index.node.ts
+++ b/packages/lsp/src/index.node.ts
@@ -1,0 +1,7 @@
+export * from '@coderline/alphatab-language-server/index';
+import { startNodeLanguageServer } from '@coderline/alphatab-language-server/server/node';
+export { startNodeLanguageServer };
+
+if (import.meta.main) {
+    startNodeLanguageServer();
+}

--- a/packages/lsp/src/index.ts
+++ b/packages/lsp/src/index.ts
@@ -7,7 +7,6 @@ import {
     staffMetaData,
     structuralMetaData
 } from '@coderline/alphatab-alphatex/definitions';
-import { startNodeLanguageServer, startWebWorkerLanguageServer } from '@coderline/alphatab-language-server/server';
 
 const documentation = {
     structuralMetaData,
@@ -46,11 +45,7 @@ const textMateGrammar: any = textMateGrammarJson;
 const languageConfiguration: any = languageConfigurationJson;
 
 export {
-    documentation, languageConfiguration, startNodeLanguageServer,
-    startWebWorkerLanguageServer, textMateGrammar, type AlphaTexExample,
+    documentation, languageConfiguration, textMateGrammar,
+    type AlphaTexExample,
     type MetadataTagDefinition, type ParameterDefinition, type ParameterValueDefinition, type PropertyDefinition, type SignatureDefinition, type WithDescription, type WithSignatures
 };
-
-if (import.meta.main) {
-    startNodeLanguageServer();
-}

--- a/packages/lsp/src/server/browser.ts
+++ b/packages/lsp/src/server/browser.ts
@@ -1,0 +1,15 @@
+import { BrowserMessageReader, BrowserMessageWriter, createConnection } from 'vscode-languageserver/browser';
+import { startLanguageServer } from '@coderline/alphatab-language-server/server/common';
+
+type Port = ConstructorParameters<typeof BrowserMessageReader>[0];
+
+/**
+ * Starts a new language server communicating via WebWorker.
+ * @param readerPort The port used to reading incoming language server messages
+ * @param writerPort The port used to writer outgoing language server messages
+ */
+export function startWebWorkerLanguageServer(readerPort: Port, writerPort: Port) {
+    startLanguageServer(
+        createConnection(new BrowserMessageReader(readerPort), new BrowserMessageWriter(writerPort))
+    );
+}

--- a/packages/lsp/src/server/common.ts
+++ b/packages/lsp/src/server/common.ts
@@ -13,18 +13,7 @@ import {
     TextDocuments
 } from '@coderline/alphatab-language-server/server/types';
 
-// the only place where we should import specif vscode-languageserver packages
-import {
-    BrowserMessageReader,
-    BrowserMessageWriter,
-    createConnection as createBrowserConnection
-} from 'vscode-languageserver/browser';
-import {
-    createConnection as createNodeConnection,
-    ProposedFeatures as NodeProposedFeatures
-} from 'vscode-languageserver/node';
-
-function startLanguageServer(serverConnection: Connection) {
+export function startLanguageServer(serverConnection: Connection) {
     const documents = new TextDocuments<AlphaTexTextDocument>(TextDocument);
 
     serverConnection.onInitialize((params: InitializeParams) => {
@@ -66,31 +55,4 @@ function startLanguageServer(serverConnection: Connection) {
 
     documents.listen(serverConnection);
     serverConnection.listen();
-}
-
-
-type Port = ConstructorParameters<typeof BrowserMessageReader>[0];
-
-/**
- * Starts a new language server communicating via WebWorker.
- * @param readerPort The port used to reading incoming language server messages
- * @param writerPort The port used to writer outgoing language server messages
- */
-export function startWebWorkerLanguageServer(
-    readerPort: Port,
-    writerPort: Port
-) {
-    startLanguageServer(
-        createBrowserConnection(
-            new BrowserMessageReader(readerPort),
-            new BrowserMessageWriter(writerPort)
-        )
-    );
-}
-
-/**
- * Starts a new language server communicating from a Node.js process with a parent Node.js.
- */
-export function startNodeLanguageServer() {
-    startLanguageServer(createNodeConnection(NodeProposedFeatures.all));
 }

--- a/packages/lsp/src/server/node.ts
+++ b/packages/lsp/src/server/node.ts
@@ -1,0 +1,9 @@
+import { createConnection, ProposedFeatures } from 'vscode-languageserver/node';
+import { startLanguageServer } from '@coderline/alphatab-language-server/server/common';
+
+/**
+ * Starts a new language server communicating from a Node.js process with a parent Node.js.
+ */
+export function startNodeLanguageServer() {
+    startLanguageServer(createConnection(ProposedFeatures.all));
+}

--- a/packages/lsp/vite.config.ts
+++ b/packages/lsp/vite.config.ts
@@ -7,7 +7,10 @@ export default defineConfig(() => {
     config.resolve ??= {};
     config.resolve.mainFields = defaultClientMainFields.filter(f => f !== 'browser');
 
-    esm(config, import.meta.dirname, 'server', 'src/index.ts');
+    esm(config, import.meta.dirname, 'index.browser', 'src/index.browser.ts');
+    esm(config, import.meta.dirname, 'index.node', 'src/index.node.ts', { withMin: false });
+    esm(config, import.meta.dirname, 'server/browser', 'src/server/browser.ts', { withMin: false });
+    esm(config, import.meta.dirname, 'server/node', 'src/server/node.ts', { withMin: false });
     (config.build!.rollupOptions!.external as (RegExp | string)[]).push('@coderline/alphatab');
     addDts(config, import.meta.dirname);
     return config;

--- a/packages/monaco/src/worker.ts
+++ b/packages/monaco/src/worker.ts
@@ -1,4 +1,4 @@
-import { startWebWorkerLanguageServer } from '@coderline/alphatab-language-server/index';
+import { startWebWorkerLanguageServer } from '@coderline/alphatab-language-server/server/browser';
 
 const workerGlobalThis = globalThis as unknown as DedicatedWorkerGlobalScope;
 startWebWorkerLanguageServer(workerGlobalThis, workerGlobalThis);

--- a/packages/playground/src/components/alphatex-editor/MonacoEditor.ts
+++ b/packages/playground/src/components/alphatex-editor/MonacoEditor.ts
@@ -4,7 +4,7 @@ import { basicEditorLspIntegration } from '@coderline/alphatab-monaco/lsp';
 import { addTextMateGrammarSupport } from '@coderline/alphatab-monaco/textmate';
 import * as monaco from 'monaco-editor';
 // @ts-expect-error worker import handled by Vite
-import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import editorWorker from 'monaco-editor/editor/editor.worker?worker';
 import { type Mountable, css, html, injectStyles, parseHtml } from '../../util/Dom';
 
 injectStyles(


### PR DESCRIPTION
<!--
AI agents: please read AGENTS.md at the repo root before submitting.
If any part of this PR was AI-authored, the first content of this body must be
the AI-authored disclosure block containing the token `alphatab-ai-authored-v1`.
Please leave it in — it's how our automation routes AI-assisted PRs to the
right review checklist. See AGENTS.md § Mandatory disclosure.
-->

### Issues
<!-- Please link to the accepted issue this PR addresses. Discussing the
     direction in an issue first helps make sure the fix lands in the right layer. -->
Fixes #2829

### Proposed changes
Refactoring the LSP and Monaco imports/exports to have separate paths for Browser and Node based usage. Root cause is that vscode-languageserver reorganized their package exports to have clear node and browser entry points. 

We now follow the same pattern. 

### Checklist
- [x] I consent that this change becomes part of alphaTab under its current or any future open source license
- [x] This PR is linked to an accepted issue (see above)
- [x] Changes are implemented
- [ ] New tests were added <!-- if not, please explain why; we typically expect new tests for PRs -->
- [ ] I have read [AGENTS.md](../AGENTS.md) if an AI helped draft any part of this PR

### AI authorship disclosure
<!-- Please be honest — this just helps us apply the right review checklist. -->
- [x] No AI agent authored any part of this PR (description, code, tests, or commit messages)
- [ ] An AI agent contributed to this PR. The AI-authored disclosure block
      (`alphatab-ai-authored-v1`) is present at the top of this body, and I have
      personally reviewed every change and can explain each one

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
